### PR TITLE
52 add functionality to re add a crawljob to queue after a crawl was successfully conducted

### DIFF
--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.BackgroundServices/TplCrawlJobDispatcher.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.BackgroundServices/TplCrawlJobDispatcher.cs
@@ -102,6 +102,7 @@ public class TplCrawlJobDispatcher : ICrawlJobDispatcher
 		{
 			CrawlResult result = await _processCrawlJobUseCase.Execute(job);
 			await EnqueueNewJobs(result);
+			await ReAddJobToQueueScheduledUpdateCrawl(job, result.CrawledAt);
 		}
 		catch (ArgumentException ex)
 		{
@@ -127,10 +128,8 @@ public class TplCrawlJobDispatcher : ICrawlJobDispatcher
 			return;
 		}
 
-		//int index = (job.RetryCount - 1) >= 0 ? job.RetryCount - 1 : 0;
-
 		job.NextAttempt = 
-			DateTime.UtcNow + _crawlerSettingsLoader.Load().GetRetryDelayInterval(job.RetryCount);//   RetryIntervals[index];
+			DateTime.UtcNow + _crawlerSettingsLoader.Load().GetRetryDelayInterval(job.RetryCount);
 
 		job.RetryCount++;
 		
@@ -149,6 +148,15 @@ public class TplCrawlJobDispatcher : ICrawlJobDispatcher
 
 			await Enqueue(newJob);
 		}
+	}
+
+	private async Task ReAddJobToQueueScheduledUpdateCrawl(CrawlJob job, DateTime crawledAt)
+	{
+		if (job.RetryCount > 1) job.RetryCount = 1;
+
+		job.NextAttempt = crawledAt + _crawlerSettingsLoader.Load().CrawlUpdateInterval;
+
+		await Enqueue(job);
 	}
 
 	/// <inheritdoc />

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/BackgroundServices.Tests/TplCrawlJobDispatcherTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/BackgroundServices.Tests/TplCrawlJobDispatcherTests.cs
@@ -35,7 +35,7 @@ public class TplCrawlJobDispatcherTests
 				TimeSpan.FromMilliseconds(150),
 				TimeSpan.FromMilliseconds(200)
 			},
-			crawlUpdateInterval: TimeSpan.FromMilliseconds(200),
+			crawlUpdateInterval: TimeSpan.FromMilliseconds(500),
             seedUrls: new List<string> { "ltu.se" },
 			whiteList: new List<string> { "ltu.se" },
 			robotsExceptionRules: new Dictionary<string, List<string>>{
@@ -244,11 +244,13 @@ public class TplCrawlJobDispatcherTests
 	[Fact]
 	public async Task HandleFailedJob_MaxRetryNotReached_IsRetriedWithCorrectTimeDelayAdded()
 	{
+		// Arrange
 		DateTime nextAttemptExpected = 
-			DateTime.UtcNow + _mockCrawlerSettingsLoader.Object.Load().GetRetryDelayInterval(1);// .RetryIntervals[0];
+			DateTime.UtcNow + _mockCrawlerSettingsLoader.Object.Load().GetRetryDelayInterval(1);
 		
 		DateTime nextAttemptToLong 
-			= DateTime.UtcNow +  _mockCrawlerSettingsLoader.Object.Load().GetRetryDelayInterval(2); //.RetryIntervals[1];
+			= DateTime.UtcNow +  _mockCrawlerSettingsLoader.Object.Load().GetRetryDelayInterval(2); 
+
 
 		var job = new CrawlJob
 		{
@@ -264,15 +266,21 @@ public class TplCrawlJobDispatcherTests
 		);
 
 		using var cts = new CancellationTokenSource();
+		
 		var startTask = _sut.Start(cts.Token);
 
 		// Act
 		await _sut.Enqueue(job);
-
-		await Task.Delay(500);
-
+		
+		int maxWait = 500;
+		int totWait = 0;
+		while ((job.RetryCount < 2) && totWait < maxWait)
+		{
+			await Task.Delay(100);
+			totWait += 100;
+		}
+		
 		// Assert
-		_mockUseCase.Verify(u => u.Execute(It.IsAny<CrawlJob>()), Times.AtLeast(2));
 		Assert.Equal(2, job.RetryCount);
 		Assert.True(
 			job.NextAttempt >= nextAttemptExpected && 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/BackgroundServices.Tests/TplCrawlJobDispatcherTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/BackgroundServices.Tests/TplCrawlJobDispatcherTests.cs
@@ -5,7 +5,6 @@ using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
 using LTU.SearchEngine.BackgroundServices;
 using LTU.SearchEngine.Infrastructure.Configuration;
 using LTU.SearchEngine.Test.HelperClasses;
-using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.Extensions.Logging;
 using Moq;
 using System.Net;
@@ -274,7 +273,7 @@ public class TplCrawlJobDispatcherTests
 
 		cts.Cancel();
 
-		// Assert
+		// Assert - CrawlUpdateInterval = 500
 		TimeSpan elapsedTime = dateTimes[1] - dateTimes[0];
 		Assert.InRange(elapsedTime, TimeSpan.FromMilliseconds(500), TimeSpan.FromMilliseconds(560));
 		_mockUseCase.Verify(uc => uc.Execute(It.IsAny<CrawlJob>()), Times.Exactly(2));
@@ -453,7 +452,10 @@ public class TplCrawlJobDispatcherTests
 
 		await Task.Delay(2000);
 
-		Assert.Equal( _mockCrawlerSettingsLoader.Object.Load().MaxConcurrencyPerDomain, maxObserved);
+		Assert.Equal( 
+			_mockCrawlerSettingsLoader.Object.Load().MaxConcurrencyPerDomain, 
+			maxObserved
+		);
 
 		cts.Cancel();
 		await taskStart;

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/BackgroundServices.Tests/TplCrawlJobDispatcherTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/BackgroundServices.Tests/TplCrawlJobDispatcherTests.cs
@@ -17,6 +17,7 @@ public class TplCrawlJobDispatcherTests
 	private readonly SemaphoreProvider _semaphoreProvider;
 	private Mock<IProcessCrawlJobUseCase> _mockUseCase;
 	private readonly ICrawlJobDispatcher _sut;
+	private readonly Mock<ILogger<TplCrawlJobDispatcher>> _mockLogger;
 
     private CrawlResult CreateResult()
 	{
@@ -52,13 +53,13 @@ public class TplCrawlJobDispatcherTests
 		
 		_mockCrawlerSettingsLoader = new Mock<ICrawlerSettingsLoader>();
 		_mockCrawlerSettingsLoader.Setup(csl => csl.Load()).Returns(CreateSettings());
-		
+		_mockLogger = new Mock<ILogger<TplCrawlJobDispatcher>>();
 
         _sut = new TplCrawlJobDispatcher(
 		  _mockUseCase.Object,
 		  _semaphoreProvider,
 		  _mockCrawlerSettingsLoader!.Object,
-		  new Mock<ILogger<TplCrawlJobDispatcher>>().Object
+		  _mockLogger.Object
 		);
     }
 
@@ -317,6 +318,16 @@ public class TplCrawlJobDispatcherTests
 
 		// Assert - Retry counter is only incremented before enqueue.
 		Assert.Equal(3, job.RetryCount);
+		_mockLogger.Verify(
+			x => x.Log(
+				LogLevel.Warning,
+				It.IsAny<EventId>(),
+				It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Discarding job")),
+				It.IsAny<Exception>(),
+				It.IsAny<Func<It.IsAnyType, Exception, string>>()!
+			),
+			Times.Once
+		);
 
 		cts.Cancel();
 		await startTask;

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/BackgroundServices.Tests/TplCrawlJobDispatcherTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/BackgroundServices.Tests/TplCrawlJobDispatcherTests.cs
@@ -5,6 +5,7 @@ using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
 using LTU.SearchEngine.BackgroundServices;
 using LTU.SearchEngine.Infrastructure.Configuration;
 using LTU.SearchEngine.Test.HelperClasses;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.Extensions.Logging;
 using Moq;
 using System.Net;
@@ -212,7 +213,8 @@ public class TplCrawlJobDispatcherTests
 				gate.Release();
 				
 				return CreateResult();
-			});
+			}
+		);
 
 		using var cts = new CancellationTokenSource();
 		var startTask = _sut.Start(cts.Token);
@@ -233,6 +235,51 @@ public class TplCrawlJobDispatcherTests
 		cts.Cancel();
 		await startTask;
 	}
+
+	[Fact]
+	public async Task HandleUseCaseAsync_SuccessfulCrawl_JobReAddedToQueueWithCorrectNextAttempt()
+	{
+		// Arrange 
+		var job = new CrawlJob
+		{
+			Id = 1,
+			Url = "https://example.com",
+			NextAttempt = DateTime.UtcNow
+		};
+
+		List<DateTime>  dateTimes = new List<DateTime>();
+
+		_mockUseCase.Setup(uc => uc.Execute(It.IsAny<CrawlJob>())).Returns( async () =>
+			{
+				var result = CreateResult();
+				dateTimes.Add(DateTime.UtcNow);
+				return result;
+			}
+		);
+		
+		// Act
+		var cts = new CancellationTokenSource();
+		
+		await _sut.Enqueue(job);
+		Task task = _sut.Start(cts.Token);
+
+		int totalWait = 0;
+		int maxWait = 5000;
+		
+		while (totalWait < maxWait && dateTimes.Count < 2)
+		{
+			totalWait += 100;
+			await Task.Delay(100);
+		}
+
+		cts.Cancel();
+
+		// Assert
+		TimeSpan elapsedTime = dateTimes[1] - dateTimes[0];
+		Assert.InRange(elapsedTime, TimeSpan.FromMilliseconds(500), TimeSpan.FromMilliseconds(560));
+		_mockUseCase.Verify(uc => uc.Execute(It.IsAny<CrawlJob>()), Times.Exactly(2));
+	}
+
 
 	[Fact]
 	public async Task Enqueue_Job_Null_ShouldThrow_ArgumentNullException()
@@ -291,6 +338,7 @@ public class TplCrawlJobDispatcherTests
 		cts.Cancel();
 		await startTask;
 	}
+
 
 	[Fact]
 	public async Task HandleFailedJob_MaxRetryReached_JobIsDropped()

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Core.Tests/TextNormalization/LuceneAnalyzerStrategyTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Core.Tests/TextNormalization/LuceneAnalyzerStrategyTests.cs
@@ -1,10 +1,5 @@
 using LTU.SearchEngine.Backend.Core.TextNormalization;
-using Lucene.Net.Analysis;
 using Lucene.Net.Analysis.Core;
-using Lucene.Net.Analysis.En;
-using Lucene.Net.Analysis.Snowball;
-using Lucene.Net.Analysis.Standard;
-using Lucene.Net.Util;
 using Microsoft.Extensions.Logging;
 using Moq;
 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Crawling.Tests/CrawlerTest.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Crawling.Tests/CrawlerTest.cs
@@ -1,5 +1,4 @@
-﻿using Castle.Core.Logging;
-using LTU.SearchEngine.Backend.Core.HelperClasses;
+﻿using LTU.SearchEngine.Backend.Core.HelperClasses;
 using LTU.SearchEngine.Backend.Core.Model;
 using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
 using LTU.SearchEngine.Infrastructure.Crawling;

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Crawling.Tests/ProcessCrawlJobUseCaseTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Crawling.Tests/ProcessCrawlJobUseCaseTests.cs
@@ -1,15 +1,11 @@
 ﻿using LTU.SearchEngine.Application;
-using LTU.SearchEngine.Backend.Core;
-using LTU.SearchEngine.Backend.Core.Exceptions;
 using LTU.SearchEngine.Backend.Core.Model;
 using LTU.SearchEngine.Backend.Core.Model.Entities;
 using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
-using LTU.SearchEngine.Infrastructure.Configurations;
 using LTU.SearchEngine.Infrastructure.Crawling;
 using LTU.SearchEngine.Test.HelperClasses;
 using Moq;
 using System.Net;
-using System.Text;
 
 namespace LTU.SearchEngine.Test.Crawling.Tests;
 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/IntegrationTesting/IndexerIntegrationTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/IntegrationTesting/IndexerIntegrationTests.cs
@@ -1,13 +1,9 @@
-using Castle.Components.DictionaryAdapter.Xml;
 using LTU.SearchEngine.Backend.Api;
 using LTU.SearchEngine.Backend.Core.Model.Entities;
-using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
 using LTU.SearchEngine.BackgroundServices;
-using LTU.SearchEngine.Infrastructure;
 using LTU.SearchEngine.Infrastructure.Configurations;
 using LTU.SearchEngine.Infrastructure.Data;
 using LTU.SearchEngine.Infrastructure.Indexing;
-using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;


### PR DESCRIPTION
Successful crawl jobs now gets readded to the queue with an updated next attempt time, and tests were updated and added to accommodate the changes.

The requested "drop of job, on 3 fails", was already implemented, but i did expand the tests to also include a log check.