### PR TITLE
31 implement test case tc frq 1003 a

### DIFF
--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.BackgroundServices/CrawlBackgroundService.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.BackgroundServices/CrawlBackgroundService.cs
@@ -1,6 +1,5 @@
 ﻿using LTU.SearchEngine.Backend.Core.Model;
 using LTU.SearchEngine.Backend.Core.Model.Entities;
-using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
 using LTU.SearchEngine.Infrastructure.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.BackgroundServices/TplCrawlJobDispatcher.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.BackgroundServices/TplCrawlJobDispatcher.cs
@@ -167,6 +167,7 @@ public class TplCrawlJobDispatcher : ICrawlJobDispatcher
 				_jobPriorityQueue.Enqueue(job, job.NextAttempt ?? DateTime.UtcNow);
 		}
 
+	
 		return Task.CompletedTask;
 	}
 
@@ -177,24 +178,35 @@ public class TplCrawlJobDispatcher : ICrawlJobDispatcher
 			_worker, 
 			new DataflowLinkOptions { PropagateCompletion = true }
 		);
-        while (!ct.IsCancellationRequested)
-        {
-            DateTime now = DateTime.UtcNow;
-	
-            List<CrawlJob> ready = new List<CrawlJob>();
 
-            lock (_jobPriorityQueue)
-            {
-                while (_jobPriorityQueue.Count > 0 &&
-                    _jobPriorityQueue.Peek().NextAttempt <= now)
-                {
-                    ready.Add(_jobPriorityQueue.Dequeue());
-                }
-            }
+		try
+		{
+			while (!ct.IsCancellationRequested)
+			{
+				DateTime now = DateTime.UtcNow;
+				CrawlJob? crawlJob = null;
 
-            foreach (CrawlJob job in ready) await _buffer.SendAsync(job, ct);
+				lock (_jobPriorityQueue)
+				{
+					if (_jobPriorityQueue.Count > 0 &&
+						_jobPriorityQueue.Peek().NextAttempt <= now)
+					{
+						crawlJob =  _jobPriorityQueue.Dequeue();	
+					}
+				}
 
-            await Task.Delay(_crawlerSettingsLoader.Load().MinDelayMs);
-        }
+				if (crawlJob is not null)
+				{
+					await _buffer.SendAsync(crawlJob, ct);
+					await Task.Delay(_crawlerSettingsLoader.Load().MinDelayMs, ct);
+				}
+				else await Task.Delay(50, ct); // Processor friendly wait
+			}		
+		}
+		catch (OperationCanceledException)
+		{
+			Debug.WriteLine("Dispatcher has been stopped"); // ToDo: should be properly logged
+		}
+      
     }
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.BackgroundServices/TplCrawlJobDispatcher.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.BackgroundServices/TplCrawlJobDispatcher.cs
@@ -159,7 +159,7 @@ public class TplCrawlJobDispatcher : ICrawlJobDispatcher
 		if (job == null) throw new ArgumentNullException(nameof(job));
 
 		// If job is due for immediate processing, send to buffer; otherwise, enqueue with scheduled time.
-		if (job.NextAttempt is null || job.NextAttempt <= DateTime.UtcNow)
+		if (job.NextAttempt is null)
 			return _buffer.SendAsync(job);
 		else
 		{

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/BackgroundServices.Tests/TplCrawlJobDispatcherTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/BackgroundServices.Tests/TplCrawlJobDispatcherTests.cs
@@ -13,7 +13,6 @@ namespace LTU.SearchEngine.Test.BackgroundServices.Tests;
 
 public class TplCrawlJobDispatcherTests
 {
-	// rivate readonly CrawlerSettings _crawlerSettings;
 	private readonly Mock<ICrawlerSettingsLoader> _mockCrawlerSettingsLoader;
 	private readonly SemaphoreProvider _semaphoreProvider;
 	private Mock<IProcessCrawlJobUseCase> _mockUseCase;
@@ -55,6 +54,7 @@ public class TplCrawlJobDispatcherTests
 	{
 		_semaphoreProvider = new SemaphoreProvider();
 		_mockUseCase = new Mock<IProcessCrawlJobUseCase>();
+		_mockUseCase.Setup(uc => uc.Execute(It.IsAny<CrawlJob>())).ReturnsAsync(CreateResult());
 
 		_mockCrawlerSettingsLoader = new Mock<ICrawlerSettingsLoader>();
 		_mockCrawlerSettingsLoader.Setup(csl => csl.Load()).Returns(CreateSettings());
@@ -146,17 +146,18 @@ public class TplCrawlJobDispatcherTests
 
         // Signal when Execute is invoked to wait deterministically in the test.
         _mockUseCase.Setup(u => u.Execute(It.IsAny<CrawlJob>()))
-		.Returns(async () =>
-		{
-			executionSignal.TrySetResult(true);
-			return CreateResult();
-		});
+			.Returns(async () =>
+			{
+				executionSignal.TrySetResult(true);
+				return CreateResult();
+			}
+		);
 
         var job = new CrawlJob
         {
             Id = 2,
             Url = "https://example.com",
-            NextAttempt = DateTime.UtcNow.AddMilliseconds(300) 
+            NextAttempt = DateTime.UtcNow.AddSeconds(1) 
         };
 
         using var cts = new CancellationTokenSource();
@@ -164,21 +165,22 @@ public class TplCrawlJobDispatcherTests
 
 		// Act
         await _sut.Enqueue(job);
-
+		
         // Assert (before scheduled time)
-        await Task.Delay(100);
+        await Task.Delay(200);
         // Verify that the job has not been executed yet
-        Assert.False(executionSignal.Task.IsCompleted);
+        Assert.False(executionSignal.Task.IsCompleted, "Job executed early!");
 
         // Assert (after scheduled time)
-        await Task.Delay(300);
+        await Task.Delay(1000);
         // Wait until the mocked Execute method signals execution
-        await executionSignal.Task.WaitAsync(TimeSpan.FromSeconds(1));
+        await executionSignal.Task.WaitAsync(TimeSpan.FromSeconds(2));
 
         _mockUseCase.Verify(u => u.Execute(It.IsAny<CrawlJob>()), Times.Once);
 
         cts.Cancel();
-        await startTask;
+		
+       	await startTask;
     }
     
     [Fact]

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/IntegrationTesting/CrawlerIntegrationTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/IntegrationTesting/CrawlerIntegrationTests.cs
@@ -31,12 +31,11 @@ public class CrawlerIntegrationTests : IClassFixture<WebApplicationFactory<Progr
     } 
 
     private WebApplicationFactory<Program> CreateTestFactory(
-        // string initialJson,
         Mock<IIndexer> indexerMock,
         HttpClient httpClientForCrawler,
         string seedUrl = "http://localhost/page1.html",
-        string maxConcurrencyPerDomain = "2",
-        string minDelayMs = "10"
+        int maxConcurrencyPerDomain = 2,
+        int minDelayMs = 10
     )
     {
         string fakeAppSettings = $$$"""
@@ -58,6 +57,12 @@ public class CrawlerIntegrationTests : IClassFixture<WebApplicationFactory<Progr
         var testFactory = _factory.WithWebHostBuilder(builder =>
         {
             
+            // Replaces the preconfigured seed url with the test version. 
+            builder.ConfigureAppConfiguration((context, config) =>
+            {
+                config.AddJsonFile(_tempSettingsPath, optional: false, reloadOnChange: true);
+            }); 
+
             builder.ConfigureServices(services =>
             {
                 // This finds the service that we want to remove from the application startup
@@ -70,11 +75,6 @@ public class CrawlerIntegrationTests : IClassFixture<WebApplicationFactory<Progr
                 services.AddSingleton(indexerMock.Object);
             });
 
-            // Replaces the preconfigured seed url with the test version. 
-            builder.ConfigureAppConfiguration((context, config) =>
-            {
-                config.AddJsonFile(_tempSettingsPath, optional: false, reloadOnChange: true);
-            });   
         });
 
         return testFactory;
@@ -379,13 +379,17 @@ public class CrawlerIntegrationTests : IClassFixture<WebApplicationFactory<Progr
     {
         // Arrange 
         // Setting up timing instruments
-        string maxConcurrencyPerDomain = "2";
+        string seedURL = "http://localhost/seed.html";
+        int maxConcurrencyPerDomain = 2;
+        int minDelayMs = 200;
 
         var timesStamps = new List<DateTime>();
         int activeRequests = 0;
         int maxObservedConcurrency = 0;
         var lockObject = new Object();
 
+
+     
         using var host = Host.CreateDefaultBuilder()
             .ConfigureWebHostDefaults( webBuilder =>
             {
@@ -399,8 +403,8 @@ public class CrawlerIntegrationTests : IClassFixture<WebApplicationFactory<Progr
                        var current = Interlocked.Increment(ref activeRequests);
                        lock (lockObject)
                        {
-                           maxObservedConcurrency = Math.Max(maxObservedConcurrency, current);
-                           timesStamps.Add(DateTime.UtcNow);
+                           maxObservedConcurrency = Math.Max(maxObservedConcurrency, current); // Used to map concurrency.
+                           timesStamps.Add(DateTime.UtcNow); // Used to map delay.
                        }
 
                        // we force the connection to stay open to measure concurrency 
@@ -413,16 +417,19 @@ public class CrawlerIntegrationTests : IClassFixture<WebApplicationFactory<Progr
         
         await host.StartAsync();
 
+
+
         using WebApplicationFactory<Program> testFactory = CreateTestFactory(
-            new Mock<IIndexer>(), 
-            host.GetTestClient(),
-            maxConcurrencyPerDomain
+            indexerMock: new Mock<IIndexer>(), 
+            httpClientForCrawler: host.GetTestClient(),
+            seedURL,
+            maxConcurrencyPerDomain,
+            minDelayMs
         );
 
         using var scope = testFactory.Services.CreateScope();
         var dispatcher = scope.ServiceProvider.GetRequiredService<ICrawlJobDispatcher>();
         var settingsLoader = scope.ServiceProvider.GetRequiredService<ICrawlerSettingsLoader>();       
-        
         
         // Act
         using var cts = new CancellationTokenSource();
@@ -441,8 +448,27 @@ public class CrawlerIntegrationTests : IClassFixture<WebApplicationFactory<Progr
         await Task.Delay(3000); 
         cts.Cancel();
 
-        // Assert
-        Assert.True(maxObservedConcurrency <= settingsLoader.Load().MaxConcurrencyPerDomain);
+        // Assert - Concurrency
+        Assert.True(
+            maxObservedConcurrency <= settingsLoader.Load().MaxConcurrencyPerDomain, 
+            $"observed: {maxObservedConcurrency}, expected: {settingsLoader.Load().MaxConcurrencyPerDomain}"
+        );
+
+        // Assert - Delay
+        // Makes sure that execution times are in sequential order.
+        var orderedStamps = timesStamps.OrderBy(ts => ts); 
+
+        for (int i = 0; i < timesStamps.Count - 1; i++)
+        {   
+            if (i + 1 <= timesStamps.Count)
+            {
+                var actualDelay = timesStamps[i + 1] - timesStamps[i];
+                Assert.True(
+                    actualDelay.TotalMilliseconds >= minDelayMs - 20, // Added small margin 
+                    $"Delay between call {i} and {i+1} was to short: expected: {minDelayMs}ms actual: {actualDelay.TotalMilliseconds}ms"
+                );     
+            }
+        }
     }
 
     public void Dispose()

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/IntegrationTesting/CrawlerIntegrationTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/IntegrationTesting/CrawlerIntegrationTests.cs
@@ -2,11 +2,16 @@ using LTU.SearchEngine.Backend.Api;
 using LTU.SearchEngine.Backend.Core.Model.Entities;
 using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
 using LTU.SearchEngine.BackgroundServices;
-using LTU.SearchEngine.Test.HelperClasses;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Moq;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using LTU.SearchEngine.Infrastructure.Configuration;
 
 namespace LTU.SearchEngine.Test.IntegrationTesting;
 
@@ -14,29 +19,53 @@ namespace LTU.SearchEngine.Test.IntegrationTesting;
 public class CrawlerIntegrationTests : IClassFixture<WebApplicationFactory<Program>>, IDisposable
 {
     private readonly WebApplicationFactory<Program> _factory; 
-    private readonly WebHostBuilder _webHostBuilder;
+    private readonly HelperClasses.WebHostBuilder _webHostBuilder;
     private string _tempSettingsPath; 
      
     public CrawlerIntegrationTests(WebApplicationFactory<Program> factory)
     {
         _factory = factory;
-        _webHostBuilder = new WebHostBuilder();
+        _webHostBuilder = new HelperClasses.WebHostBuilder();
          _tempSettingsPath = 
             Path.Combine(Path.GetTempPath(), $"Settings_{Guid.NewGuid()}.ToJsonSchemaType");
     } 
 
     private WebApplicationFactory<Program> CreateTestFactory(
-        string initialJson,
+        // string initialJson,
         Mock<IIndexer> indexerMock,
-        HttpClient httpClientForCrawler)
+        HttpClient httpClientForCrawler,
+        string seedUrl = "http://localhost/page1.html",
+        string maxConcurrencyPerDomain = "2",
+        string minDelayMs = "10"
+    )
     {
-        File.WriteAllText(_tempSettingsPath, initialJson);
+        string fakeAppSettings = $$$"""
+        {
+            "CrawlerSettings": {
+                "UserAgent": "TestBot",
+                "MaxConcurrencyPerDomain": {{{maxConcurrencyPerDomain}}},
+                "MinDelayMs": {{{minDelayMs}}},
+                "RetryIntervals": ["00:00:01"],
+                "SeedUrls": ["{{{seedUrl}}}"],
+                "WhiteList": ["localhost"]
+            }
+        }
+        """;
+
+        File.WriteAllText(_tempSettingsPath, fakeAppSettings);
 
         // Creates a version of the application, but with a mock index instead.
         var testFactory = _factory.WithWebHostBuilder(builder =>
         {
+            
             builder.ConfigureServices(services =>
             {
+                // This finds the service that we want to remove from the application startup
+                var descriptor = services.FirstOrDefault(d => 
+                    d.ImplementationType == typeof(CrawlBackgroundService));
+
+                if (descriptor is not null) services.Remove(descriptor);
+
                 services.AddSingleton(httpClientForCrawler); // Replace the HttpClient the client uses to the inmemory webHostBuilder
                 services.AddSingleton(indexerMock.Object);
             });
@@ -61,20 +90,9 @@ public class CrawlerIntegrationTests : IClassFixture<WebApplicationFactory<Progr
         string page1 = "http://localhost/page1.html";
         string page2 = "http://localhost/page2.html";
         string final = "http://localhost/final.html";
-
-        string fakeAppSettings = $$$"""
-        {
-            "CrawlerSettings": {
-                "UserAgent": "TestBot",
-                "MaxConcurrencyPerDomain": 2,
-                "MinDelayMs": 10,
-                "RetryIntervals": ["00:00:01"],
-                "SeedUrls": ["{{{seedURL}}}"],
-                "WhiteList": ["localhost"]
-            }
-        }
-        """;
     
+        CrawlJob crawlJob = new CrawlJob{Url = seedURL, NextAttempt = DateTime.UtcNow};
+
         var visitedList = new List<CrawlResult>();
         var indexerMock = new Mock<IIndexer>();
 
@@ -87,7 +105,6 @@ public class CrawlerIntegrationTests : IClassFixture<WebApplicationFactory<Progr
         using var httpClientForCrawler = webHelper.BuildHttpClient();
         
         using WebApplicationFactory<Program> testFactory = CreateTestFactory(
-            fakeAppSettings,
             indexerMock, 
             httpClientForCrawler
         );
@@ -95,18 +112,32 @@ public class CrawlerIntegrationTests : IClassFixture<WebApplicationFactory<Progr
 
         // Retrieve the actuall implementation of the crawler. 
         using var scope = testFactory.Services.CreateScope();
+        var dispatcher = scope.ServiceProvider.GetRequiredService<ICrawlJobDispatcher>();
        
         // Act
-        int timeoutMs = 5000;
-        int elapsedTime = 0;
+        var cts = new CancellationTokenSource();
 
-        // Wait up to 5 sec to fill list 
-        while (visitedList.Count < 4 && elapsedTime < timeoutMs)
+        await dispatcher.Enqueue(crawlJob);
+        
+        try
         {
-            await Task.Delay(100); // wait with 100 ms intervalls
-            elapsedTime += 100;
-        }
+            _ = dispatcher.Start(cts.Token);
+        
+            int timeoutMs = 5000;
+            int elapsedTime = 0;
 
+            // Wait up to 5 sec to fill list 
+            while (visitedList.Count < 4 && elapsedTime < timeoutMs)
+            {
+                await Task.Delay(100); // wait with 100 ms intervalls
+                elapsedTime += 100;
+            }
+        }
+        finally
+        {
+            cts.Cancel();
+        }
+      
         // Assert
         Assert.Equal(4, visitedList.Count);
         Assert.Equal(seedURL, visitedList[0].Url);
@@ -122,21 +153,8 @@ public class CrawlerIntegrationTests : IClassFixture<WebApplicationFactory<Progr
     {
         // Arrange 
         string externalURL = "http://forbidden-domain.com";
+        CrawlJob crawlJob = new CrawlJob{ Url = externalURL, NextAttempt = DateTime.UtcNow};
 
-        string fakeAppSettings = $$$"""
-        {
-            "CrawlerSettings": {
-                "UserAgent": "TestBot",
-                "MaxConcurrencyPerDomain": 2,
-                "MinDelayMs": 10,
-                "RetryIntervals": ["00:00:01"],
-                "SeedUrls": ["{{{externalURL}}}"],
-                "WhiteList": ["localhost"]
-            }
-        }
-        """;
-       
-        
         var visitedList = new List<CrawlResult>();
         var indexerMock = new Mock<IIndexer>();
 
@@ -149,25 +167,41 @@ public class CrawlerIntegrationTests : IClassFixture<WebApplicationFactory<Progr
         using var httpClientForCrawler = webHelper.BuildHttpClient();
         
         using WebApplicationFactory<Program> testFactory = CreateTestFactory(
-            fakeAppSettings,
             indexerMock,
-            httpClientForCrawler
+            httpClientForCrawler,
+            externalURL
         );
 
 
         // Retrieve the actuall implementation of the crawler. 
         using var scope = testFactory.Services.CreateScope();
-     
-        // Act
-        int timeoutMs = 500;
-        int elapsedTime = 0;
+        var dispatcher = scope.ServiceProvider.GetRequiredService<ICrawlJobDispatcher>();
 
-        // Wait up to 5 sec to fill list 
-        while (elapsedTime < timeoutMs)
+        // Act
+        var cts = new CancellationTokenSource();
+        
+        await dispatcher.Enqueue(crawlJob);
+        
+        try
         {
-            await Task.Delay(100); // wait with 100 ms intervalls
-            elapsedTime += 100;
+            _ = dispatcher.Start(cts.Token);    
+            
+            int timeoutMs = 500;
+            int elapsedTime = 0;
+
+            // Wait up to 5 sec to fill list 
+            while (elapsedTime < timeoutMs)
+            {
+                await Task.Delay(100); // wait with 100 ms intervalls
+                elapsedTime += 100;
+            }
+
         }
+        finally
+        {
+            cts.Cancel();
+        }
+       
 
         // Assert
         Assert.Empty(visitedList);
@@ -187,19 +221,8 @@ public class CrawlerIntegrationTests : IClassFixture<WebApplicationFactory<Progr
         string page1 = "http://localhost/page1.html";
         string page2 = "http://localhost/page2.html";
         string final = "http://localhost/final.html";
-        
-        string fakeAppSettings = $$$"""
-        {
-            "CrawlerSettings": {
-                "UserAgent": "TestBot",
-                "MaxConcurrencyPerDomain": 2,
-                "MinDelayMs": 10,
-                "RetryIntervals": ["00:00:01"],
-                "SeedUrls": ["{{{seedURL}}}"],
-                "WhiteList": ["localhost"]
-            }
-        }
-        """;
+
+        CrawlJob crawlJob = new CrawlJob{ Url = seedURL, NextAttempt = DateTime.UtcNow };
 
         var visitedList = new List<CrawlResult>();
         var indexerMock = new Mock<IIndexer>();
@@ -212,25 +235,37 @@ public class CrawlerIntegrationTests : IClassFixture<WebApplicationFactory<Progr
         using var httpClientForCrawler = _webHostBuilder.CreateFakeInternetClient();
         
         using WebApplicationFactory<Program> testFactory = CreateTestFactory(
-            fakeAppSettings,
             indexerMock, 
-            httpClientForCrawler
+            httpClientForCrawler,
+            seedURL
         );
 
-
-        // Retrieve the actuall implementation of the crawler. 
+        // Retrieve the actuall implementation of the CrawlJobDispatcher. 
         using var scope = testFactory.Services.CreateScope();
-      
+        var dispatcher = scope.ServiceProvider.GetRequiredService<ICrawlJobDispatcher>();
+
 
         // Act
-        int timeoutMs = 4000;
-        int elapsedTime = 0;
-
-        // Wait up to 5 sec to fill list 
-        while (visitedList.Count < 4 && elapsedTime < timeoutMs)
+        await dispatcher.Enqueue(crawlJob);
+        var cts = new CancellationTokenSource();
+        
+        try
         {
-            await Task.Delay(100); // wait with 100 ms intervalls
-            elapsedTime += 100;
+            _ = dispatcher.Start(cts.Token);
+            
+            int timeoutMs = 4000;
+            int elapsedTime = 0;
+
+            // Wait up to 4 sec to fill list 
+            while (visitedList.Count < 4 && elapsedTime < timeoutMs)
+            {
+                await Task.Delay(100); // wait with 100 ms intervalls
+                elapsedTime += 100;
+            }
+        }
+        finally
+        {
+            cts.Cancel();
         }
 
         // Assert
@@ -250,19 +285,11 @@ public class CrawlerIntegrationTests : IClassFixture<WebApplicationFactory<Progr
         // includes domain external-domain.com
         string seedURL = "http://localhost/SeedIncludingExternalUrl.html"; 
 
-        string fakeAppSettings = $$$"""
-        {
-            "CrawlerSettings": {
-                "UserAgent": "TestBot",
-                "MaxConcurrencyPerDomain": 2,
-                "MinDelayMs": 10,
-                "RetryIntervals": ["00:00:01"],
-                "SeedUrls": ["{{{seedURL}}}"],
-                "WhiteList": ["localhost"]
-            }
-        }
-        """;
-        
+        CrawlJob crawlJob1 = new CrawlJob { Url = seedURL, NextAttempt = DateTime.UtcNow };
+
+        int timeoutMs = 4000;
+        int elapsedTime = 0;
+
         var visitedList = new List<CrawlResult>();
         var indexerMock = new Mock<IIndexer>();
 
@@ -275,64 +302,148 @@ public class CrawlerIntegrationTests : IClassFixture<WebApplicationFactory<Progr
         using var httpClientForCrawler = _webHostBuilder.CreateFakeInternetClient();
         
         using WebApplicationFactory<Program> testFactory = CreateTestFactory(
-            fakeAppSettings,
             indexerMock, 
-            httpClientForCrawler
+            httpClientForCrawler,
+            seedURL
         );
 
 
         // Retrieve the actuall implementation of the crawler. 
         using var scope = testFactory.Services.CreateScope();
         var dispatcher = scope.ServiceProvider.GetService<ICrawlJobDispatcher>();
+
+        var cts = new CancellationTokenSource();    
         
+        await dispatcher!.Enqueue(crawlJob1);
 
         // Act 1 -- Verify that none whitelisted domain is blocked
-        int timeoutMs = 4000;
-        int elapsedTime = 0;
-
-        // Wait up to 4 sec to fill list 
-        while (visitedList.Count < 4 && elapsedTime < timeoutMs)
+        try
         {
-            await Task.Delay(100); // wait with 100 ms intervalls
-            elapsedTime += 100;
-        }
-
-        Assert.DoesNotContain(visitedList, im => im.Url.Contains("external-domain.com"));
-        visitedList.Clear();
-
-        // Act 2 -- Verify that updated whitelist domain is now allowed 
-        string updatedFakeAppSettings = $$$"""
-        {
-            "CrawlerSettings": {
-                "UserAgent": "TestBot",
-                "MaxConcurrencyPerDomain": 2,
-                "MinDelayMs": 10,
-                "RetryIntervals": ["00:00:01"],
-                "SeedUrls": ["{{{seedURL}}}"],
-                "WhiteList": ["external-domain.com", "localhost"]
+            _ = dispatcher.Start(cts.Token);
+            
+           // Wait up to 4 sec to fill list 
+            while (visitedList.Count < 4 && elapsedTime < timeoutMs)
+            {
+                await Task.Delay(100); // wait with 100 ms intervalls
+                elapsedTime += 100;
             }
-        }
-        """;
 
-        CrawlJob crawlJob = new CrawlJob{Url = seedURL, NextAttempt = DateTime.UtcNow};
-
-        File.WriteAllText(_tempSettingsPath, updatedFakeAppSettings);
+             Assert.DoesNotContain(visitedList, im => im.Url.Contains("external-domain.com"));
         
-        elapsedTime = 0;
-        await Task.Delay(1000);
-        await dispatcher!.Enqueue(crawlJob);
+            // Reset measuring variables
+            visitedList.Clear();
+            elapsedTime = 0;
 
-        // Wait up to 4 sec to fill list 
-        while (visitedList.Count < 5 && elapsedTime < timeoutMs)
-        {
-            await Task.Delay(100); // wait with 100 ms intervalls
-            elapsedTime += 100;
+            // Act 2 -- Verify that updated whitelist domain is now allowed 
+            string updatedFakeAppSettings = $$$"""
+            {
+                "CrawlerSettings": {
+                    "UserAgent": "TestBot",
+                    "MaxConcurrencyPerDomain": 2,
+                    "MinDelayMs": 10,
+                    "RetryIntervals": ["00:00:01"],
+                    "SeedUrls": ["{{{seedURL}}}"],
+                    "WhiteList": ["external-domain.com", "localhost"]
+                }
+            }
+            """;
+
+            CrawlJob crawlJob2 = new CrawlJob{Url = seedURL, NextAttempt = DateTime.UtcNow};
+
+            File.WriteAllText(_tempSettingsPath, updatedFakeAppSettings);
+            
+            await Task.Delay(1000);
+            await dispatcher!.Enqueue(crawlJob2);
+
+            // Wait up to 4 sec to fill list 
+            while (visitedList.Count < 5 && elapsedTime < timeoutMs)
+            {
+                await Task.Delay(100); // wait with 100 ms intervalls
+                elapsedTime += 100;
+            }
+
+            // Assert 
+            Assert.Contains(visitedList, im => im.Url.Contains("external-domain.com"));    
         }
-
-        // Assert 
-        Assert.Contains(visitedList, im => im.Url.Contains("external-domain.com"));
+        finally
+        {
+            cts.Cancel();
+        }
+        
+       
     }
 
+    [Fact]
+    [Trait("TestCase", "TC-FRQ-1003-A")]
+    public async Task Crawler_DomainRateAndConcurrencyLimitEnforcement()
+    {
+        // Arrange 
+        // Setting up timing instruments
+        string maxConcurrencyPerDomain = "2";
+
+        var timesStamps = new List<DateTime>();
+        int activeRequests = 0;
+        int maxObservedConcurrency = 0;
+        var lockObject = new Object();
+
+        using var host = Host.CreateDefaultBuilder()
+            .ConfigureWebHostDefaults( webBuilder =>
+            {
+                webBuilder.UseTestServer();
+                
+                webBuilder.Configure(app =>
+                {
+                   app.Run( async context =>
+                   {
+                       // log concurrency
+                       var current = Interlocked.Increment(ref activeRequests);
+                       lock (lockObject)
+                       {
+                           maxObservedConcurrency = Math.Max(maxObservedConcurrency, current);
+                           timesStamps.Add(DateTime.UtcNow);
+                       }
+
+                       // we force the connection to stay open to measure concurrency 
+                       await Task.Delay(300); 
+                       Interlocked.Decrement(ref activeRequests);
+                       await context.Response.WriteAsync("<html><body>Done</body></html>");
+                   });
+                });
+            }).Build();; 
+        
+        await host.StartAsync();
+
+        using WebApplicationFactory<Program> testFactory = CreateTestFactory(
+            new Mock<IIndexer>(), 
+            host.GetTestClient(),
+            maxConcurrencyPerDomain
+        );
+
+        using var scope = testFactory.Services.CreateScope();
+        var dispatcher = scope.ServiceProvider.GetRequiredService<ICrawlJobDispatcher>();
+        var settingsLoader = scope.ServiceProvider.GetRequiredService<ICrawlerSettingsLoader>();       
+        
+        
+        // Act
+        using var cts = new CancellationTokenSource();
+        var dispatcherTask = dispatcher.Start(cts.Token);
+
+        for (int i = 0; i < 5; i++)
+        {
+            await dispatcher.Enqueue(new CrawlJob
+            {
+                Url = $"http://localhost/page{i}",
+                NextAttempt = DateTime.UtcNow
+            });
+        }
+
+        // Ensures that the dispatcher was given enough time to execute
+        await Task.Delay(3000); 
+        cts.Cancel();
+
+        // Assert
+        Assert.True(maxObservedConcurrency <= settingsLoader.Load().MaxConcurrencyPerDomain);
+    }
 
     public void Dispose()
     {


### PR DESCRIPTION
Test Case: TC-FRQ-1003-A implemented.
Note: all other crawler integration tests were also updated to use the dispatcher as their starting point and not the crawler.


However the tests failed, because of a faulty implementation of the dispatcher.
Therefore I also updated the dispatcher. It now handles concurrency and delays without issues.