### PR TITLE
67 implement test case tc frq 2006

### DIFF
--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/ProcessCrawlJobUseCase.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/ProcessCrawlJobUseCase.cs
@@ -66,35 +66,8 @@ public class ProcessCrawlJobUseCase : IProcessCrawlJobUseCase
 
             return response;
         }
-        // catch (HttpRequestException ex) // LET THIS BUUBLE 
-        // {
-        //     stopwatch.Stop();
-		// 	/// ToDo: LOGG THIS $"HTTP request failed: {ex.Message}"
-        
-        //     return await CreateFailedRequestResponse(job, fetchStartTime, stopwatch, ex);
-        // }
         finally { stopwatch.Stop(); } 
 	}
-
-
-    private async Task<ProcessJobResponse> CreateFailedRequestResponse(
-		CrawlJob job, 
-		DateTime fetchStartTime,
-		Stopwatch stopwatch,
-		HttpRequestException ex
-	)
-    {
-        var statusCode = ex.StatusCode ?? System.Net.HttpStatusCode.ServiceUnavailable;
-
-        CrawlResult crawlResult = _crawler.CreateErrorResult(
-            job.Url,
-            statusCode,
-            stopwatch.ElapsedMilliseconds,
-            fetchStartTime
-        );
-
-        return await CreateProcessJobResponse(changedContent: false, fetchStartTime, crawlResult);
-    }
 
 
     private async Task<ProcessJobResponse> CreateProcessJobResponse(

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/ProcessCrawlJobUseCase.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/ProcessCrawlJobUseCase.cs
@@ -66,14 +66,14 @@ public class ProcessCrawlJobUseCase : IProcessCrawlJobUseCase
 
             return response;
         }
-        catch (HttpRequestException ex)
-        {
-            stopwatch.Stop();
-			/// ToDo: LOGG THIS $"HTTP request failed: {ex.Message}"
+        // catch (HttpRequestException ex) // LET THIS BUUBLE 
+        // {
+        //     stopwatch.Stop();
+		// 	/// ToDo: LOGG THIS $"HTTP request failed: {ex.Message}"
         
-            return await CreateFailedRequestResponse(job, fetchStartTime, stopwatch, ex);
-        }
-        finally {stopwatch.Stop();}
+        //     return await CreateFailedRequestResponse(job, fetchStartTime, stopwatch, ex);
+        // }
+        finally { stopwatch.Stop(); } 
 	}
 
 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.BackgroundServices/TplCrawlJobDispatcher.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.BackgroundServices/TplCrawlJobDispatcher.cs
@@ -113,7 +113,7 @@ public class TplCrawlJobDispatcher : ICrawlJobDispatcher
 		{
 			_logger.LogWarning($"Job {job.Id} skipped: invalid job ({ex.Message})");
 		}
-		catch (InvalidOperationException ex)
+		catch (Exception ex) when (ex is InvalidOperationException || ex is HttpRequestException)
 		{
 			_logger.LogError($"Job {job.Id} failed: fetch error ({ex.Message})");
 			await HandleFailedJob(job);

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.BackgroundServices/TplCrawlJobDispatcher.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.BackgroundServices/TplCrawlJobDispatcher.cs
@@ -1,5 +1,6 @@
 ﻿using LTU.SearchEngine.Application;
 using LTU.SearchEngine.Backend.Core;
+using LTU.SearchEngine.Backend.Core.Model;
 using LTU.SearchEngine.Backend.Core.Model.Entities;
 using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
 using LTU.SearchEngine.Infrastructure.Configuration;
@@ -100,6 +101,8 @@ public class TplCrawlJobDispatcher : ICrawlJobDispatcher
 	{
 		try
 		{
+			job.Status = CrawlJobStatus.InProgress;
+
 			ProcessJobResponse jobResponse = await _processCrawlJobUseCase.Execute(job);
 			
 			if (jobResponse.CrawlResult is not null) await EnqueueNewJobs(jobResponse.CrawlResult);
@@ -127,6 +130,9 @@ public class TplCrawlJobDispatcher : ICrawlJobDispatcher
 		if (job.RetryCount >= _crawlerSettingsLoader.Load().RetryIntervals.Count)
 		{
 			_logger.LogWarning($"Job {job.Id} reached max retry count. Discarding job.");
+			
+			job.Status = CrawlJobStatus.Failed;
+
 			return;
 		}
 
@@ -134,6 +140,7 @@ public class TplCrawlJobDispatcher : ICrawlJobDispatcher
 			DateTime.UtcNow + _crawlerSettingsLoader.Load().GetRetryDelayInterval(job.RetryCount);
 
 		job.RetryCount++;
+		job.Status = CrawlJobStatus.Pending;
 		
 		await Enqueue(job);
 	}
@@ -145,6 +152,7 @@ public class TplCrawlJobDispatcher : ICrawlJobDispatcher
 			CrawlJob newJob = new CrawlJob
 			{
 				Url = link,
+				Status = CrawlJobStatus.Pending,
 				NextAttempt = DateTime.UtcNow
 			};
 
@@ -157,6 +165,7 @@ public class TplCrawlJobDispatcher : ICrawlJobDispatcher
 		if (job.RetryCount > 1) job.RetryCount = 1;
 
 		job.NextAttempt = crawledAt + _crawlerSettingsLoader.Load().CrawlUpdateInterval;
+		job.Status = CrawlJobStatus.Pending;
 
 		await Enqueue(job);
 	}

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Crawling/Crawler.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Crawling/Crawler.cs
@@ -113,7 +113,7 @@ public class Crawler : ICrawler
             extractedLinks: Enumerable.Empty<string>(),
             statusCode: statusCode,
             timeTakenMs: timeTaken,
-            contentHash: _contentHasher.CalculateHash(Array.Empty<byte>()), 
+            contentHash: "noHash",
             crawledAt: crawledAt
         );
     }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/BackgroundServices.Tests/TplCrawlJobDispatcherTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/BackgroundServices.Tests/TplCrawlJobDispatcherTests.cs
@@ -279,7 +279,7 @@ public class TplCrawlJobDispatcherTests
 
 		// Assert - CrawlUpdateInterval = 500
 		TimeSpan elapsedTime = dateTimes[1] - dateTimes[0];
-		Assert.InRange(elapsedTime, TimeSpan.FromMilliseconds(500), TimeSpan.FromMilliseconds(560));
+		Assert.InRange(elapsedTime, TimeSpan.FromMilliseconds(500), TimeSpan.FromMilliseconds(570));
 		_mockUseCase.Verify(uc => uc.Execute(It.IsAny<CrawlJob>()), Times.Exactly(2));
 	}
 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/BackgroundServices.Tests/TplCrawlJobDispatcherTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/BackgroundServices.Tests/TplCrawlJobDispatcherTests.cs
@@ -370,6 +370,7 @@ public class TplCrawlJobDispatcherTests
 		_mockUseCase.Verify(u => u.Execute(It.IsAny<CrawlJob>()), Times.Once);
 	}
 
+
 	[Fact]
 	public async Task HandleUseCaseAsync_OnArgumentException_ShouldNotRetry()
 	{
@@ -406,9 +407,14 @@ public class TplCrawlJobDispatcherTests
 		await Assert.ThrowsAsync<ArgumentNullException>(async () => await _sut.Enqueue(job));
 	}
 
-	[Fact]
-	public async Task HandleFailedJob_MaxRetryNotReached_IsRetriedWithCorrectTimeDelayAdded()
+	
+	[Theory]
+	[InlineData(typeof(InvalidOperationException))]
+	[InlineData(typeof(HttpRequestException))]
+	public async Task HandleFailedJob_MaxRetryNotReached_IsRetriedWithCorrectTimeDelayAdded(Type exceptionType)
 	{
+		var exception = (Exception)Activator.CreateInstance(exceptionType, "Simulated error")!;
+
 		// Arrange
 		DateTime nextAttemptExpected = 
 			DateTime.UtcNow + _mockCrawlerSettingsLoader.Object.Load().GetRetryDelayInterval(1);
@@ -426,7 +432,7 @@ public class TplCrawlJobDispatcherTests
 		};
 
 		_mockUseCase.SetupSequence(u => u.Execute(It.IsAny<CrawlJob>()))
-			.ThrowsAsync(new InvalidOperationException("fetch failed"))
+			.ThrowsAsync(exception)
 			.ReturnsAsync(CreateResponse()
 		);
 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Crawling.Tests/ProcessCrawlJobUseCaseTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Crawling.Tests/ProcessCrawlJobUseCaseTests.cs
@@ -144,49 +144,6 @@ public class ProcessCrawlJobUseCaseTests
 	}
 
 
-	[Theory]
-	[InlineData(HttpStatusCode.NotFound)]
-	[InlineData(HttpStatusCode.BadGateway)]
-	[InlineData(HttpStatusCode.Forbidden)]
-	[InlineData(HttpStatusCode.Gone)]
-	public async Task Execute_ShouldReturnErrorResponse_WhenFetchRawThrowsHttpRequestException(HttpStatusCode input)
-	{
-		// Arrange
-		var expectedStatusCode = input;
-		var processedAt = DateTime.UtcNow;
-
-
-		var expectedResult = CrawlResultBuilder.BuildCrawlResult(
-			url: _crawlJob.Url,
-			statusCode: input
-		);
-		
-		_crawlerMock
-			.Setup(c => c.FetchRawAsync(_crawlJob.Url))
-			.ThrowsAsync(new HttpRequestException("", null, input));
-			
-		_crawlerMock
-			.Setup(c => c.CreateErrorResult(
-				_crawlJob.Url, 
-				input, 
-				It.IsAny<long>(), 
-				It.IsAny<DateTime>()
-			)).Returns(expectedResult);
-		
-		
-		// Act 
-		
-		ProcessJobResponse response = await _sut.Execute(_crawlJob);
-
-		// Assert 
-		Assert.False(response.ChangedContent);
-		Assert.NotNull(response.CrawlResult);
-		Assert.Equal(input, response.CrawlResult.StatusCode);
-		_indexerMock.Verify(i => i.IndexAsync(It.IsAny<CrawlResult>()), Times.Never);
-	}
-
-
-
 	[Fact]
 	public async Task Execute_ShouldThrowArgumentNullException_WhenJobIsNull()
 	{

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/HelperClasses/WebHostBuilder.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/HelperClasses/WebHostBuilder.cs
@@ -10,9 +10,11 @@ namespace LTU.SearchEngine.Test.HelperClasses;
 public class WebHostBuilder
 {
 	public Dictionary<string, string> DynamicContent { get; } = new();
+	public Func<string, Task>? OnRequestReceived { get; set; }
 
 	public HttpClient CreateFakeInternetClient(CallTracker? callTracker = null)
 	{
+		
 		var host = Host.CreateDefaultBuilder().ConfigureWebHostDefaults(webBuilder =>
 		{
 			webBuilder.UseTestServer();
@@ -25,10 +27,13 @@ public class WebHostBuilder
 				app.UseEndpoints(endpoint =>
 				{	
 					// Dynamic generic page
-					endpoint.MapGet("/{page}.html", ( string page, CallTracker tracker, Dictionary<string, string> content) =>
+					endpoint.MapGet("/{page}.html", async ( string page, CallTracker tracker, Dictionary<string, string> content) =>
 					{
 						var url = $"http://localhost/{page}.html";
 						tracker.VisitedUrls.Add(url);
+
+						// Allows us to "pause" the execution and to some action before continuing.
+						if (OnRequestReceived is not null) await OnRequestReceived(url);
 
 						if (content.TryGetValue(url, out var customHtml))
 						{

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/IntegrationTesting/IndexerIntegrationTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/IntegrationTesting/IndexerIntegrationTests.cs
@@ -1,11 +1,11 @@
-using System.IO.Compression;
+
+using System.Diagnostics;
 using LTU.SearchEngine.Backend.Api;
 using LTU.SearchEngine.Backend.Core.Model.Entities;
 using LTU.SearchEngine.BackgroundServices;
 using LTU.SearchEngine.Infrastructure.Configurations;
 using LTU.SearchEngine.Infrastructure.Data;
 using LTU.SearchEngine.Infrastructure.Indexing;
-using LTU.SearchEngine.Test.HelperClasses;
 using LTU.SearchEngine.Tests.Helpers;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.Data.Sqlite;
@@ -305,6 +305,7 @@ public class IndexerIntegrationTests : IClassFixture<WebApplicationFactory<Progr
     public async Task Integration_CrawlShouldUpdateJobAndQueue_EvenWhenFetchFails()
     {
         // Arrange
+        var loggerMock = new Mock<ILogger<TplCrawlJobDispatcher>>();
         var httpClient = _webHostBuilder.CreateFakeInternetClient();
     
         var url = "http://localhost/bad-page.html";
@@ -324,10 +325,13 @@ public class IndexerIntegrationTests : IClassFixture<WebApplicationFactory<Progr
             return Task.CompletedTask;
         };
         
-        using var testFactory = CreateTestFactory<Indexer>(
+        // CREATE MOCK LOGGER
+
+        using var testFactory = CreateTestFactory<TplCrawlJobDispatcher>(
             httpClient: httpClient, 
             seedUrl: url,
-            maxConcurrencyPerDomain: 1
+            maxConcurrencyPerDomain: 1,
+            logger: loggerMock
         );
 
         using var scope = testFactory.Services.CreateScope();
@@ -345,13 +349,32 @@ public class IndexerIntegrationTests : IClassFixture<WebApplicationFactory<Progr
         var cts = new CancellationTokenSource();
         Task dispatchTask = dispatcher.Start(cts.Token);
         
-        await TestWait.UntilTrue(maxWaitMs: 1000);
+        await TestWait.UntilTrue(maxWaitMs: 2000);
         cts.Cancel();
 
         // Assert **1**
         var pageCount = await dbContext.Pages.CountAsync();
         Assert.Equal(0, pageCount);
         
+
+        // Verify failed fetch
+        loggerMock.Verify(l => l.Log(
+            logLevel: LogLevel.Error,
+            eventId: It.IsAny<EventId>(),
+            state: It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains($"failed: fetch error")),  
+            exception: It.IsAny<Exception>(),
+            It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+        Times.Once); 
+        
+        // Verify attempt att retry
+        loggerMock.Verify(l => l.Log(
+            logLevel: LogLevel.Warning,
+            eventId: It.IsAny<EventId>(),
+            state: It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains($"reached max retry count")),  
+            exception: It.IsAny<Exception>(),
+            It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+        Times.Once); 
+
 
         // Act **2**
         var cts2 = new CancellationTokenSource();

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/IntegrationTesting/IndexerIntegrationTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/IntegrationTesting/IndexerIntegrationTests.cs
@@ -302,7 +302,7 @@ public class IndexerIntegrationTests : IClassFixture<WebApplicationFactory<Progr
 
     [Fact]
     [Trait("TestCase", "TC-FRQ-2006")]
-    public async Task Integration_CrawlShouldCreateRecord_EvenWhenFetchFails()
+    public async Task Integration_CrawlShouldUpdateJobAndQueue_EvenWhenFetchFails()
     {
         // Arrange
         var httpClient = _webHostBuilder.CreateFakeInternetClient();
@@ -310,10 +310,17 @@ public class IndexerIntegrationTests : IClassFixture<WebApplicationFactory<Progr
         var url = "http://localhost/bad-page.html";
         _webHostBuilder.DynamicContent[url] = "<html><body><h1>Content</h1></body></html>";
 
+        int requestCount = 0;
         // Says to server, when you get this call, throw exception instead.
         _webHostBuilder.OnRequestReceived = (requestUrl) =>
         {
-            if (requestUrl.Equals(url)) throw new HttpRequestException("Simulated connection reset");
+            if (requestUrl.Equals(url)) 
+            {
+                requestCount++;
+                
+                // Crude way of allowing next attempt to succeed.
+                if (requestCount < 2) throw new HttpRequestException("Simulated connection reset");
+            }
             return Task.CompletedTask;
         };
         
@@ -327,7 +334,7 @@ public class IndexerIntegrationTests : IClassFixture<WebApplicationFactory<Progr
 
         var dispatcher = scope.ServiceProvider.GetRequiredService<ICrawlJobDispatcher>();
         
-        await dispatcher.Enqueue(new CrawlJob { Url = url , NextAttempt = DateTime.UtcNow });
+        await dispatcher.Enqueue(new CrawlJob { Url = url , NextAttempt = DateTime.UtcNow, RetryCount = 3 });
 
 
         var dbFactory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<SearchDbContext>>();
@@ -337,12 +344,32 @@ public class IndexerIntegrationTests : IClassFixture<WebApplicationFactory<Progr
         // Act **1**
         var cts = new CancellationTokenSource();
         Task dispatchTask = dispatcher.Start(cts.Token);
+        
+        await TestWait.UntilTrue(maxWaitMs: 1000);
+        cts.Cancel();
 
         // Assert **1**
-        await TestWait.UntilTrue(maxWaitMs: 5000);
         var pageCount = await dbContext.Pages.CountAsync();
         Assert.Equal(0, pageCount);
         
+
+        // Act **2**
+        var cts2 = new CancellationTokenSource();
+        
+        await dispatcher.Enqueue(new CrawlJob { Url = url , NextAttempt = DateTime.UtcNow, RetryCount = 1 });
+        Task dispatchTask2 = dispatcher.Start(cts2.Token);
+        
+        await TestWait.UntilTrue(async () =>
+        {
+            using var db = dbFactory.CreateDbContext();
+            return await db.Pages.CountAsync() > 0;
+        }, maxWaitMs: 5000);
+
+        cts2.Cancel();
+
+        // Assert **2**
+        pageCount = await dbContext.Pages.CountAsync();
+        Assert.Equal(1, pageCount);
     }   
 
 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/IntegrationTesting/IndexerIntegrationTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/IntegrationTesting/IndexerIntegrationTests.cs
@@ -188,7 +188,6 @@ public class IndexerIntegrationTests : IClassFixture<WebApplicationFactory<Progr
     {
         // Arrange
         var httpClient = _webHostBuilder.CreateFakeInternetClient();
-        var builder = new WebHostBuilder();
     
         var urlA = "http://localhost/page-a.html";
         var urlB = "http://localhost/page-b.html";
@@ -299,6 +298,53 @@ public class IndexerIntegrationTests : IClassFixture<WebApplicationFactory<Progr
             .Select(p => (DateTime?)p.LastCrawled) 
             .FirstOrDefaultAsync();
     }
+
+
+    [Fact]
+    [Trait("TestCase", "TC-FRQ-2006")]
+    public async Task Integration_CrawlShouldCreateRecord_EvenWhenFetchFails()
+    {
+        // Arrange
+        var httpClient = _webHostBuilder.CreateFakeInternetClient();
+    
+        var url = "http://localhost/bad-page.html";
+        _webHostBuilder.DynamicContent[url] = "<html><body><h1>Content</h1></body></html>";
+
+        // Says to server, when you get this call, throw exception instead.
+        _webHostBuilder.OnRequestReceived = (requestUrl) =>
+        {
+            if (requestUrl.Equals(url)) throw new HttpRequestException("Simulated connection reset");
+            return Task.CompletedTask;
+        };
+        
+        using var testFactory = CreateTestFactory<Indexer>(
+            httpClient: httpClient, 
+            seedUrl: url,
+            maxConcurrencyPerDomain: 1
+        );
+
+        using var scope = testFactory.Services.CreateScope();
+
+        var dispatcher = scope.ServiceProvider.GetRequiredService<ICrawlJobDispatcher>();
+        
+        await dispatcher.Enqueue(new CrawlJob { Url = url , NextAttempt = DateTime.UtcNow });
+
+
+        var dbFactory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<SearchDbContext>>();
+        using var dbContext = dbFactory.CreateDbContext();
+        dbContext.Database.EnsureCreated();
+        
+        // Act **1**
+        var cts = new CancellationTokenSource();
+        Task dispatchTask = dispatcher.Start(cts.Token);
+
+        // Assert **1**
+        await TestWait.UntilTrue(maxWaitMs: 5000);
+        var pageCount = await dbContext.Pages.CountAsync();
+        Assert.Equal(0, pageCount);
+        
+    }   
+
 
     [Theory]
     [InlineData("/IndexerNormalizingTextRun.html", "run", 5)]


### PR DESCRIPTION
I deviated a bit from what was requested in the issue description, as that information was obsolete and does not elaine with the current version of the system. 

what this test DOES do:
- Check that a failed fetch still results in an attempt to place the job back in the queue (with updated values).
- That the same fetch with a successful attempt is added to the index.

The logger is used as a way of verifying these attempts. While a check in the database is performed to check if the attempt was successful.  