### PR TITLE
118 current implementation of the haphtmlparser does not filter away non relevant resources implement said functionality

### DIFF
--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/HapHtmlParser.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/HapHtmlParser.cs
@@ -12,6 +12,7 @@ namespace LTU.SearchEngine.Infrastructure;
 
 public class HapHtmlParser : IHtmlParser
 {
+    private static readonly string[] AllowedExtensions = { ".html", ".htm", ".pdf", "/" };
     private readonly IDomainValidator _domainValidator;
     private readonly IRobotsHandler _robotsHandler;
     private readonly ILogger _logger;
@@ -63,7 +64,7 @@ public class HapHtmlParser : IHtmlParser
                 // 2. The host (domain) must match the base URL's host to be considered "internal".
                 bool isHttp = resultUri.Scheme == Uri.UriSchemeHttp || resultUri.Scheme == Uri.UriSchemeHttps;
                 
-                if (isHttp)
+                if (isHttp && IsSupportedResourceType(resultUri))
                 {
                     string url = resultUri.AbsoluteUri;
 
@@ -87,7 +88,7 @@ public class HapHtmlParser : IHtmlParser
         return internalLinks.Distinct().ToList();
     }
 
-
+ 
     /// <inheritdoc/>
     public string ExtractRawText(string html)
     {
@@ -172,6 +173,18 @@ public class HapHtmlParser : IHtmlParser
         return terms;
     }
     
+    
+    private bool IsSupportedResourceType(Uri uri)
+    {
+        string path = uri.AbsolutePath;
+        string extension = Path.GetExtension(path);
+
+        // If path == /, regard it as html (i,e,. http://domain.se/)
+        if (string.IsNullOrEmpty(path) || path.Equals("/")) return true;
+
+        return AllowedExtensions.Any(ext => extension.EndsWith(ext, StringComparison.OrdinalIgnoreCase));
+    }
+
 
     private async Task<bool> IsNotRobotsBlockedAndWhitelistedAsync(string url)
     {

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Crawling.Tests/ParserTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Crawling.Tests/ParserTests.cs
@@ -32,7 +32,7 @@ public class ParserTests
 	}
 
 	[Fact]
-	public async Task HapHtmlParser_ExtractInternalLinks_FindsAllLinksInDocument()
+	public async Task HapHtmlParser_ExtractInternalLinks_FindsAllRelevantLinksInDocument()
 	{
 		// Arrange
 		var html = await _client.GetStringAsync("/LinksAndPDFDetection.html");
@@ -50,7 +50,9 @@ public class ParserTests
 		Assert.Contains("http://localhost/Linked.html", links);
 		Assert.Contains("http://localhost/HelloWorld.pdf", links);
         Assert.Contains(new Uri("https://google.com").AbsoluteUri, links);
-
+        Assert.DoesNotContain(links, l => l.Equals("http://localhost/style.css"));
+        Assert.DoesNotContain(links, l => l.Equals("http://localhost/image1.jpg"));
+        Assert.DoesNotContain(links, l => l.Equals("http://localhost/image2.png"));
     }
 
    

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/TestFiles/Documents/LinksAndPDFDetection.html
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/TestFiles/Documents/LinksAndPDFDetection.html
@@ -20,5 +20,9 @@
 
     <!-- External link - Should be ignored if not in the domain whitelist (FRQ-1003) -->
     <p>Visit <a href="https://google.com">Google</a> to test domain whitelist restriction logic.</p>
+
+    <a href="https://localhost/style.css">Style</a>
+    <a href="https://localhost/image1.jpg">Image1</a>
+    <a href="https://localhost/image2.png">Image2</a>
 </body>
 </html>


### PR DESCRIPTION
Requested functionality has been implemented.

I added a whitelist of allowed path endings and a method to validate the links before being added to the list. 
Now only valid links are added to the list. 