### PR TITLE
50 the content parsed from a crawl is to be hashed and saved in crawlresult and sent to the index

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,10 @@
 {
     "cSpell.words": [
+        "Entitize",
         "localdb",
         "lturobots",
         "mssqllocaldb",
-        "NFRQ"
+        "NFRQ",
+        "noscript"
     ]
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Api/Program.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Api/Program.cs
@@ -4,6 +4,7 @@ using LTU.SearchEngine.Application.QueryParsing;
 using LTU.SearchEngine.Application.QueryParsing.Helpers;
 using LTU.SearchEngine.Backend.Core;
 using LTU.SearchEngine.Backend.Core.Enums;
+using LTU.SearchEngine.Backend.Core.HelperClasses;
 using LTU.SearchEngine.Backend.Core.Model;
 using LTU.SearchEngine.Backend.Core.Model.DTOs;
 using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
@@ -52,6 +53,7 @@ public partial class Program
         builder.Services.AddHttpClient();
 
         // Semaphore for handling global concurrency/throttling if needed.
+        builder.Services.AddSingleton<IContentHasher, ContentHasher>();
         builder.Services.AddSingleton<SemaphoreProvider>();
 
         // HTML Parsing strategy (e.g., using HtmlAgilityPack).

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Api/appsettings.json
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Api/appsettings.json
@@ -13,6 +13,7 @@
     "UserAgent": "LTUSearchCrawler / 1.0(Academic project; contact: some.mail @student.ltu.se",
     "MaxConcurrencyPerDomain": 2,
     "MinDelayMs": 500,
+    "CrawlUpdateInterval": "7.00:00:00",
     "RetryIntervals": [
       "01:00:00",
       "1.00:00:00",

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/HelperClasses/ContentHasher.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/HelperClasses/ContentHasher.cs
@@ -1,8 +1,6 @@
-namespace LTU.SearchEngine.Backend.Core.HelperClasses;
-
 using System.Security.Cryptography;
-using System.Text;
 
+namespace LTU.SearchEngine.Backend.Core.HelperClasses;
 /// <summary>
 /// Provides utility methods for generating cryptographic hashes of content.
 /// </summary>

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/HelperClasses/ContentHasher.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/HelperClasses/ContentHasher.cs
@@ -1,0 +1,28 @@
+namespace LTU.SearchEngine.Backend.Core.HelperClasses;
+
+using System.Security.Cryptography;
+using System.Text;
+
+/// <summary>
+/// Provides utility methods for generating cryptographic hashes of content.
+/// </summary>
+public class ContentHasher : IContentHasher
+{
+    /// <summary>
+    /// Computes a SHA256 hash for the specified string content and returns it as a hexadecimal string.
+    /// </summary>
+    /// <param name="content">The string content to be hashed.</param>
+    /// <returns>
+    /// A 64-character hexadecimal string representing the SHA256 hash. <br/>
+    /// Returns <see cref="string.Empty"/> if the input content is null or empty.
+    /// </returns>
+    public string CalculateHash(byte[] content)
+    {
+        if (content == null || content.Length == 0)
+            return string.Empty;
+
+        var hashBytes = SHA256.HashData(content);
+
+        return Convert.ToHexString(hashBytes);
+    }
+}

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/HelperClasses/IContentHasher.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/HelperClasses/IContentHasher.cs
@@ -1,0 +1,6 @@
+namespace LTU.SearchEngine.Backend.Core.HelperClasses;
+
+public interface IContentHasher
+{
+    string CalculateHash(byte[] content);
+}

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/IIndexingPipeline.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/IIndexingPipeline.cs
@@ -1,12 +1,8 @@
 ﻿using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
-namespace LTU.SearchEngine.Backend.Core.Model
+namespace LTU.SearchEngine.Backend.Core.Model;
+
+public interface IIndexingPipeline
 {
-    public interface IIndexingPipeline
-    {
-        IndexDocument Transform(CrawlResult crawlResult);
-    }
+    IndexDocument Transform(CrawlResult crawlResult);
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/CrawlResult.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/CrawlResult.cs
@@ -24,6 +24,7 @@ public sealed class CrawlResult
 	public IReadOnlyList<string> ExtractedLinks { get; }
 	public HttpStatusCode StatusCode { get; }
 	public long TimeTakenMs { get; }
+	public string ContentHash { get; }
 
 	public CrawlResult(
 		string url,
@@ -34,7 +35,8 @@ public sealed class CrawlResult
 		byte[] content,
 		IEnumerable<string> extractedLinks,
 		HttpStatusCode statusCode,
-		long timeTakenMs)
+		long timeTakenMs,
+		string contentHash)
 	{
 		Url = !string.IsNullOrWhiteSpace(url)
 			? url
@@ -49,6 +51,9 @@ public sealed class CrawlResult
 			: throw new ArgumentException("Type cannot be null or whitespace.", nameof(type));
 
 		Content = content ?? throw new ArgumentNullException(nameof(content));
+		ContentHash = !string.IsNullOrWhiteSpace(contentHash)
+			? contentHash
+			: throw new ArgumentException("ContentHash cannot be null or whitespace.", nameof(contentHash));
 
 		if (indexedTerms is null)
 			throw new ArgumentNullException(nameof(indexedTerms));

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/CrawlResult.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/CrawlResult.cs
@@ -50,11 +50,12 @@ public sealed class CrawlResult
 			? type
 			: throw new ArgumentException("Type cannot be null or whitespace.", nameof(type));
 
-		Content = content ?? throw new ArgumentNullException(nameof(content));
 		ContentHash = !string.IsNullOrWhiteSpace(contentHash)
 			? contentHash
 			: throw new ArgumentException("ContentHash cannot be null or whitespace.", nameof(contentHash));
-
+		
+		Content = content ?? throw new ArgumentNullException(nameof(content));
+		
 		if (indexedTerms is null)
 			throw new ArgumentNullException(nameof(indexedTerms));
 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Crawling/Crawler.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Crawling/Crawler.cs
@@ -1,4 +1,5 @@
-﻿using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
+﻿using LTU.SearchEngine.Backend.Core.HelperClasses;
+using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
 using System.Diagnostics;
 
 namespace LTU.SearchEngine.Infrastructure.Crawling;
@@ -7,11 +8,13 @@ public class Crawler : ICrawler
 {
     private readonly HttpClient _httpClient;
     private readonly IHtmlParser _htmlParser;
+    private readonly IContentHasher _contentHasher;
 
-    public Crawler(HttpClient httpClient, IHtmlParser htmlParser)
+    public Crawler(HttpClient httpClient, IHtmlParser htmlParser, IContentHasher contentHasher)
     {
         _httpClient = httpClient;
         _htmlParser = htmlParser;
+        _contentHasher = contentHasher;
     }
 
     /// <inheritdoc/>
@@ -57,7 +60,8 @@ public class Crawler : ICrawler
                 content: content,
                 extractedLinks: links,
                 statusCode: response.StatusCode,
-                timeTakenMs: stopwatch.ElapsedMilliseconds
+                timeTakenMs: stopwatch.ElapsedMilliseconds,
+                contentHash: _contentHasher.CalculateHash(content)
             );
         }
         catch (HttpRequestException ex) 
@@ -84,7 +88,8 @@ public class Crawler : ICrawler
             content: Array.Empty<byte>(),
             extractedLinks: Enumerable.Empty<string>(),
             statusCode: statusCode,
-            timeTakenMs: timeTaken
+            timeTakenMs: timeTaken,
+            contentHash: _contentHasher.CalculateHash(Array.Empty<byte>())
         );
     }
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/HapHtmlParser.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/HapHtmlParser.cs
@@ -94,13 +94,13 @@ public class HapHtmlParser : IHtmlParser
             }
         }
 
-        // --- 3. EXTRACT META DATA (Fix för UTF-8 testet) ---
+        // --- 3. EXTRACT META DATA (Fix for UTF-8 test) ---
         var metaNodes = doc.DocumentNode.SelectNodes("//meta");
         if (metaNodes != null)
         {
             foreach (var node in metaNodes)
             {
-                // Meta-taggar har sällan InnerText. Vi kollar attribut som 'charset' eller 'content'
+                // Meta-tags seldomly have meaningful InnerText, so we check attributes like 'charset' or 'content'
                 var content = node.GetAttributeValue("content", "");
                 var charset = node.GetAttributeValue("charset", "");
 
@@ -122,8 +122,7 @@ public class HapHtmlParser : IHtmlParser
             }
         }
 
-        // --- EXTRAHERA BILD-TEXT (Alt-taggar) ---
-        // Vi letar efter alla <img> taggar som har ett alt-attribut
+        // --- EXTRACT IMAGE TEXT (Alt-tags) <img> with alt-attributes ---
         var imageNodes = doc.DocumentNode.SelectNodes("//img[@alt]");
         if (imageNodes != null)
         {
@@ -132,12 +131,9 @@ public class HapHtmlParser : IHtmlParser
                 var altText = node.GetAttributeValue("alt", "");
                 if (!string.IsNullOrWhiteSpace(altText))
                 {
-                    // Vi ger ofta alt-text samma vikt som Body eller Header 
-                    // beroende på hur "viktig" man anser bilden vara.
+                    // alt-text is often given the same importance as a body or header
                     AddTerms(terms, altText, TermSource.Body);
                 }
-                // Vi tar inte bort hela image-noden än om vi vill behålla strukturen, 
-                // men det skadar inte att göra det om vi bara vill ha texten.
                 node.Remove();
             }
         }
@@ -145,7 +141,6 @@ public class HapHtmlParser : IHtmlParser
         // --- 4. EXTRACT BODY TEXT (Low/Standard Ranking Priority) ---
         // At this stage, scripts, titles, and headers have been removed.
         // InnerText now contains only the remaining "Body" content (paragraphs, lists, divs).
-
         var bodyText = doc.DocumentNode.InnerText;
         AddTerms(terms, bodyText, TermSource.Body);
 
@@ -177,14 +172,14 @@ public class HapHtmlParser : IHtmlParser
         var doc = new HtmlDocument();
         doc.LoadHtml(html);
 
-        //Remove garbage
+        // Remove garbage
         var garbageNodes = doc.DocumentNode.SelectNodes("//script|//style|//noscript|//nav|//footer");
         if(garbageNodes != null)
         {
             foreach (var node in garbageNodes) node.Remove();
         }
 
-        //return all text as a single string
+        // Return all text as a single string
         string plainText = doc.DocumentNode.InnerText;
         return HtmlEntity.DeEntitize(plainText).Trim();
     }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Indexing/Indexer.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Indexing/Indexer.cs
@@ -2,42 +2,39 @@
 using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
 using LTU.SearchEngine.Infrastructure.Repositories;
 
-namespace LTU.SearchEngine.Infrastructure.Indexing
+namespace LTU.SearchEngine.Infrastructure.Indexing;
+
+/// <summary>
+/// Orchestrates the indexing flow for crawl results.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The indexer is responsible for receiving <see cref="CrawlResult"/> instances,
+/// validating whether indexing should occur, invoking the indexing pipeline,
+/// and persisting the resulting index documents via a repository.
+/// </para>
+/// <para>
+/// This class coordinates the indexing process but does not perform text normalization,
+/// term frequency calculation, or direct storage operations.
+/// </para>
+/// </remarks>
+public class Indexer : IIndexer
 {
-    /// <summary>
-    /// Orchestrates the indexing flow for crawl results.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// The indexer is responsible for receiving <see cref="CrawlResult"/> instances,
-    /// validating whether indexing should occur, invoking the indexing pipeline,
-    /// and persisting the resulting index documents via a repository.
-    /// </para>
-    /// <para>
-    /// This class coordinates the indexing process but does not perform text normalization,
-    /// term frequency calculation, or direct storage operations.
-    /// </para>
-    /// </remarks>
-    public class Indexer : IIndexer
+    private readonly IIndexRepository _repository;
+    private readonly IIndexingPipeline _pipeline;
+    public Indexer(IIndexRepository repository, IIndexingPipeline pipeline)
     {
-        private readonly IIndexRepository _repository;
-        private readonly IIndexingPipeline _pipeline;
-        public Indexer(IIndexRepository repository, IIndexingPipeline pipeline)
-        {
-            _repository = repository;
-            _pipeline = pipeline;
-        }
+        _repository = repository;
+        _pipeline = pipeline;
+    }
 
-        public async Task IndexAsync(CrawlResult crawlResult)
-        {
-            if (crawlResult is null)
-                throw new ArgumentNullException(nameof(crawlResult));
+    public async Task IndexAsync(CrawlResult crawlResult)
+    {
+        if (crawlResult is null)
+            throw new ArgumentNullException(nameof(crawlResult));
 
-            // Transform är förmodligen CPU-bunden och går snabbt, så den kan ofta vara synkron
-            var document = _pipeline.Transform(crawlResult);
+        var document = _pipeline.Transform(crawlResult);
 
-            // Nu väntar vi snällt på att databasen ska spara klart, utan att låsa tråden!
-            await _repository.SaveAsync(document);
-        }
+        await _repository.SaveAsync(document);
     }
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Repositories/SqlIndexRepository.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Repositories/SqlIndexRepository.cs
@@ -54,7 +54,7 @@ public class SqlIndexRepository : IIndexRepository
         };
 
         context.Pages.Add(page);
-        //Save imediatly to generate a ID
+        //Save immediately to generate a ID
         await context.SaveChangesAsync(); 
 
         // 4. Iterate through all unique words and link them to the page

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/BackgroundServices.Tests/TplCrawlJobDispatcherTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/BackgroundServices.Tests/TplCrawlJobDispatcherTests.cs
@@ -9,7 +9,6 @@ using LTU.SearchEngine.Test.HelperClasses;
 using Microsoft.Extensions.Logging;
 using Moq;
 using System.Net;
-using System.Text;
 
 namespace LTU.SearchEngine.Test.BackgroundServices.Tests;
 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/BackgroundServices.Tests/TplCrawlJobDispatcherTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/BackgroundServices.Tests/TplCrawlJobDispatcherTests.cs
@@ -5,6 +5,7 @@ using LTU.SearchEngine.Backend.Core.Model.Entities;
 using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
 using LTU.SearchEngine.BackgroundServices;
 using LTU.SearchEngine.Infrastructure.Configuration;
+using LTU.SearchEngine.Test.HelperClasses;
 using Microsoft.Extensions.Logging;
 using Moq;
 using System.Net;
@@ -21,17 +22,7 @@ public class TplCrawlJobDispatcherTests
 
     private CrawlResult CreateResult()
 	{
-		return new CrawlResult(
-			url: "https://example.com",
-			title: "x",
-			language: "en",
-			indexedTerms: new List<IndexedTerm>(),
-			type: "text/html",
-			content: Encoding.UTF8.GetBytes("x"),
-			extractedLinks: Array.Empty<string>(),
-			statusCode: HttpStatusCode.OK,
-			timeTakenMs: 1
-		);
+		return CrawlResultBuilder.BuildCrawlResult();
 	}
 	
 	private static CrawlerSettings CreateSettings()
@@ -352,17 +343,18 @@ public class TplCrawlJobDispatcherTests
 	[Fact]
 	public async Task ExtractedLinks_CreateNewJobs()
 	{
-		var result = new CrawlResult(
+		var result = CrawlResultBuilder.BuildCrawlResult(
 			url: "https://root.com",
 			title: "root",
 			language: "en",
-			indexedTerms: new List<IndexedTerm>(),
 			type: "text/html",
-			content: Encoding.UTF8.GetBytes("x"),
-			extractedLinks: new[] { "https://a.com", "https://b.com" },
+			indexedTerms: new List<IndexedTerm>(),
+			content: "x",
+			extractedLinks: new List<string> { "https://a.com", "https://b.com" },
 			statusCode: HttpStatusCode.OK,
 			timeTakenMs: 10
 		);
+		
 
 		_mockUseCase.Setup(u => u.Execute(It.IsAny<CrawlJob>()))
 			.ReturnsAsync(result);

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Core.Tests/ContentHasherTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Core.Tests/ContentHasherTests.cs
@@ -1,0 +1,72 @@
+using System.Text;
+using LTU.SearchEngine.Backend.Core.HelperClasses;
+
+namespace LTU.SearchEngine.Test.Core.Tests;
+
+public class ContentHasherTests
+{
+    private readonly IContentHasher _sut;
+    string _emptyString = string.Empty;
+
+    public ContentHasherTests()
+    {
+        _sut = new ContentHasher();
+    }
+
+
+    [Fact]
+    public void CalculateHash_ContentIsNull_ReturnsEmptyString()
+    {
+        // Arrange 
+        byte[] content = null!;
+
+        // Act
+        var result = _sut.CalculateHash(content);
+
+        // Assert
+        Assert.Equal(_emptyString, result);
+    }
+
+    [Fact]
+    public void CalculateHash_ContentIsEmpty_ReturnsEmptyString()
+    {
+        // Arrange 
+        byte[] content = new byte[0];
+
+        // Act
+        var result = _sut.CalculateHash(content);
+
+        // Assert
+        Assert.Equal(_emptyString, result);
+    }
+
+    [Fact]
+    public void CalculateHash_TwoSeparateIdenticalInput_ReturnsSameHash()
+    {
+        // Arrange 
+        byte[] content1 = Encoding.UTF8.GetBytes("Test content");
+        byte[] content2 = Encoding.UTF8.GetBytes("Test content");
+
+        // Act
+        var hash1 = _sut.CalculateHash(content1);
+        var hash2 = _sut.CalculateHash(content2);
+
+        // Assert
+        Assert.Equal(hash1, hash2);
+    }
+    
+    [Fact]
+    public void CalculateHash_TwoSeparateDifferentInput_ReturnsDifferentHash()
+    {
+        // Arrange 
+        byte[] content1 = Encoding.UTF8.GetBytes("Test content 1");
+        byte[] content2 = Encoding.UTF8.GetBytes("Test content 2");
+
+        // Act
+        var hash1 = _sut.CalculateHash(content1);
+        var hash2 = _sut.CalculateHash(content2);
+
+        // Assert
+        Assert.NotEqual(hash1, hash2);
+    }
+}

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Core.Tests/SemaphoreProviderTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Core.Tests/SemaphoreProviderTests.cs
@@ -1,7 +1,5 @@
 ﻿using LTU.SearchEngine.Backend.Core;
-using Microsoft.AspNetCore.DataProtection.KeyManagement;
 using System.Collections.Concurrent;
-using System.Runtime.ConstrainedExecution;
 
 namespace LTU.SearchEngine.Test.Core.Tests;
 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Crawling.Tests/CrawlBackgroundServiceTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Crawling.Tests/CrawlBackgroundServiceTests.cs
@@ -37,19 +37,19 @@ namespace LTU.SearchEngine.Test.Crawling.Tests
             // now Moq knows the difference between start pages and sub pages..
             mockCrawler.Setup(c => c.FetchAsync(seedUrl)).ReturnsAsync(new CrawlResult(
                 seedUrl, "Home", "Welcome", dummyTerms, "text/html", Array.Empty<byte>(),
-                new List<string> { page1Url }, HttpStatusCode.OK, 100));
+                new List<string> { page1Url }, HttpStatusCode.OK, 100, "FakeHash"));
 
             mockCrawler.Setup(c => c.FetchAsync(page1Url)).ReturnsAsync(new CrawlResult(
                 page1Url, "Page 1", "Content 1", dummyTerms, "text/html", Array.Empty<byte>(),
-                new List<string> { page2Url }, HttpStatusCode.OK, 100));
+                new List<string> { page2Url }, HttpStatusCode.OK, 100, "FakeHash"));
 
             mockCrawler.Setup(c => c.FetchAsync(page2Url)).ReturnsAsync(new CrawlResult(
                 page2Url, "Page 2", "Content 2", dummyTerms, "text/html", Array.Empty<byte>(),
-                new List<string> { finalPageUrl }, HttpStatusCode.OK, 100));
+                new List<string> { finalPageUrl }, HttpStatusCode.OK, 100, "FakeHash"));
 
             mockCrawler.Setup(c => c.FetchAsync(finalPageUrl)).ReturnsAsync(new CrawlResult(
                 finalPageUrl, "Final", "End", dummyTerms, "text/html", Array.Empty<byte>(),
-                new List<string>(), HttpStatusCode.OK, 100));
+                new List<string>(), HttpStatusCode.OK, 100, "FakeHash"));
 
             var settings = new CrawlerSettings(
                 userAgent: "TestBot",

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Crawling.Tests/CrawlerTest.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Crawling.Tests/CrawlerTest.cs
@@ -1,4 +1,5 @@
-﻿using LTU.SearchEngine.Backend.Core.Model;
+﻿using LTU.SearchEngine.Backend.Core.HelperClasses;
+using LTU.SearchEngine.Backend.Core.Model;
 using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
 using LTU.SearchEngine.Infrastructure.Crawling;
 using Moq;
@@ -12,6 +13,7 @@ namespace LTU.SearchEngine.Test.Crawling.Tests
     {
         private readonly Mock<IHtmlParser> _parserMock;
         private readonly Mock<HttpMessageHandler> _handlerMock;
+        private readonly Mock<IContentHasher> _contentHasherMock;
         private readonly HttpClient _httpClient;
         private readonly Crawler _sut;
         private readonly ITestOutputHelper _output;
@@ -20,11 +22,13 @@ namespace LTU.SearchEngine.Test.Crawling.Tests
         {
             _parserMock = new Mock<IHtmlParser>();
             _handlerMock = new Mock<HttpMessageHandler>();
+            _contentHasherMock = new Mock<IContentHasher>();
+            _contentHasherMock.Setup(ch => ch.CalculateHash(It.IsAny<byte[]>())).Returns("FakeHash");
 
             // We create a HttpClient that uses our mocked handler
             _httpClient = new HttpClient(_handlerMock.Object);
 
-            _sut = new Crawler(_httpClient, _parserMock.Object);
+            _sut = new Crawler(_httpClient, _parserMock.Object, _contentHasherMock.Object);
             _output = output;
         }
 
@@ -38,13 +42,13 @@ namespace LTU.SearchEngine.Test.Crawling.Tests
             <html>
                 <head>
                   <title>Test Page Title</title>
-          </head>
-          <body>
-        <h1>Welcome to LTU</h1>
-        <p>This is a test page with search terms.</p>
-        <a href='/contact'>Contact Us</a>
-    </body>
-        </html>";
+                </head>
+                <body>
+                    <h1>Welcome to LTU</h1>
+                    <p>This is a test page with search terms.</p>
+                    <a href='/contact'>Contact Us</a>
+                </body>
+            </html>";
 
             var expectedContent = System.Text.Encoding.UTF8.GetBytes(fakeHtml);
 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Crawling.Tests/CrawlerTest.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Crawling.Tests/CrawlerTest.cs
@@ -154,7 +154,7 @@ namespace LTU.SearchEngine.Test.Crawling.Tests
             Assert.Empty(result.IndexedTerms);
         }
 
-        // --- Helpmethod for moq HttpClient ---
+        // --- Help method for moq HttpClient ---
         private void SetupHttpResponse(HttpStatusCode code, string content)
         {
             _handlerMock

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Crawling.Tests/Model/CrawlResultsTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Crawling.Tests/Model/CrawlResultsTests.cs
@@ -125,6 +125,20 @@ public class CrawlResultsTests
 			);
 		}
 
+		[Theory]
+		[InlineData("NULL_TEST")]
+		[InlineData("")]
+		[InlineData(" ")]
+		public void Constructor_InvalidContentHash_ThrowsArgumentNullException(string input)
+		{
+			string? invalidContentHash = input.Equals("NULL_TEST") ? null : input;
+
+			Assert.Throws<ArgumentException>(() => 
+				CrawlResultBuilder.BuildCrawlResult(hashContent: invalidContentHash!)
+			);
+		}
+
+
 		[Fact]
 		public void Constructor_NegativeTimeTaken_ThrowsArgumentOutOfRangeException()
 		{

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Crawling.Tests/Model/CrawlResultsTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Crawling.Tests/Model/CrawlResultsTests.cs
@@ -1,6 +1,8 @@
 ﻿using LTU.SearchEngine.Backend.Core.Model;
 using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
+using LTU.SearchEngine.Test.HelperClasses;
 using System.Net;
+using System.Text;
 
 namespace LTU.SearchEngine.Test.Crawling.Tests.Model;
 
@@ -17,13 +19,24 @@ public class CrawlResultsTests
 			var language = "en";
 			var terms = new List<IndexedTerm> { new IndexedTerm("test", TermSource.Title) };
 			var type = "text/html";
-			var content = new byte[] { 1, 2, 3 };
+			var content = Encoding.UTF8.GetBytes("x");
 			var links = new List<string> { "https://link.com" };
 			var statusCode = HttpStatusCode.OK;
 			var timeTakenMs = 123;
 
 			// Act
-			var sut = new CrawlResult(url, title, language, terms, type, content, links, statusCode, timeTakenMs);
+			var sut = CrawlResultBuilder.BuildCrawlResult(
+				url: url,
+				title: title,
+				language: language,
+				indexedTerms: terms,
+				type: type,
+				content: "x",
+				extractedLinks: links,
+				statusCode: statusCode,
+				timeTakenMs: timeTakenMs,
+				hashContent: "FakeHash"
+			);
 
 			// Assert
 			Assert.Equal(url, sut.Url);
@@ -45,17 +58,7 @@ public class CrawlResultsTests
 		{
 			string? invalidUrl = input.Equals("NULL_TEST") ? null : input;
 
-			var ex = Assert.Throws<ArgumentException>(() => new CrawlResult(
-				invalidUrl!, 
-				"title", 
-				"en",
-				new List<IndexedTerm>(), 
-				"text/html", 
-				new byte[0],
-				new List<string>(), 
-				HttpStatusCode.OK, 
-				10)
-			);
+			var ex = Assert.Throws<ArgumentException>(() => CrawlResultBuilder.BuildCrawlResult(url: invalidUrl!));
 
 			Assert.Contains("Url cannot be null or whitespace", ex.Message);
 		}
@@ -63,17 +66,7 @@ public class CrawlResultsTests
 		[Fact]
 		public void Constructor_TitleCanBeNull()
 		{
-			var result = new CrawlResult(
-				"https://example.com", 
-				null, 
-				"en",
-				new List<IndexedTerm>(), 
-				"text/html", 
-				new byte[0],
-				new List<string>(), 
-				HttpStatusCode.OK, 
-				10
-			);
+			var result = CrawlResultBuilder.BuildCrawlResult(title: null!);
 
 			Assert.Null(result.Title);
 		}
@@ -88,16 +81,8 @@ public class CrawlResultsTests
 
 			string? invalidLanguage = input.Equals("NULL_TEST") ? null : input;
 
-			var ex = Assert.Throws<ArgumentException>(() => new CrawlResult(
-				"https://example.com",
-				"title",
-				invalidLanguage!,
-				new List<IndexedTerm>(),
-				"text/html",
-				new byte[0],
-				new List<string>(),
-				HttpStatusCode.OK,
-				10)
+			var ex = Assert.Throws<ArgumentException>(() => 
+				CrawlResultBuilder.BuildCrawlResult(language: invalidLanguage!)
 			);
 
 			Assert.Contains("Language cannot be null or whitespace.", ex.Message);
@@ -107,16 +92,8 @@ public class CrawlResultsTests
 		[Fact]
 		public void Constructor_NullIndexedTerms_ThrowsArgumentNullException()
 		{
-			Assert.Throws<ArgumentNullException>(() => new CrawlResult(
-				"https://example.com", 
-				"title", 
-				"en",
-				null!,
-				"text/html", 
-				new byte[0],
-				new List<string>(), 
-				HttpStatusCode.OK, 
-				10)
+			Assert.Throws<ArgumentNullException>(() => 
+				CrawlResultBuilder.BuildCrawlResult(indexedTerms: null!, extractedLinks: new List<string>())
 			);
 		}
 
@@ -129,17 +106,7 @@ public class CrawlResultsTests
 
 			string? invalidType = input.Equals(input) ? null : input;
 
-			var ex = Assert.Throws<ArgumentException>(() => new CrawlResult(
-				"https://example.com",
-				"title",
-				"en",
-				new List<IndexedTerm>(),
-				invalidType!,
-				new byte[0],
-				new List<string>(),
-				HttpStatusCode.OK,
-				10)
-			);
+			var ex = Assert.Throws<ArgumentException>(() => CrawlResultBuilder.BuildCrawlResult(type: invalidType!));
 
 			Assert.Contains("Type cannot be null or whitespace.", ex.Message);
 		}
@@ -147,49 +114,23 @@ public class CrawlResultsTests
 		[Fact]
 		public void Constructor_ContentNull_ThrowsArgumentNullException()
 		{
-			Assert.Throws<ArgumentNullException>(() => new CrawlResult(
-				"https://example.com",
-				"title",
-				"en",
-				new List<IndexedTerm>(),
-				"text/html",
-				null!,
-				new List<string>(),
-				HttpStatusCode.OK,
-				10)
-			);
+			Assert.Throws<ArgumentNullException>(() => CrawlResultBuilder.BuildCrawlResult(content: null!));
 		}
 
 		[Fact]
 		public void Constructor_NullExtractedLinks_ThrowsArgumentNullException()
 		{
-			Assert.Throws<ArgumentNullException>(() => new CrawlResult(
-				"https://example.com", 
-				"title", 
-				"en",
-				new List<IndexedTerm>(), 
-				"text/html", 
-				new byte[0],
-				null!, 
-				HttpStatusCode.OK, 
-				10)
+			Assert.Throws<ArgumentNullException>(() => 
+				CrawlResultBuilder.BuildCrawlResult(extractedLinks: null!, indexedTerms: new List<IndexedTerm>())
 			);
 		}
 
 		[Fact]
 		public void Constructor_NegativeTimeTaken_ThrowsArgumentOutOfRangeException()
 		{
-			var ex = Assert.Throws<ArgumentOutOfRangeException>(() => new CrawlResult(
-				"https://example.com", 
-				"title",
-				"en",
-				new List<IndexedTerm>(), 
-				"text/html", 
-				new byte[0],
-				new List<string>(), 
-				HttpStatusCode.OK, 
-				-1)
-			);
+			var ex = Assert.Throws<ArgumentOutOfRangeException>(
+				() => CrawlResultBuilder.BuildCrawlResult(timeTakenMs: -1
+			));
 
 			Assert.Contains("TimeTakenMs cannot be negative.", ex.Message);
 		}
@@ -201,10 +142,17 @@ public class CrawlResultsTests
 			var terms = new List<IndexedTerm> { new IndexedTerm("term1", TermSource.Header) };
 			var links = new List<string> { "https://link.com" };
 
-			var result = new CrawlResult(
-				"https://example.com", "title", "en",
-				terms, "text/html", new byte[0],
-				links, HttpStatusCode.OK, 100);
+			var result = CrawlResultBuilder.BuildCrawlResult(
+				url: "https://example.com", 
+				title: "title", 
+				language: "en",
+				indexedTerms: terms, 
+				type: "text/html",
+				content: "x",
+				extractedLinks: links, 
+				statusCode: HttpStatusCode.OK, 
+				timeTakenMs:100
+			);
 
 			// Modify original lists
 			terms.Add(new IndexedTerm("term2", TermSource.Body));

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Crawling.Tests/ProcessCrawlJobUseCaseTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Crawling.Tests/ProcessCrawlJobUseCaseTests.cs
@@ -6,6 +6,7 @@ using LTU.SearchEngine.Backend.Core.Model.Entities;
 using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
 using LTU.SearchEngine.Infrastructure.Configurations;
 using LTU.SearchEngine.Infrastructure.Crawling;
+using LTU.SearchEngine.Test.HelperClasses;
 using Moq;
 using System.Net;
 using System.Text;
@@ -70,25 +71,24 @@ public class ProcessCrawlJobUseCaseTests
 			</html>
 		""";
 
-		var contentBytes = Encoding.UTF8.GetBytes(html);
-
 		var extractedLinks = new List<string>
 		{
 			"https://example.com/about",
 		};
 
-		var expectedResult = new CrawlResult(
+		var expectedResult = CrawlResultBuilder.BuildCrawlResult(
 			url: _crawlJob.Url,
 			title: "title",
 			language: "sv",
 			indexedTerms: indexedTerms,
 			type: "text/html",
-			content: contentBytes,
+			content: html,
 			extractedLinks: extractedLinks,
 			statusCode: HttpStatusCode.OK,
 			timeTakenMs: 342
 		);
 
+		
 		_crawlerMock
 			.Setup(c => c.FetchAsync(_crawlJob.Url))
 			.ReturnsAsync(expectedResult);

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/HelperClasses/CrawlResultbuilder.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/HelperClasses/CrawlResultbuilder.cs
@@ -1,0 +1,60 @@
+using System.Net;
+using System.Text;
+using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
+
+namespace LTU.SearchEngine.Test.HelperClasses;
+
+public class CrawlResultBuilder
+{
+    public static CrawlResult BuildCrawlResult(
+        string url = "https://example.com",
+		string title = "x",
+	    string language = "en",
+		string type = "text/html",
+		string content = "x",
+		HttpStatusCode statusCode = HttpStatusCode.OK,
+		int timeTakenMs = 1,
+		string hashContent = "FakeHash"
+        )
+    {
+        return new CrawlResult(
+			url: url,
+			title: title,
+			language: language,
+			indexedTerms: new List<IndexedTerm>(),
+			type: type,
+			content: Encoding.UTF8.GetBytes(content),
+			extractedLinks: Array.Empty<string>(),
+			statusCode: statusCode,
+			timeTakenMs: timeTakenMs,
+            contentHash: hashContent
+		);
+    }
+
+    public static CrawlResult BuildCrawlResult(
+        IEnumerable<IndexedTerm> indexedTerms,
+        IEnumerable<string> extractedLinks,
+        string url = "https://example.com",
+		string title = "x",
+	    string language = "en",
+		string type = "text/html",
+		string content = "x",
+		HttpStatusCode statusCode = HttpStatusCode.OK,
+		int timeTakenMs = 1,
+		string hashContent = "FakeHash"
+        )
+    {
+        return new CrawlResult(
+			url: url,
+			title: title,
+			language: language,
+			indexedTerms: indexedTerms!,
+			type: type,
+			content: Encoding.UTF8.GetBytes(content),
+			extractedLinks: extractedLinks!,
+			statusCode: statusCode,
+			timeTakenMs: timeTakenMs,
+            contentHash: hashContent
+		);
+    }
+}

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Indexing.Tests/IndexerTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Indexing.Tests/IndexerTests.cs
@@ -44,7 +44,8 @@ namespace LTU.SearchEngine.Test.Indexing.IndexerTests
                 content: new byte[0],
                 extractedLinks: new List<string>(),
                 statusCode: HttpStatusCode.OK,
-                timeTakenMs: 10
+                timeTakenMs: 10,
+                "FakeHash"
             );
         }
 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Indexing.Tests/IndexerTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Indexing.Tests/IndexerTests.cs
@@ -1,98 +1,92 @@
-﻿using LTU.SearchEngine.Backend.Core;
-using LTU.SearchEngine.Backend.Core.Model;
+﻿using LTU.SearchEngine.Backend.Core.Model;
 using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
 using LTU.SearchEngine.Infrastructure.Indexing;
 using LTU.SearchEngine.Infrastructure.Repositories;
+using LTU.SearchEngine.Test.HelperClasses;
 using Moq;
 using System.Net;
-using System.Threading.Tasks; // Behövs för Task
-using Xunit;
-using IIndexingPipeline = LTU.SearchEngine.Backend.Core.Model.IIndexingPipeline; // Antar att du använder Xunit baserat på [Fact]
+using IIndexingPipeline = LTU.SearchEngine.Backend.Core.Model.IIndexingPipeline; 
 
-namespace LTU.SearchEngine.Test.Indexing.IndexerTests
+namespace LTU.SearchEngine.Test.Indexing.IndexerTests;
+
+public class IndexerTests
 {
-    public class IndexerTests
+    private readonly Mock<IIndexRepository> _repositoryMock;
+    private readonly Mock<IIndexingPipeline> _pipelineMock;
+    private readonly Indexer _sut;
+
+    public IndexerTests()
     {
-        private readonly Mock<IIndexRepository> _repositoryMock;
-        private readonly Mock<IIndexingPipeline> _pipelineMock;
+        _repositoryMock = new Mock<IIndexRepository>();
+        _pipelineMock = new Mock<IIndexingPipeline>();
 
-
-        private readonly Indexer _sut;
-
-        public IndexerTests()
-        {
-            _repositoryMock = new Mock<IIndexRepository>();
-            _pipelineMock = new Mock<IIndexingPipeline>();
-
-            _sut = new Indexer(
-                repository: _repositoryMock.Object,
-                pipeline: _pipelineMock.Object
-            );
-        }
-
-        private CrawlResult CreateDummyCrawlResult()
-        {
-            return new CrawlResult(
-                url: "https://test.com",
-                title: "Test",
-                language: "en",
-                indexedTerms: new List<IndexedTerm>
-                {
-                    new IndexedTerm("engine", TermSource.Title)
-                },
-                type: "text/html",
-                content: new byte[0],
-                extractedLinks: new List<string>(),
-                statusCode: HttpStatusCode.OK,
-                timeTakenMs: 10,
-                "FakeHash"
-            );
-        }
-
-        [Fact]
-        public async Task IndexAsync_ShouldThrow_WhenCrawlResultIsNull()
-        {
-            // Act & Assert
-            // Vi måste använda ThrowsAsync när metoden returnerar en Task
-            await Assert.ThrowsAsync<ArgumentNullException>(() => _sut.IndexAsync(null!));
-        }
-
-        [Fact]
-        public async Task IndexAsync_ShouldCallPipeline_WhenValidInput()
-        {
-            var crawlResult = CreateDummyCrawlResult();
-
-            // Lade till "Test" som titel i IndexDocument-konstruktorn
-            _pipelineMock
-                .Setup(p => p.Transform(crawlResult))
-                .Returns(new IndexDocument("1", "https://test.com", "Test"));
-
-            // Act
-            // Vi måste ha await framför asynkrona metodanrop i tester
-            await _sut.IndexAsync(crawlResult);
-
-            // Assert
-            _pipelineMock.Verify(p => p.Transform(crawlResult), Times.Once);
-        }
-
-        [Fact]
-        public async Task IndexAsync_ShouldSaveTransformedDocument()
-        {
-            var crawlResult = CreateDummyCrawlResult();
-
-            // Lade till "Test" som titel i IndexDocument-konstruktorn
-            var indexDocument = new IndexDocument("1", "https://test.com", "Test");
-
-            _pipelineMock
-                .Setup(p => p.Transform(crawlResult))
-            .Returns(indexDocument); 
-
-            // Act
-            await _sut.IndexAsync(crawlResult); 
-
-            // Assert
-            _repositoryMock.Verify(r => r.SaveAsync(indexDocument), Times.Once);
-        }
+        _sut = new Indexer(
+            repository: _repositoryMock.Object,
+            pipeline: _pipelineMock.Object
+        );
     }
-    
+
+    private CrawlResult CreateDummyCrawlResult()
+    {
+        return CrawlResultBuilder.BuildCrawlResult(
+            url: "https://test.com",
+            title: "Test",
+            language: "en",
+            indexedTerms: new List<IndexedTerm>
+            {
+                new IndexedTerm("engine", TermSource.Title)
+            },
+            type: "text/html",
+            content: "x",
+            extractedLinks: new List<string>(),
+            statusCode: HttpStatusCode.OK,
+            timeTakenMs: 10,
+            hashContent: "FakeHash"
+        );
+    }
+
+    [Fact]
+    public async Task IndexAsync_ShouldThrow_WhenCrawlResultIsNull()
+    {
+        // Act & Assert
+        // Vi måste använda ThrowsAsync när metoden returnerar en Task
+        await Assert.ThrowsAsync<ArgumentNullException>(() => _sut.IndexAsync(null!));
+    }
+
+    [Fact]
+    public async Task IndexAsync_ShouldCallPipeline_WhenValidInput()
+    {
+        var crawlResult = CreateDummyCrawlResult();
+
+        // Lade till "Test" som titel i IndexDocument-konstruktorn
+        _pipelineMock
+            .Setup(p => p.Transform(crawlResult))
+            .Returns(new IndexDocument("1", "https://test.com", "Test"));
+
+        // Act
+        // Vi måste ha await framför asynkrona metodanrop i tester
+        await _sut.IndexAsync(crawlResult);
+
+        // Assert
+        _pipelineMock.Verify(p => p.Transform(crawlResult), Times.Once);
+    }
+
+    [Fact]
+    public async Task IndexAsync_ShouldSaveTransformedDocument()
+    {
+        var crawlResult = CreateDummyCrawlResult();
+
+        // Lade till "Test" som titel i IndexDocument-konstruktorn
+        var indexDocument = new IndexDocument("1", "https://test.com", "Test");
+
+        _pipelineMock
+            .Setup(p => p.Transform(crawlResult))
+        .Returns(indexDocument); 
+
+        // Act
+        await _sut.IndexAsync(crawlResult); 
+
+        // Assert
+        _repositoryMock.Verify(r => r.SaveAsync(indexDocument), Times.Once);
+    }
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Indexing.Tests/IndexingPipelineTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Indexing.Tests/IndexingPipelineTests.cs
@@ -2,133 +2,133 @@
 using LTU.SearchEngine.Backend.Core.Model;
 using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
 using LTU.SearchEngine.Infrastructure.Indexing;
+using LTU.SearchEngine.Test.HelperClasses;
 using Moq;
-using System;
 using System.Net;
-using Xunit;
 
-namespace LTU.SearchEngine.Test.Indexing.Tests
+namespace LTU.SearchEngine.Test.Indexing.Tests;
+
+public class IndexingPipelineTests
 {
-    public class IndexingPipelineTests
+    private readonly Mock<ITextNormalizer<string>> _normalizerMock;
+    private readonly IndexingPipeline _pipeline;
+
+    public IndexingPipelineTests()
     {
-        private readonly Mock<ITextNormalizer<string>> _normalizerMock;
-        private readonly IndexingPipeline _pipeline;
+        _normalizerMock = new Mock<ITextNormalizer<string>>();
+        _pipeline = new IndexingPipeline(_normalizerMock.Object);
+    }
 
-        public IndexingPipelineTests()
-        {
-            _normalizerMock = new Mock<ITextNormalizer<string>>();
-            _pipeline = new IndexingPipeline(_normalizerMock.Object);
-        }
+    private CrawlResult CreateCrawlResult(IEnumerable<IndexedTerm> indexedTerms)
+    {
+        return CrawlResultBuilder.BuildCrawlResult(
+            url: "https://example.com",
+            title: "Example Title",
+            language: "en",
+            indexedTerms: indexedTerms,
+            type: "text/html",
+            content: "x",
+            extractedLinks: Array.Empty<string>(),
+            statusCode: HttpStatusCode.OK,
+            timeTakenMs: 0,
+            hashContent: "FakeHash"
+        );
+    }
 
-        private CrawlResult CreateCrawlResult(IEnumerable<IndexedTerm> indexedTerms)
-        {
-            return new CrawlResult(
-                url: "https://example.com",
-                title: "Example Title",
-                language: "en",
-                indexedTerms: indexedTerms,
-                type: "text/html",
-                content: new byte[0],
-                extractedLinks: Array.Empty<string>(),
-                statusCode: HttpStatusCode.OK,
-                timeTakenMs: 0
-            );
-        }
+    [Fact]
+    public void Transform_GivenNullCrawlResult_ShouldThrowArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            _pipeline.Transform(null!));
+    }
 
-        [Fact]
-        public void Transform_GivenNullCrawlResult_ShouldThrowArgumentNullException()
-        {
-            Assert.Throws<ArgumentNullException>(() =>
-                _pipeline.Transform(null!));
-        }
+    [Fact]
+    public void Transform_GivenSingleIndexedTerm_ShouldAddNormalizedTerm()
+    {
+        // Arrange
+        _normalizerMock
+            .Setup(n => n.Normalize("Running"))
+            .Returns("run");
 
-        [Fact]
-        public void Transform_GivenSingleIndexedTerm_ShouldAddNormalizedTerm()
-        {
-            // Arrange
-            _normalizerMock
-                .Setup(n => n.Normalize("Running"))
-                .Returns("run");
+        var crawlResult = CreateCrawlResult(
+            new[] { new IndexedTerm("Running", TermSource.Body) });
 
-            var crawlResult = CreateCrawlResult(
-                new[] { new IndexedTerm("Running", TermSource.Body) });
+        // Act
+        var document = _pipeline.Transform(crawlResult);
 
-            // Act
-            var document = _pipeline.Transform(crawlResult);
+        // Assert
+        Assert.Equal(1, document.ContentTerms["run"]);
+        _normalizerMock.Verify(n => n.Normalize("Running"), Times.Once());
+    }
 
-            // Assert
-            Assert.Equal(1, document.ContentTerms["run"]);
-            _normalizerMock.Verify(n => n.Normalize("Running"), Times.Once());
-        }
+    [Fact]
+    public void Transform_GivenSameTermInDifferentFields_ShouldKeepFieldSeparation()
+    {
+        _normalizerMock
+            .Setup(n => n.Normalize("Running"))
+            .Returns("run");
 
-        [Fact]
-        public void Transform_GivenSameTermInDifferentFields_ShouldKeepFieldSeparation()
-        {
-            _normalizerMock
-                .Setup(n => n.Normalize("Running"))
-                .Returns("run");
+        var crawlResult = CreateCrawlResult(
+            new[]
+            {
+                new IndexedTerm("Running", TermSource.Title),
+                new IndexedTerm("Running", TermSource.Body)
+            });
 
-            var crawlResult = CreateCrawlResult(
-                new[]
-                {
-                    new IndexedTerm("Running", TermSource.Title),
-                    new IndexedTerm("Running", TermSource.Body)
-                });
+        var document = _pipeline.Transform(crawlResult);
 
-            var document = _pipeline.Transform(crawlResult);
+        Assert.Equal(1, document.TitleTerms["run"]);
+        Assert.Equal(1, document.ContentTerms["run"]);
 
-            Assert.Equal(1, document.TitleTerms["run"]);
-            Assert.Equal(1, document.ContentTerms["run"]);
+        _normalizerMock.Verify(n => n.Normalize("Running"), Times.Exactly(2));
+    }
 
-            _normalizerMock.Verify(n => n.Normalize("Running"), Times.Exactly(2));
-        }
+    [Fact]
+    public void Transform_GivenNullNormalizedTerm_ShouldSkipTerm()
+    {
+        _normalizerMock
+            .Setup(n => n.Normalize("Running"))
+            .Returns("run");
 
-        [Fact]
-        public void Transform_GivenNullNormalizedTerm_ShouldSkipTerm()
-        {
-            _normalizerMock
-                .Setup(n => n.Normalize("Running"))
-                .Returns("run");
+        _normalizerMock
+            .Setup(n => n.Normalize("THE"))
+            .Returns((string?)null);
 
-            _normalizerMock
-                .Setup(n => n.Normalize("THE"))
-                .Returns((string?)null);
+        var crawlResult = CreateCrawlResult(
+            new[]
+            {
+                new IndexedTerm("Running", TermSource.Body),
+                new IndexedTerm("THE", TermSource.Body)
+            });
 
-            var crawlResult = CreateCrawlResult(
-                new[]
-                {
-                    new IndexedTerm("Running", TermSource.Body),
-                    new IndexedTerm("THE", TermSource.Body)
-                });
+        var document = _pipeline.Transform(crawlResult);
 
-            var document = _pipeline.Transform(crawlResult);
+        Assert.Equal(1, document.ContentTerms["run"]);
+        Assert.Single(document.ContentTerms);
 
-            Assert.Equal(1, document.ContentTerms["run"]);
-            Assert.Single(document.ContentTerms);
+        _normalizerMock.Verify(n => n.Normalize(It.IsAny<string>()), Times.Exactly(2));
+    }
 
-            _normalizerMock.Verify(n => n.Normalize(It.IsAny<string>()), Times.Exactly(2));
-        }
+    [Fact]
+    public void Transform_GivenNoIndexedTerms_ShouldReturnEmptyDocument()
+    {
+        var crawlResult = CreateCrawlResult(Array.Empty<IndexedTerm>());
 
-        [Fact]
-        public void Transform_GivenNoIndexedTerms_ShouldReturnEmptyDocument()
-        {
-            var crawlResult = CreateCrawlResult(Array.Empty<IndexedTerm>());
+        var document = _pipeline.Transform(crawlResult);
 
-            var document = _pipeline.Transform(crawlResult);
+        Assert.Equal("https://example.com", document.Url);
 
-            Assert.Equal("https://example.com", document.Url);
+        // DocId is generated Guid
+        Assert.NotNull(document.DocId);
+        Assert.True(Guid.TryParse(document.DocId, out _));
 
-            // DocId is generated Guid
-            Assert.NotNull(document.DocId);
-            Assert.True(Guid.TryParse(document.DocId, out _));
+        Assert.Equal("Example Title", document.Title);
 
-            Assert.Equal("Example Title", document.Title);
+        Assert.Empty(document.TitleTerms);
+        Assert.Empty(document.HeaderTerms);
+        Assert.Empty(document.ContentTerms);
 
-            Assert.Empty(document.TitleTerms);
-            Assert.Empty(document.HeaderTerms);
-            Assert.Empty(document.ContentTerms);
-
-            _normalizerMock.Verify(n => n.Normalize(It.IsAny<string>()), Times.Never());
-        }
+        _normalizerMock.Verify(n => n.Normalize(It.IsAny<string>()), Times.Never());
     }
 }
+


### PR DESCRIPTION
The requested changes were implemented. 
This included amongst other things the creation of the I&ContentHasher, its inclusion in the Crawler class, DI pipeline and and its associated tests. 

I also made a refactor on how CrawlResults were created as it was starting to get out of control with test updates.  

A final point. I did not implement the changes in the Indexing pipeline, as a noticed that that process is unfinished and needs to be reworked in its seperat issue (which I have now created). 