### PR TITLE
74 the haphtmlparser must be able to extract what encoding and language is used

### DIFF
--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Crawling/Crawler.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Crawling/Crawler.cs
@@ -1,6 +1,9 @@
-﻿using LTU.SearchEngine.Backend.Core.HelperClasses;
-using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
+﻿
 using System.Diagnostics;
+using System.Text;
+using LTU.SearchEngine.Backend.Core.HelperClasses;
+using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
+using Microsoft.Extensions.Logging;
 
 namespace LTU.SearchEngine.Infrastructure.Crawling;
 
@@ -9,12 +12,44 @@ public class Crawler : ICrawler
     private readonly HttpClient _httpClient;
     private readonly IHtmlParser _htmlParser;
     private readonly IContentHasher _contentHasher;
+    private readonly ILogger<Crawler> _logger;
 
-    public Crawler(HttpClient httpClient, IHtmlParser htmlParser, IContentHasher contentHasher)
+    public Crawler(HttpClient httpClient, IHtmlParser htmlParser, IContentHasher contentHasher, ILogger<Crawler> logger)
     {
         _httpClient = httpClient;
         _htmlParser = htmlParser;
         _contentHasher = contentHasher;
+        _logger = logger;
+    }
+
+
+    private bool IsHtmlFormat(string format) => format.Contains("text/html");
+
+    private Encoding SetEncoding(string? charSet)
+    {
+        var encoding = Encoding.UTF8; 
+
+        if (!string.IsNullOrWhiteSpace(charSet))
+        {
+            try
+            {
+                encoding = Encoding.GetEncoding(charSet);
+            }
+            catch (ArgumentException)
+            {
+                _logger.LogWarning("Failed to get encoding for charset: {CharSet}, defaulting to UTF-8.", charSet);
+            }
+        }
+        return encoding;
+    }
+
+    private string GetHtmlString(byte[] content, HttpResponseMessage response)
+    {
+        // If charset was missing or unrecognized, default to UTF-8
+        string? charSet = response.Content.Headers.ContentType?.CharSet; 
+        var encoding = SetEncoding(charSet);
+    
+        return encoding.GetString(content);
     }
 
     /// <inheritdoc/>
@@ -25,39 +60,42 @@ public class Crawler : ICrawler
 
         try
         {
-            var response = await _httpClient.GetAsync(url);
+            using var response = await _httpClient.GetAsync(url);
             stopwatch.Stop();
 
             // Handle 404/500 errors per Acceptance Criteria: 
             // Return status code without body content.
             if (!response.IsSuccessStatusCode)
-            {
                 return CreateErrorResult(url, response.StatusCode, stopwatch.ElapsedMilliseconds, "None", crawledAt);
-            }
+            
 
             //if call successful get the data
             byte[] content = await response.Content.ReadAsByteArrayAsync();
-            string contentType = response.Content.Headers.ContentType?.MediaType ?? "text/plain";
+            var contentType = response.Content.Headers.ContentType;
+
+            string? format = contentType?.MediaType ?? "text/plain";
 
             var terms = Enumerable.Empty<IndexedTerm>();
             var links = Enumerable.Empty<string>();
             string title = null!;
+            string languageCode = "Unknown";
 
-            if (contentType.Contains("text/html"))
+            if (IsHtmlFormat(format))
             {
-                var htmlString = System.Text.Encoding.UTF8.GetString(content);
+                var htmlString = GetHtmlString(content, response);
 
-                terms = _htmlParser.ExtractTerms(htmlString);
-                links = await _htmlParser.ExtractInternalLinks(htmlString, url);
+                languageCode = _htmlParser.ExtractLanguage(htmlString);
                 title = _htmlParser.ExtractTitle(htmlString);
+                links = await _htmlParser.ExtractInternalLinks(htmlString, url);
+                terms = _htmlParser.ExtractTerms(htmlString);
             }
 
             return new CrawlResult(
                 url: url,
                 title: title,
-                language: "Unknown",
+                language: languageCode,
                 indexedTerms: terms,
-                type: contentType,
+                type: format,
                 content: content,
                 extractedLinks: links,
                 statusCode: response.StatusCode,
@@ -77,8 +115,8 @@ public class Crawler : ICrawler
                 crawledAt
             );
         }
-        catch (Exception) 
-        {
+        catch (Exception e) 
+        {   Debug.WriteLine(e);
             stopwatch.Stop();
             return null!; 
         }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Crawling/IHtmlParser.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Crawling/IHtmlParser.cs
@@ -29,15 +29,15 @@ public interface IHtmlParser
 	/// <returns>A plain-text representation of the visible content.</returns>
 	string ExtractRawText(string html);
 
-	/// <summary>
-	/// Extracts the document title from the given HTML content.
-	/// </summary>
+	/// <summary>Extracts the document title from the given HTML content.</summary>
 	/// <param name="html">The raw HTML content to parse.</param>
-	/// <returns>
-	/// The value of the HTML <c>&lt;title&gt;</c> element, or an empty <br />
-	/// string if no title is present.
-	/// </returns>
+	/// <returns>The value of the HTML <c>&lt;title&gt;</c> element, or an empty string if no title is present.</returns>
 	string ExtractTitle(string html);
+
+	/// <summary>Extracts the language code used in the given HTML content.</summary>
+	/// <param name="html">The raw HTML content to parse.</param>
+	/// <returns>The value of the HTML <c>&lt;html&gt;</c> element's <c>lang</c> attribute, or an "Unknown" if not specified.</returns>
+	string ExtractLanguage(string html);
 
     /// <summary>
     /// Extracts indexable terms from raw HTML by stripping non-content elements (scripts, styles) 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/HapHtmlParser.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/HapHtmlParser.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Diagnostics;
+using System.Text.RegularExpressions;
 using HtmlAgilityPack;
 using LTU.SearchEngine.Backend.Core;
 using LTU.SearchEngine.Backend.Core.Exceptions;
@@ -33,6 +34,7 @@ public class HapHtmlParser : IHtmlParser
     {
         var doc = new HtmlDocument();
         doc.LoadHtml(html);
+
         var internalLinks = new List<string>();
 
         // Try to create a Uri object from the baseUrl.
@@ -109,7 +111,8 @@ public class HapHtmlParser : IHtmlParser
     /// <inheritdoc/>
     public string ExtractTitle(string html)
     {
-        if(string.IsNullOrWhiteSpace(html)) return string.Empty;
+        Debug.WriteLine("inside ExtractTitle");
+        if (string.IsNullOrWhiteSpace(html)) return string.Empty;
 
         //Load HTML in HtmlAgilityPack
         var doc = new HtmlDocument();
@@ -119,7 +122,7 @@ public class HapHtmlParser : IHtmlParser
         var titleNode = doc.DocumentNode.SelectSingleNode("//title");
 
         //handle if tag is missing
-        if(titleNode == null)return string.Empty;
+        if (titleNode == null) return string.Empty;
 
         //Get text, decode HTML entities and trim whitespace
         string titleText = titleNode.InnerText;
@@ -128,9 +131,26 @@ public class HapHtmlParser : IHtmlParser
     }
 
 
+    public string ExtractLanguage(string html)
+    {
+        Debug.WriteLine("inside ExtractLanguage");
+        string languageCode = "Unknown";
+
+        var doc = new HtmlDocument();
+        doc.LoadHtml(html);
+
+        var htmlNode = doc.DocumentNode.SelectSingleNode("//html");
+        
+        if (htmlNode is not null)
+            languageCode = htmlNode.GetAttributeValue("lang", "Unknown"); 
+        
+        return languageCode;
+    }
+
     /// <inheritdoc/>
     public IEnumerable<IndexedTerm> ExtractTerms(string html)
     {
+        Debug.WriteLine("inside externaTerms");
         var terms = new List<IndexedTerm>();
         var doc = new HtmlDocument();
         doc.LoadHtml(html);
@@ -288,8 +308,15 @@ public class HapHtmlParser : IHtmlParser
     // Add space to prevent word concatenation after removal
     private void ReplaceChildWithSpaceNode(HtmlDocument doc, HtmlNode childNode)
     {
-        var spaceNode = doc.CreateTextNode(" "); 
-        childNode.ParentNode.ReplaceChild(spaceNode, childNode); 
+        if (childNode?.ParentNode is not null)
+        {
+            var spaceNode = doc.CreateTextNode(" "); 
+            childNode.ParentNode.ReplaceChild(spaceNode, childNode); 
+        }
+        else
+        {
+            childNode?.Remove();
+        }
     }
 
 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Crawling.Tests/CrawlerTest.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Crawling.Tests/CrawlerTest.cs
@@ -1,7 +1,9 @@
-﻿using LTU.SearchEngine.Backend.Core.HelperClasses;
+﻿using Castle.Core.Logging;
+using LTU.SearchEngine.Backend.Core.HelperClasses;
 using LTU.SearchEngine.Backend.Core.Model;
 using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
 using LTU.SearchEngine.Infrastructure.Crawling;
+using Microsoft.Extensions.Logging;
 using Moq;
 using Moq.Protected;
 using System.Net;
@@ -28,7 +30,12 @@ public class CrawlerTest
         // We create a HttpClient that uses our mocked handler
         _httpClient = new HttpClient(_handlerMock.Object);
 
-        _sut = new Crawler(_httpClient, _parserMock.Object, _contentHasherMock.Object);
+        _sut = new Crawler(
+            httpClient: _httpClient, 
+            htmlParser: _parserMock.Object, 
+            contentHasher: _contentHasherMock.Object,
+            logger: new Mock<ILogger<Crawler>>().Object
+            );
         _output = output;
     }
 
@@ -38,8 +45,8 @@ public class CrawlerTest
     {
         // ARRANGE
         var url = "https://ltu.se";
-        var fakeHtml = @"
-            <html>
+        var fakeHtml = """
+            <html lang="en">
                 <head>
                   <title>Test Page Title</title>
                 </head>
@@ -48,7 +55,8 @@ public class CrawlerTest
                     <p>This is a test page with search terms.</p>
                     <a href='/contact'>Contact Us</a>
                 </body>
-            </html>";
+            </html>
+            """;
 
         var expectedContent = System.Text.Encoding.UTF8.GetBytes(fakeHtml);
 
@@ -66,7 +74,10 @@ public class CrawlerTest
 
         _parserMock.Setup(p => p.ExtractTitle(It.IsAny<string>()))
             .Returns(expectedTitle);
-
+    
+        _parserMock.Setup(p => p.ExtractLanguage(It.IsAny<string>()))
+            .Returns("en");
+        
         SetupHttpResponse(HttpStatusCode.OK, fakeHtml);
 
         // ACT
@@ -77,7 +88,7 @@ public class CrawlerTest
         Assert.NotNull(result);
         Assert.Equal(url, result.Url);
         Assert.Equal(HttpStatusCode.OK, result.StatusCode);
-        Assert.Equal("Unknown", result.Language);
+        Assert.Equal("en", result.Language);
         Assert.NotEmpty(result.IndexedTerms);
         Assert.Equal(expectedContent, result.Content);
         Assert.True(result.TimeTakenMs >= 0);

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/HelperClasses/WebHostBuilder.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/HelperClasses/WebHostBuilder.cs
@@ -167,6 +167,7 @@ public class WebHostBuilder
 
 					});
 
+					
 					endpoint.MapGet("/InvertedIndexTestFile1.html", () =>
 					{
 						var html = """
@@ -180,6 +181,7 @@ public class WebHostBuilder
 						return Results.Content(html, "text/html");
 					});
 					
+					
 					endpoint.MapGet("/InvertedIndexTestFile2.html", () =>
 					{
 						var html = """
@@ -189,6 +191,40 @@ public class WebHostBuilder
 
 						return Results.Content(html, "text/html");
 					});
+					
+					
+					endpoint.MapGet("/IndexerNormalizingTextRun.html", () =>
+					{
+						var html = """
+							<body>
+								<h1>Running run Run runs Runs</h1>
+							</body>
+						""";
+
+						return Results.Content(html, "text/html");
+					});
+					
+					
+					endpoint.MapGet("/IndexerNormalizingTextSwim.html", () =>
+					{
+						var html = """
+							<body>
+								<h1>Swimming swims SwiMs SwIM swim</h1>
+							</body>
+						""";
+						return Results.Content(html, "text/html");
+					});
+					
+					endpoint.MapGet("/IndexerNormalizingTextCat.html", () =>
+					{
+						var html = """
+							<body>
+								<h1>Cat Cats cat's cat cats</h1>
+							</body>
+						""";
+						return Results.Content(html, "text/html");
+					});
+
 				});
 			});
 		})

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/HelperClasses/WebHostBuilder.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/HelperClasses/WebHostBuilder.cs
@@ -218,9 +218,11 @@ public class WebHostBuilder
 					endpoint.MapGet("/IndexerNormalizingTextCat.html", () =>
 					{
 						var html = """
+						<html lang="en">
 							<body>
 								<h1>Cat Cats cat's cat cats</h1>
 							</body>
+						</html>
 						""";
 						return Results.Content(html, "text/html");
 					});

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/IntegrationTesting/IndexerIntegrationTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/IntegrationTesting/IndexerIntegrationTests.cs
@@ -122,9 +122,74 @@ public class IndexerIntegrationTests : IClassFixture<WebApplicationFactory<Progr
         //                          |   Term2    
         //  Term3                   |   
         //  InvertedIndexTestFile2  |
-        
+
         // Arrange
         string seedUrl = "http://localhost/InvertedIndexTestFile1.html";
+        var httpClient = _webHostBuilder.CreateFakeInternetClient();
+
+        using var testFactory = CreateTestFactory<Indexer>(httpClient: httpClient, seedUrl: seedUrl);
+        using var scope = testFactory.Services.CreateScope();
+
+        var dispatcher = scope.ServiceProvider.GetRequiredService<ICrawlJobDispatcher>();
+        await dispatcher.Enqueue(new CrawlJob { Url = seedUrl, NextAttempt = DateTime.UtcNow });
+
+        var cts = new CancellationTokenSource();
+
+        var dbFactory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<SearchDbContext>>();
+        using var dbContext = dbFactory.CreateDbContext();
+        dbContext.Database.EnsureCreated();
+
+        // Act 
+        Task dispatchTask = dispatcher.Start(cts.Token);
+
+        await ASecondsWait();
+
+        cts.Cancel();
+
+
+
+        // Assert 
+        // Each unique term is stored exactly once in the index.
+        var TotalTermCount = await dbContext.Terms.CountAsync();
+        var Term1Count = await dbContext.Terms.Where(t => t.Word.Equals("term1")).CountAsync();
+        var Term2Count = await dbContext.Terms.Where(t => t.Word.Equals("term2")).CountAsync();
+        var Term3Count = await dbContext.Terms.Where(t => t.Word.Equals("term3")).CountAsync();
+
+        Assert.True(TotalTermCount.Equals(4));
+        Assert.True(Term1Count.Equals(1));
+        Assert.True(Term2Count.Equals(1));
+        Assert.True(Term3Count.Equals(1));
+
+        // Each term maps to one or more page references (URLs or document IDs).
+        // Pages containing the same term are associated with that term.
+        int term1Id = await dbContext.Terms
+            .Where(t => t.Word.Equals("term1"))
+            .Select(t => t.Id)
+            .FirstAsync(); ;
+
+        var term1PageWordLink = await dbContext.PageWordFrequencies
+            .Include(pwf => pwf.Page)
+            .Include(pwf => pwf.Term)
+            .Where(pwf => pwf.Term.Id.Equals(term1Id))
+            .ToListAsync();
+
+        var term1PageAssociation = term1PageWordLink
+            .Where(pwl => pwl.TermId.Equals(term1Id))
+            .Select(pwl => pwl.Page.Url);
+
+        Assert.Contains("http://localhost/InvertedIndexTestFile1.html", term1PageAssociation);
+        Assert.Contains("http://localhost/InvertedIndexTestFile2.html", term1PageAssociation);
+    }
+
+    [Theory]
+    [InlineData("/IndexerNormalizingTextRun.html", "run", 5)]
+    [InlineData("/IndexerNormalizingTextSwim.html", "swim", 5)]
+    [InlineData("/IndexerNormalizingTextCat.html", "cat", 5)]
+    [Trait("TestCase", "TC-FRQ-2007")]
+    public async Task Indexer_TextIsNormalizedOnIndex(string url, string expectedTerm, int expectedFrequency)
+    {
+        // Arrange
+        string seedUrl = $"http://localhost{url}";
         var httpClient = _webHostBuilder.CreateFakeInternetClient();
         
         using var testFactory = CreateTestFactory<Indexer>(httpClient: httpClient, seedUrl: seedUrl);
@@ -142,52 +207,33 @@ public class IndexerIntegrationTests : IClassFixture<WebApplicationFactory<Progr
         // Act 
         Task dispatchTask = dispatcher.Start(cts.Token);
         
-        int timeoutMs = 5000;
-        int elapsedTime = 0;
+        await ASecondsWait();
+
+        cts.Cancel();
         
+        // Assert 
+        // Each unique term is stored exactly once in the index.
+        var termPageWordLink = await dbContext.PageWordFrequencies
+            .Include(pwf => pwf.Page)
+            .Include(pwf => pwf.Term)
+            .ToListAsync(); 
+
+        Assert.Equal(expectedTerm, termPageWordLink.First().Term.Word);
+        Assert.Equal(expectedFrequency, termPageWordLink.First().HeaderFrequency);
+    }
+
+    private static async Task ASecondsWait()
+    {
+        int timeoutMs = 1000;
+        int elapsedTime = 0;
+
         while (elapsedTime < timeoutMs)
         {
             elapsedTime += 100;
             await Task.Delay(100);
         }
+    }
 
-        cts.Cancel();
-
-
-        
-        // Assert 
-        // Each unique term is stored exactly once in the index.
-        var TotalTermCount = await dbContext.Terms.CountAsync();
-        var Term1Count = await dbContext.Terms.Where(t => t.Word.Equals("term1")).CountAsync();
-        var Term2Count = await dbContext.Terms.Where(t => t.Word.Equals("term2")).CountAsync();
-        var Term3Count = await dbContext.Terms.Where(t => t.Word.Equals("term3")).CountAsync();
-
-        Assert.True(TotalTermCount.Equals(4));
-        Assert.True(Term1Count.Equals(1));
-        Assert.True(Term2Count.Equals(1));
-        Assert.True(Term3Count.Equals(1));
-        
-        // Each term maps to one or more page references (URLs or document IDs).
-        // Pages containing the same term are associated with that term.
-        int term1Id = await dbContext.Terms
-            .Where(t => t.Word.Equals("term1"))
-            .Select(t => t.Id)
-            .FirstAsync();;
-     
-        var term1PageWordLink = await dbContext.PageWordFrequencies
-            .Include(pwf => pwf.Page)
-            .Include(pwf => pwf.Term)
-            .Where(pwf => pwf.Term.Id.Equals(term1Id))
-            .ToListAsync(); 
-
-        var term1PageAssociation = term1PageWordLink
-            .Where(pwl => pwl.TermId.Equals(term1Id))
-            .Select(pwl => pwl.Page.Url);
-
-        Assert.Contains("http://localhost/InvertedIndexTestFile1.html", term1PageAssociation);
-        Assert.Contains("http://localhost/InvertedIndexTestFile2.html", term1PageAssociation);
-}
-    
 
     public void Dispose()
     {


### PR DESCRIPTION
Small refactor of the crawler and the HapHtmlParser can now extract the html language code used. 