### PR TITLE
12 implement changes to allow phrase queries change ef core entities according to changes in the er diagram

### DIFF
--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/HelperClasses/ITermMapper.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/HelperClasses/ITermMapper.cs
@@ -1,8 +1,28 @@
 namespace LTU.SearchEngine.Backend.Core.HelperClasses;
 
-
-public interface ITermMapper<TCollection>//, TKey, TValue> 
+/// <summary>
+/// Defines a contract for components that map and transform terms into a specific collection during the indexing process.
+/// </summary>
+/// <typeparam name="TCollection">
+/// The type of read-only collection to be returned <br/>
+/// (e.g., <see cref="IReadOnlyList{T}"/> or <see cref="IReadOnlyDictionary{TKey, TValue}"/>).
+/// </typeparam>
+public interface ITermMapper<TCollection>
 {
+    /// <summary>
+    /// Adds a term to the internal collection and performs specific mapping logic 
+    /// (e.g., incrementing frequency or storing the positional index).
+    /// </summary>
+    /// <param name="term">The string representation of the term to be mapped.</param>
+    /// <exception cref="ArgumentNullException">Thrown when the term is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when the term is empty or consists only of white-space characters.</exception>
     void AddTerm(string term);
+
+    /// <summary>
+    /// Converts the internal state into a read-only representation of the collected data.
+    /// </summary>
+    /// <returns>
+    /// A collection of type <typeparamref name="TCollection"/> containing the mapped terms.
+    /// </returns>
     TCollection ToReadOnly();
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/HelperClasses/ITermMapper.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/HelperClasses/ITermMapper.cs
@@ -1,0 +1,8 @@
+namespace LTU.SearchEngine.Backend.Core.HelperClasses;
+
+
+public interface ITermMapper<TCollection>//, TKey, TValue> 
+{
+    void AddTerm(string term);
+    TCollection ToReadOnly();
+}

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/HelperClasses/TermFrequencyMap.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/HelperClasses/TermFrequencyMap.cs
@@ -7,7 +7,7 @@ namespace LTU.SearchEngine.Backend.Core.HelperClasses;
 /// This helper is used during the indexing process to count occurrences of normalized terms 
 /// before they are finalized into a read-only format for the index.
 /// </remarks>
-public class TermFrequencyMap
+public class TermFrequencyMap : ITermMapper<IReadOnlyDictionary<string, int>>//<string, int>
 {
     private readonly Dictionary<string, int> _terms = new();
 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/HelperClasses/TermPositionMap.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/HelperClasses/TermPositionMap.cs
@@ -1,0 +1,19 @@
+namespace LTU.SearchEngine.Backend.Core.HelperClasses;
+
+
+public class TermPositionMap : ITermMapper<IReadOnlyList<string>>
+{
+    private readonly List<string> _terms = new List<string>();
+
+    public void AddTerm(string term)
+    {
+        if (term == null) throw new ArgumentNullException(nameof(term));
+
+        if (string.IsNullOrWhiteSpace(term))
+            throw new ArgumentException("Term cannot be empty or whitespace.", nameof(term));
+
+            _terms.Add(term);
+    }
+
+    public IReadOnlyList<string> ToReadOnly() => _terms.AsReadOnly();
+}

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/HelperClasses/TermPositionMap.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/HelperClasses/TermPositionMap.cs
@@ -1,12 +1,25 @@
 namespace LTU.SearchEngine.Backend.Core.HelperClasses;
 
-
+/// <summary>
+/// A specialized mapper that maintains the sequential order of terms as they appear in a document.
+/// This is used to build positional indices, enabling advanced search features like phrase matching.
+/// </summary>
+/// <remarks>
+/// Unlike a frequency map, this class preserves duplicates to ensure every occurrence 
+/// of a term is recorded at its specific index.
+/// </remarks>
 public class TermPositionMap : ITermMapper<IReadOnlyList<string>>
 {
     private readonly List<string> _terms = new List<string>();
 
+    /// <summary>
+    /// Appends a term to the end of the current sequence.
+    /// </summary>
+    /// <param name="term">The normalized term to be added.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="term"/> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="term"/> is empty or whitespace.</exception>
     public void AddTerm(string term)
-    {
+    {   
         if (term == null) throw new ArgumentNullException(nameof(term));
 
         if (string.IsNullOrWhiteSpace(term))
@@ -15,5 +28,7 @@ public class TermPositionMap : ITermMapper<IReadOnlyList<string>>
             _terms.Add(term);
     }
 
+    
+    /// <inheritdoc/>
     public IReadOnlyList<string> ToReadOnly() => _terms.AsReadOnly();
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/Entities/IndexDocument.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/Entities/IndexDocument.cs
@@ -7,6 +7,10 @@
     public IReadOnlyDictionary<string, int> TitleTerms { get; }
     public IReadOnlyDictionary<string, int> HeaderTerms { get; }
     public IReadOnlyDictionary<string, int> ContentTerms { get; }
+    public IReadOnlyList<string> TitleTermPositions { get; } 
+    public IReadOnlyList<string> HeaderTermPositions { get; } 
+    public IReadOnlyList<string> ContentTermPositions { get; } 
+        
     public string ContentHash { get; }
     public DateTime LastCrawl { get; }
 
@@ -18,6 +22,9 @@
         IReadOnlyDictionary<string, int> titleTerms, 
         IReadOnlyDictionary<string, int> headerTerms, 
         IReadOnlyDictionary<string, int> contentTerms,
+        IReadOnlyList<string> titleTermPositions, 
+        IReadOnlyList<string> headerTermPositions, 
+        IReadOnlyList<string> contentTermPositions, 
         string contentHash,
         DateTime lastCrawl
         )
@@ -29,6 +36,9 @@
         TitleTerms = titleTerms;
         HeaderTerms = headerTerms;
         ContentTerms = contentTerms;
+        TitleTermPositions = titleTermPositions;
+        HeaderTermPositions = headerTermPositions;
+        ContentTermPositions = contentTermPositions;
         ContentHash = contentHash;
         LastCrawl = lastCrawl; 
     }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/Entities/Page.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/Entities/Page.cs
@@ -14,6 +14,7 @@ public class Page
     public int HttpStatus { get; set; }
     public string Language { get; set; } = string.Empty;
     public ICollection<PageWordFrequency> WordFrequencies { get; set; } = new List<PageWordFrequency>();
+    public ICollection<PageWordPosition> PagePositions { get; set; } = new List<PageWordPosition>();
     public ICollection<PageLink> OutgoingLinks { get; set; } = new List<PageLink>();
     public ICollection<PageLink> IncomingLinks { get; set; } = new List<PageLink>();
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/Entities/PageWordPosition.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/Entities/PageWordPosition.cs
@@ -9,5 +9,6 @@ public class PageWordPosition
         public int TermId { get; set; }
         public Term Term { get; set; } = null!;
         public int Position { get; set; }
+        public TermSource TermSource { get; set; }
 }
 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/Entities/PageWordPosition.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/Entities/PageWordPosition.cs
@@ -1,0 +1,13 @@
+using LTU.SearchEngine.Backend.Core.Entities;
+
+namespace LTU.SearchEngine.Backend.Core.Model.Entities;
+
+public class PageWordPosition
+{
+        public int PageId { get; set; }
+        public Page Page { get; set; } = null!;
+        public int TermId { get; set; }
+        public Term Term { get; set; } = null!;
+        public int Position { get; set; }
+}
+

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/Entities/Term.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/Entities/Term.cs
@@ -9,6 +9,6 @@ public class Term
     public double IdfScore { get; set; }
 
     public ICollection<PageWordFrequency> PageFrequencies { get; set; } = new List<PageWordFrequency>();
-
+    public ICollection<PageWordPosition> PagePositions { get; set; } = new List<PageWordPosition>();
 }
 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Configurations/PageWordPositionConfiguration.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Configurations/PageWordPositionConfiguration.cs
@@ -1,0 +1,21 @@
+using LTU.SearchEngine.Backend.Core.Model.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace LTU.SearchEngine.Infrastructure.Configurations;
+
+public class PageWordPositionConfiguration : IEntityTypeConfiguration<PageWordPosition>
+{
+    public void Configure(EntityTypeBuilder<PageWordPosition> builder)
+    {
+        builder.HasKey(pwp => new { pwp.PageId, pwp.TermId, pwp.Position });
+
+        builder.HasOne(pwp => pwp.Page)
+            .WithMany(p => p.PagePositions)
+            .HasForeignKey(pwp => pwp.PageId);
+
+        builder.HasOne(pwp => pwp.Term)
+            .WithMany(t => t.PagePositions)
+            .HasForeignKey(pwp => pwp.TermId);
+    }
+}

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Configurations/PageWordPositionConfiguration.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Configurations/PageWordPositionConfiguration.cs
@@ -8,7 +8,7 @@ public class PageWordPositionConfiguration : IEntityTypeConfiguration<PageWordPo
 {
     public void Configure(EntityTypeBuilder<PageWordPosition> builder)
     {
-        builder.HasKey(pwp => new { pwp.PageId, pwp.TermId, pwp.Position });
+        builder.HasKey(pwp => new { pwp.PageId, pwp.TermId, pwp.Position, pwp.TermSource });
 
         builder.HasOne(pwp => pwp.Page)
             .WithMany(p => p.PagePositions)

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Data/SearchDbContext.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Data/SearchDbContext.cs
@@ -14,7 +14,7 @@ public class SearchDbContext : DbContext
     public DbSet<Term> Terms { get; set; }
     public DbSet<PageLink> PageLinks { get; set; }
     public DbSet<PageWordFrequency> PageWordFrequencies { get; set; }
-    public DbSet<PageWordPosition> PageWordPosition { get; set; }
+    public DbSet<PageWordPosition> PageWordPositions { get; set; }
 
     // --- Configuration (Fluent API) ---
     protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Data/SearchDbContext.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Data/SearchDbContext.cs
@@ -2,25 +2,25 @@
 using LTU.SearchEngine.Backend.Core.Model.Entities;
 using Microsoft.EntityFrameworkCore;
 
-namespace LTU.SearchEngine.Infrastructure.Data
-{
-    public class SearchDbContext : DbContext
-    {
-        public SearchDbContext(DbContextOptions<SearchDbContext> options)
-         : base(options)
-        {
-        }
-        public DbSet<Page> Pages { get; set; }
-        public DbSet<Term> Terms { get; set; }
-        public DbSet<PageLink> PageLinks { get; set; }
-        public DbSet<PageWordFrequency> PageWordFrequencies { get; set; }
+namespace LTU.SearchEngine.Infrastructure.Data;
 
-        // --- Configuration (Fluent API) ---
-        protected override void OnModelCreating(ModelBuilder modelBuilder)
-        {
-            base.OnModelCreating(modelBuilder);
-            modelBuilder.ApplyConfigurationsFromAssembly(typeof(SearchDbContext).Assembly);
-        }
+public class SearchDbContext : DbContext
+{
+    public SearchDbContext(DbContextOptions<SearchDbContext> options)
+     : base(options)
+    {
+    }
+    public DbSet<Page> Pages { get; set; }
+    public DbSet<Term> Terms { get; set; }
+    public DbSet<PageLink> PageLinks { get; set; }
+    public DbSet<PageWordFrequency> PageWordFrequencies { get; set; }
+    public DbSet<PageWordPosition> PageWordPosition { get; set; }
+
+    // --- Configuration (Fluent API) ---
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(SearchDbContext).Assembly);
     }
 }
-    
+

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Indexing/IndexingPipeline.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Indexing/IndexingPipeline.cs
@@ -32,11 +32,18 @@ public class IndexingPipeline : IIndexingPipeline
     {
         if (crawlResult == null) throw new ArgumentNullException(nameof(crawlResult));
 
-        Dictionary<TermSource, TermFrequencyMap> sourceMap = new()
+        Dictionary<TermSource, TermFrequencyMap> sourceFrequencyMap = new()
         {
             { TermSource.Title, new TermFrequencyMap() },
             { TermSource.Header, new TermFrequencyMap() },
             { TermSource.Body, new TermFrequencyMap() }  
+        };
+
+        Dictionary<TermSource, TermPositionMap> sourcePositionMap = new()
+        {
+            { TermSource.Title, new TermPositionMap() },
+            { TermSource.Header, new TermPositionMap() },
+            { TermSource.Body, new TermPositionMap() }  
         };
 
         foreach (var indexedTerm in crawlResult.IndexedTerms)
@@ -45,7 +52,8 @@ public class IndexingPipeline : IIndexingPipeline
 
             if (string.IsNullOrWhiteSpace(normalized)) continue;
             
-            sourceMap[indexedTerm.Source].AddTerm(normalized);
+            sourceFrequencyMap[indexedTerm.Source].AddTerm(normalized);
+            sourcePositionMap[indexedTerm.Source].AddTerm(normalized);
         }
 
         return new IndexDocument(
@@ -53,9 +61,12 @@ public class IndexingPipeline : IIndexingPipeline
             title: crawlResult.Title!,
             language: crawlResult.Language,
             outgoingLinks: crawlResult.ExtractedLinks,
-            titleTerms: sourceMap[TermSource.Title].ToReadOnly(), 
-            headerTerms: sourceMap[TermSource.Header].ToReadOnly(),
-            contentTerms: sourceMap[TermSource.Body].ToReadOnly(),
+            titleTerms: sourceFrequencyMap[TermSource.Title].ToReadOnly(), 
+            headerTerms: sourceFrequencyMap[TermSource.Header].ToReadOnly(),
+            contentTerms: sourceFrequencyMap[TermSource.Body].ToReadOnly(),
+            titleTermPositions: sourcePositionMap[TermSource.Title].ToReadOnly(),
+            headerTermPositions: sourcePositionMap[TermSource.Header].ToReadOnly(),
+            contentTermPositions: sourcePositionMap[TermSource.Body].ToReadOnly(),
             contentHash: crawlResult.ContentHash,
             lastCrawl: crawlResult.CrawledAt
         ); 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Migrations/20260414062411_newMigration.Designer.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Migrations/20260414062411_newMigration.Designer.cs
@@ -12,7 +12,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace LTU.SearchEngine.Infrastructure.Migrations
 {
     [DbContext(typeof(SearchDbContext))]
-    [Migration("20260327093606_newMigration")]
+    [Migration("20260414062411_newMigration")]
     partial class newMigration
     {
         /// <inheritdoc />
@@ -111,6 +111,24 @@ namespace LTU.SearchEngine.Infrastructure.Migrations
                     b.ToTable("PageWordFrequencies");
                 });
 
+            modelBuilder.Entity("LTU.SearchEngine.Backend.Core.Model.Entities.PageWordPosition", b =>
+                {
+                    b.Property<int>("PageId")
+                        .HasColumnType("int");
+
+                    b.Property<int>("TermId")
+                        .HasColumnType("int");
+
+                    b.Property<int>("Position")
+                        .HasColumnType("int");
+
+                    b.HasKey("PageId", "TermId", "Position");
+
+                    b.HasIndex("TermId");
+
+                    b.ToTable("PageWordPosition");
+                });
+
             modelBuilder.Entity("LTU.SearchEngine.Backend.Core.Model.Entities.Term", b =>
                 {
                     b.Property<int>("Id")
@@ -172,11 +190,32 @@ namespace LTU.SearchEngine.Infrastructure.Migrations
                     b.Navigation("Term");
                 });
 
+            modelBuilder.Entity("LTU.SearchEngine.Backend.Core.Model.Entities.PageWordPosition", b =>
+                {
+                    b.HasOne("LTU.SearchEngine.Backend.Core.Entities.Page", "Page")
+                        .WithMany("PagePositions")
+                        .HasForeignKey("PageId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.HasOne("LTU.SearchEngine.Backend.Core.Model.Entities.Term", "Term")
+                        .WithMany("PagePositions")
+                        .HasForeignKey("TermId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Page");
+
+                    b.Navigation("Term");
+                });
+
             modelBuilder.Entity("LTU.SearchEngine.Backend.Core.Entities.Page", b =>
                 {
                     b.Navigation("IncomingLinks");
 
                     b.Navigation("OutgoingLinks");
+
+                    b.Navigation("PagePositions");
 
                     b.Navigation("WordFrequencies");
                 });
@@ -184,6 +223,8 @@ namespace LTU.SearchEngine.Infrastructure.Migrations
             modelBuilder.Entity("LTU.SearchEngine.Backend.Core.Model.Entities.Term", b =>
                 {
                     b.Navigation("PageFrequencies");
+
+                    b.Navigation("PagePositions");
                 });
 #pragma warning restore 612, 618
         }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Migrations/20260414062411_newMigration.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Migrations/20260414062411_newMigration.cs
@@ -97,6 +97,31 @@ namespace LTU.SearchEngine.Infrastructure.Migrations
                         onDelete: ReferentialAction.Cascade);
                 });
 
+            migrationBuilder.CreateTable(
+                name: "PageWordPosition",
+                columns: table => new
+                {
+                    PageId = table.Column<int>(type: "int", nullable: false),
+                    TermId = table.Column<int>(type: "int", nullable: false),
+                    Position = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PageWordPosition", x => new { x.PageId, x.TermId, x.Position });
+                    table.ForeignKey(
+                        name: "FK_PageWordPosition_Pages_PageId",
+                        column: x => x.PageId,
+                        principalTable: "Pages",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_PageWordPosition_Terms_TermId",
+                        column: x => x.TermId,
+                        principalTable: "Terms",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
             migrationBuilder.CreateIndex(
                 name: "IX_PageLinks_ToPageId",
                 table: "PageLinks",
@@ -114,6 +139,11 @@ namespace LTU.SearchEngine.Infrastructure.Migrations
                 column: "TermId");
 
             migrationBuilder.CreateIndex(
+                name: "IX_PageWordPosition_TermId",
+                table: "PageWordPosition",
+                column: "TermId");
+
+            migrationBuilder.CreateIndex(
                 name: "IX_Terms_Word",
                 table: "Terms",
                 column: "Word",
@@ -128,6 +158,9 @@ namespace LTU.SearchEngine.Infrastructure.Migrations
 
             migrationBuilder.DropTable(
                 name: "PageWordFrequencies");
+
+            migrationBuilder.DropTable(
+                name: "PageWordPosition");
 
             migrationBuilder.DropTable(
                 name: "Pages");

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Migrations/20260414091031_newMigration.Designer.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Migrations/20260414091031_newMigration.Designer.cs
@@ -12,7 +12,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace LTU.SearchEngine.Infrastructure.Migrations
 {
     [DbContext(typeof(SearchDbContext))]
-    [Migration("20260414062411_newMigration")]
+    [Migration("20260414091031_newMigration")]
     partial class newMigration
     {
         /// <inheritdoc />
@@ -122,11 +122,14 @@ namespace LTU.SearchEngine.Infrastructure.Migrations
                     b.Property<int>("Position")
                         .HasColumnType("int");
 
-                    b.HasKey("PageId", "TermId", "Position");
+                    b.Property<int>("TermSource")
+                        .HasColumnType("int");
+
+                    b.HasKey("PageId", "TermId", "Position", "TermSource");
 
                     b.HasIndex("TermId");
 
-                    b.ToTable("PageWordPosition");
+                    b.ToTable("PageWordPositions");
                 });
 
             modelBuilder.Entity("LTU.SearchEngine.Backend.Core.Model.Entities.Term", b =>

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Migrations/20260414091031_newMigration.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Migrations/20260414091031_newMigration.cs
@@ -98,24 +98,25 @@ namespace LTU.SearchEngine.Infrastructure.Migrations
                 });
 
             migrationBuilder.CreateTable(
-                name: "PageWordPosition",
+                name: "PageWordPositions",
                 columns: table => new
                 {
                     PageId = table.Column<int>(type: "int", nullable: false),
                     TermId = table.Column<int>(type: "int", nullable: false),
-                    Position = table.Column<int>(type: "int", nullable: false)
+                    Position = table.Column<int>(type: "int", nullable: false),
+                    TermSource = table.Column<int>(type: "int", nullable: false)
                 },
                 constraints: table =>
                 {
-                    table.PrimaryKey("PK_PageWordPosition", x => new { x.PageId, x.TermId, x.Position });
+                    table.PrimaryKey("PK_PageWordPositions", x => new { x.PageId, x.TermId, x.Position, x.TermSource });
                     table.ForeignKey(
-                        name: "FK_PageWordPosition_Pages_PageId",
+                        name: "FK_PageWordPositions_Pages_PageId",
                         column: x => x.PageId,
                         principalTable: "Pages",
                         principalColumn: "Id",
                         onDelete: ReferentialAction.Cascade);
                     table.ForeignKey(
-                        name: "FK_PageWordPosition_Terms_TermId",
+                        name: "FK_PageWordPositions_Terms_TermId",
                         column: x => x.TermId,
                         principalTable: "Terms",
                         principalColumn: "Id",
@@ -139,8 +140,8 @@ namespace LTU.SearchEngine.Infrastructure.Migrations
                 column: "TermId");
 
             migrationBuilder.CreateIndex(
-                name: "IX_PageWordPosition_TermId",
-                table: "PageWordPosition",
+                name: "IX_PageWordPositions_TermId",
+                table: "PageWordPositions",
                 column: "TermId");
 
             migrationBuilder.CreateIndex(
@@ -160,7 +161,7 @@ namespace LTU.SearchEngine.Infrastructure.Migrations
                 name: "PageWordFrequencies");
 
             migrationBuilder.DropTable(
-                name: "PageWordPosition");
+                name: "PageWordPositions");
 
             migrationBuilder.DropTable(
                 name: "Pages");

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Migrations/SearchDbContextModelSnapshot.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Migrations/SearchDbContextModelSnapshot.cs
@@ -108,6 +108,24 @@ namespace LTU.SearchEngine.Infrastructure.Migrations
                     b.ToTable("PageWordFrequencies");
                 });
 
+            modelBuilder.Entity("LTU.SearchEngine.Backend.Core.Model.Entities.PageWordPosition", b =>
+                {
+                    b.Property<int>("PageId")
+                        .HasColumnType("int");
+
+                    b.Property<int>("TermId")
+                        .HasColumnType("int");
+
+                    b.Property<int>("Position")
+                        .HasColumnType("int");
+
+                    b.HasKey("PageId", "TermId", "Position");
+
+                    b.HasIndex("TermId");
+
+                    b.ToTable("PageWordPosition");
+                });
+
             modelBuilder.Entity("LTU.SearchEngine.Backend.Core.Model.Entities.Term", b =>
                 {
                     b.Property<int>("Id")
@@ -169,11 +187,32 @@ namespace LTU.SearchEngine.Infrastructure.Migrations
                     b.Navigation("Term");
                 });
 
+            modelBuilder.Entity("LTU.SearchEngine.Backend.Core.Model.Entities.PageWordPosition", b =>
+                {
+                    b.HasOne("LTU.SearchEngine.Backend.Core.Entities.Page", "Page")
+                        .WithMany("PagePositions")
+                        .HasForeignKey("PageId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.HasOne("LTU.SearchEngine.Backend.Core.Model.Entities.Term", "Term")
+                        .WithMany("PagePositions")
+                        .HasForeignKey("TermId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Page");
+
+                    b.Navigation("Term");
+                });
+
             modelBuilder.Entity("LTU.SearchEngine.Backend.Core.Entities.Page", b =>
                 {
                     b.Navigation("IncomingLinks");
 
                     b.Navigation("OutgoingLinks");
+
+                    b.Navigation("PagePositions");
 
                     b.Navigation("WordFrequencies");
                 });
@@ -181,6 +220,8 @@ namespace LTU.SearchEngine.Infrastructure.Migrations
             modelBuilder.Entity("LTU.SearchEngine.Backend.Core.Model.Entities.Term", b =>
                 {
                     b.Navigation("PageFrequencies");
+
+                    b.Navigation("PagePositions");
                 });
 #pragma warning restore 612, 618
         }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Migrations/SearchDbContextModelSnapshot.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Migrations/SearchDbContextModelSnapshot.cs
@@ -119,11 +119,14 @@ namespace LTU.SearchEngine.Infrastructure.Migrations
                     b.Property<int>("Position")
                         .HasColumnType("int");
 
-                    b.HasKey("PageId", "TermId", "Position");
+                    b.Property<int>("TermSource")
+                        .HasColumnType("int");
+
+                    b.HasKey("PageId", "TermId", "Position", "TermSource");
 
                     b.HasIndex("TermId");
 
-                    b.ToTable("PageWordPosition");
+                    b.ToTable("PageWordPositions");
                 });
 
             modelBuilder.Entity("LTU.SearchEngine.Backend.Core.Model.Entities.Term", b =>

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Repositories/SqlIndexRepository.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Repositories/SqlIndexRepository.cs
@@ -26,160 +26,170 @@ public class SqlIndexRepository : IIndexRepository
     public async Task AddDocumentAsync(IndexDocument document)
     {
         await using var context = await _factory.CreateDbContextAsync();
+        await using var transaction = await context.Database.BeginTransactionAsync();
 
-        // Check if the Page already exists in the database
-        var page = await context.Pages.FirstOrDefaultAsync(p => p.Url.Equals(document.Url));
-
-        if (page is null)
+        try
         {
-            page = new Page
+             // Check if the Page already exists in the database
+            var page = await context.Pages.FirstOrDefaultAsync(p => p.Url.Equals(document.Url));
+
+            if (page is null)
             {
-                Url = document.Url,
-                Title = document.Title,
-                LastCrawled = document.LastCrawl,
-                ContentHash = document.ContentHash,
-                WordCount = document.TotalWordCount,
-                Language = document.Language
-            };
-
-            context.Pages.Add(page);
-        }
-        else
-        {
-            // Remove old word frequencies/positions and page links for the page before adding new ones to avoid duplicates
-            var oldPageWordFrequencies = context.PageWordFrequencies.Where(pwf => pwf.PageId.Equals(page.Id));
-            context.PageWordFrequencies.RemoveRange(oldPageWordFrequencies);
-            
-            var oldPageWordPositions = context.PageWordPositions.Where(pwf => pwf.PageId.Equals(page.Id));
-            context.PageWordPositions.RemoveRange(oldPageWordPositions);
-            
-            var oldLinkEntries = context.PageLinks.Where(pl => pl.FromPageId.Equals(page.Id));
-            context.PageLinks.RemoveRange(oldLinkEntries);
-
-            // Update page metadata
-            page.Title = document.Title;
-            page.LastCrawled = document.LastCrawl;
-            page.ContentHash = document.ContentHash;
-            page.WordCount = document.TotalWordCount;
-            page.Language = document.Language;            
-        }
-
-        // Save to get a Page.Id 
-        await context.SaveChangesAsync();
-
-        // -------------------------------- Handle WordFrequency relation --------------------------------------   
-        var allUniqueTerms = document.TitleTerms.Keys
-            .Union(document.HeaderTerms.Keys)
-            .Union(document.ContentTerms.Keys)
-            .ToList();
-
-        // Retrieve any Terms that already exist in the database.
-        var existingTerms = await context.Terms
-            .Where(t => allUniqueTerms.Contains(t.Word))
-            .ToDictionaryAsync(t => t.Word);
-
-        bool hasNewTerms = false;
-
-        foreach (var term in allUniqueTerms)
-        {
-            // Creates new Terms if current Term did not exist. 
-            if (!existingTerms.TryGetValue(term, out var termEntity))
-            {
-                termEntity = new Term { Word = term };
-                context.Terms.Add(termEntity);
-                existingTerms[term] = termEntity;
-                hasNewTerms = true;
-            }
-        }
-
-        if (hasNewTerms) await context.SaveChangesAsync();
-
-
-        foreach (var term in allUniqueTerms)
-        {
-            var termEntity = existingTerms[term];
-
-            document.TitleTerms.TryGetValue(term, out int titleFrequency);
-            document.HeaderTerms.TryGetValue(term, out int headerFrequency);
-            document.ContentTerms.TryGetValue(term, out int contentFrequency);
-
-            var pageWordFrequency = new PageWordFrequency
-            {
-                PageId = page.Id,
-                TermId = termEntity.Id,
-                TitleFrequency = titleFrequency,
-                HeaderFrequency = headerFrequency,
-                BodyFrequency = contentFrequency
-            };
-
-            context.PageWordFrequencies.Add(pageWordFrequency);
-        }
-
-        // -------------------------------- Handle PageWordPosition relation --------------------------------------   
-
-        var sourceTermPosition = new Dictionary<TermSource, IReadOnlyList<string>>();
-        sourceTermPosition[TermSource.Title] = document.TitleTermPositions;
-        sourceTermPosition[TermSource.Header] = document.HeaderTermPositions;
-        sourceTermPosition[TermSource.Body] = document.ContentTermPositions;
-
-        foreach (var source in sourceTermPosition)
-        {
-
-            for (int i = 0; i < source.Value.Count; i++)
-            {
-                var currentTerm = source.Value[i];
-
-                if (existingTerms.TryGetValue(currentTerm, out var termEntity))
+                page = new Page
                 {
-                    var pageWordPosition = new PageWordPosition
-                    {
-                        PageId = page.Id,
-                        TermId = termEntity.Id,
-                        Position = i,
-                        TermSource = source.Key
-                    };   
+                    Url = document.Url,
+                    Title = document.Title,
+                    LastCrawled = document.LastCrawl,
+                    ContentHash = document.ContentHash,
+                    WordCount = document.TotalWordCount,
+                    Language = document.Language
+                };
 
-                    context.PageWordPositions.Add(pageWordPosition);
+                context.Pages.Add(page);
+            }
+            else
+            {
+                // Remove old word frequencies/positions and page links for the page before adding new ones to avoid duplicates
+                var oldPageWordFrequencies = context.PageWordFrequencies.Where(pwf => pwf.PageId.Equals(page.Id));
+                context.PageWordFrequencies.RemoveRange(oldPageWordFrequencies);
+                
+                var oldPageWordPositions = context.PageWordPositions.Where(pwf => pwf.PageId.Equals(page.Id));
+                context.PageWordPositions.RemoveRange(oldPageWordPositions);
+                
+                var oldLinkEntries = context.PageLinks.Where(pl => pl.FromPageId.Equals(page.Id));
+                context.PageLinks.RemoveRange(oldLinkEntries);
+
+                // Update page metadata
+                page.Title = document.Title;
+                page.LastCrawled = document.LastCrawl;
+                page.ContentHash = document.ContentHash;
+                page.WordCount = document.TotalWordCount;
+                page.Language = document.Language;            
+            }
+
+            // Save to get a Page.Id 
+            await context.SaveChangesAsync();
+
+            // -------------------------------- Handle WordFrequency relation --------------------------------------   
+            var allUniqueTerms = document.TitleTerms.Keys
+                .Union(document.HeaderTerms.Keys)
+                .Union(document.ContentTerms.Keys)
+                .ToList();
+
+            // Retrieve any Terms that already exist in the database.
+            var existingTerms = await context.Terms
+                .Where(t => allUniqueTerms.Contains(t.Word))
+                .ToDictionaryAsync(t => t.Word);
+
+            bool hasNewTerms = false;
+
+            foreach (var term in allUniqueTerms)
+            {
+                // Creates new Terms if current Term did not exist. 
+                if (!existingTerms.TryGetValue(term, out var termEntity))
+                {
+                    termEntity = new Term { Word = term };
+                    context.Terms.Add(termEntity);
+                    existingTerms[term] = termEntity;
+                    hasNewTerms = true;
                 }
             }
-        }
+
+            if (hasNewTerms) await context.SaveChangesAsync();
 
 
-        // -------------------------------- Handle PageLink relation -------------------------------------------
-        if (document.OutgoingLinks is not null && document.OutgoingLinks.Any())
-        {
-            var targetLinks = document.OutgoingLinks.Distinct().ToList();
-            var existingTargetPages = await context.Pages
-                .Where(p => targetLinks.Contains(p.Url))
-                .ToDictionaryAsync(p => p.Url);        
-
-            foreach (var url in targetLinks)
+            foreach (var term in allUniqueTerms)
             {
-                // If no such page exist yet, create a stub in wait of crawl
-                if (!existingTargetPages.TryGetValue(url, out var targetStubPage))
-                {
-                    targetStubPage = new Page
-                    {
-                      Url = url,
-                      Title = "pending..",
-                      ContentHash = string.Empty,
-                      Language = string.Empty
-                    };
+                var termEntity = existingTerms[term];
 
-                    context.Pages.Add(targetStubPage);
-                    existingTargetPages[url] = targetStubPage;
-                }
+                document.TitleTerms.TryGetValue(term, out int titleFrequency);
+                document.HeaderTerms.TryGetValue(term, out int headerFrequency);
+                document.ContentTerms.TryGetValue(term, out int contentFrequency);
 
-                context.PageLinks.Add( new PageLink
+                var pageWordFrequency = new PageWordFrequency
                 {
-                    FromPage = page,
-                    ToPage = targetStubPage   
-                });
+                    PageId = page.Id,
+                    TermId = termEntity.Id,
+                    TitleFrequency = titleFrequency,
+                    HeaderFrequency = headerFrequency,
+                    BodyFrequency = contentFrequency
+                };
+
+                context.PageWordFrequencies.Add(pageWordFrequency);
             }
-        }
 
-        // save everything at the same time        
-        await context.SaveChangesAsync(); 
+            // -------------------------------- Handle PageWordPosition relation --------------------------------------   
+
+            var sourceTermPosition = new Dictionary<TermSource, IReadOnlyList<string>>();
+            sourceTermPosition[TermSource.Title] = document.TitleTermPositions;
+            sourceTermPosition[TermSource.Header] = document.HeaderTermPositions;
+            sourceTermPosition[TermSource.Body] = document.ContentTermPositions;
+
+            foreach (var source in sourceTermPosition)
+            {
+
+                for (int i = 0; i < source.Value.Count; i++)
+                {
+                    var currentTerm = source.Value[i];
+
+                    if (existingTerms.TryGetValue(currentTerm, out var termEntity))
+                    {
+                        var pageWordPosition = new PageWordPosition
+                        {
+                            PageId = page.Id,
+                            TermId = termEntity.Id,
+                            Position = i,
+                            TermSource = source.Key
+                        };   
+
+                        context.PageWordPositions.Add(pageWordPosition);
+                    }
+                }
+            }
+
+
+            // -------------------------------- Handle PageLink relation -------------------------------------------
+            if (document.OutgoingLinks is not null && document.OutgoingLinks.Any())
+            {
+                var targetLinks = document.OutgoingLinks.Distinct().ToList();
+                var existingTargetPages = await context.Pages
+                    .Where(p => targetLinks.Contains(p.Url))
+                    .ToDictionaryAsync(p => p.Url);        
+
+                foreach (var url in targetLinks)
+                {
+                    // If no such page exist yet, create a stub in wait of crawl
+                    if (!existingTargetPages.TryGetValue(url, out var targetStubPage))
+                    {
+                        targetStubPage = new Page
+                        {
+                        Url = url,
+                        Title = "pending..",
+                        ContentHash = string.Empty,
+                        Language = string.Empty
+                        };
+
+                        context.Pages.Add(targetStubPage);
+                        existingTargetPages[url] = targetStubPage;
+                    }
+
+                    context.PageLinks.Add( new PageLink
+                    {
+                        FromPage = page,
+                        ToPage = targetStubPage   
+                    });
+                }
+            }
+
+            // save everything at the same time        
+            await context.SaveChangesAsync(); 
+            await transaction.CommitAsync();
+        }
+        catch //(System.Exception)
+        {
+            await transaction.RollbackAsync();
+            throw;
+        }
     }
 
 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Repositories/SqlIndexRepository.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Repositories/SqlIndexRepository.cs
@@ -1,4 +1,5 @@
 ﻿using LTU.SearchEngine.Backend.Core.Entities;
+using LTU.SearchEngine.Backend.Core.Model;
 using LTU.SearchEngine.Backend.Core.Model.Entities;
 using LTU.SearchEngine.Backend.Core.Model.ValueObjects.QueryNodes;
 using LTU.SearchEngine.Infrastructure.Data;
@@ -45,10 +46,13 @@ public class SqlIndexRepository : IIndexRepository
         }
         else
         {
-            // Remove old word frequencies and page links for the page before adding new ones to avoid duplicates
-            var oldTermEntries = context.PageWordFrequencies.Where(pwf => pwf.PageId.Equals(page.Id));
-            context.PageWordFrequencies.RemoveRange(oldTermEntries);
-
+            // Remove old word frequencies/positions and page links for the page before adding new ones to avoid duplicates
+            var oldPageWordFrequencies = context.PageWordFrequencies.Where(pwf => pwf.PageId.Equals(page.Id));
+            context.PageWordFrequencies.RemoveRange(oldPageWordFrequencies);
+            
+            var oldPageWordPositions = context.PageWordPositions.Where(pwf => pwf.PageId.Equals(page.Id));
+            context.PageWordPositions.RemoveRange(oldPageWordPositions);
+            
             var oldLinkEntries = context.PageLinks.Where(pl => pl.FromPageId.Equals(page.Id));
             context.PageLinks.RemoveRange(oldLinkEntries);
 
@@ -63,7 +67,7 @@ public class SqlIndexRepository : IIndexRepository
         // Save to get a Page.Id 
         await context.SaveChangesAsync();
 
-        // Handle WordFrequency relation    
+        // -------------------------------- Handle WordFrequency relation --------------------------------------   
         var allUniqueTerms = document.TitleTerms.Keys
             .Union(document.HeaderTerms.Keys)
             .Union(document.ContentTerms.Keys)
@@ -111,7 +115,37 @@ public class SqlIndexRepository : IIndexRepository
             context.PageWordFrequencies.Add(pageWordFrequency);
         }
 
-        // Handle PageLink relation 
+        // -------------------------------- Handle PageWordPosition relation --------------------------------------   
+
+        var sourceTermPosition = new Dictionary<TermSource, IReadOnlyList<string>>();
+        sourceTermPosition[TermSource.Title] = document.TitleTermPositions;
+        sourceTermPosition[TermSource.Header] = document.HeaderTermPositions;
+        sourceTermPosition[TermSource.Body] = document.ContentTermPositions;
+
+        foreach (var source in sourceTermPosition)
+        {
+
+            for (int i = 0; i < source.Value.Count; i++)
+            {
+                var currentTerm = source.Value[i];
+
+                if (existingTerms.TryGetValue(currentTerm, out var termEntity))
+                {
+                    var pageWordPosition = new PageWordPosition
+                    {
+                        PageId = page.Id,
+                        TermId = termEntity.Id,
+                        Position = i,
+                        TermSource = source.Key
+                    };   
+
+                    context.PageWordPositions.Add(pageWordPosition);
+                }
+            }
+        }
+
+
+        // -------------------------------- Handle PageLink relation -------------------------------------------
         if (document.OutgoingLinks is not null && document.OutgoingLinks.Any())
         {
             var targetLinks = document.OutgoingLinks.Distinct().ToList();

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Repositories/SqlIndexRepository.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Repositories/SqlIndexRepository.cs
@@ -185,7 +185,7 @@ public class SqlIndexRepository : IIndexRepository
             await context.SaveChangesAsync(); 
             await transaction.CommitAsync();
         }
-        catch //(System.Exception)
+        catch 
         {
             await transaction.RollbackAsync();
             throw;

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Repositories/SqlIndexRepository.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Repositories/SqlIndexRepository.cs
@@ -20,7 +20,6 @@ public class SqlIndexRepository : IIndexRepository
         _factory = factory;
     }
 
-    // ToDo: method AddDocumentAsync needs to be refactored and extract smaller portions of the code into smaller private methods
     // Saves a fully processed document from the pipeline to the database.
     // Merge words from the title, headers and body content.
     public async Task AddDocumentAsync(IndexDocument document)
@@ -30,156 +29,22 @@ public class SqlIndexRepository : IIndexRepository
 
         try
         {
-             // Check if the Page already exists in the database
-            var page = await context.Pages.FirstOrDefaultAsync(p => p.Url.Equals(document.Url));
-
-            if (page is null)
-            {
-                page = new Page
-                {
-                    Url = document.Url,
-                    Title = document.Title,
-                    LastCrawled = document.LastCrawl,
-                    ContentHash = document.ContentHash,
-                    WordCount = document.TotalWordCount,
-                    Language = document.Language
-                };
-
-                context.Pages.Add(page);
-            }
-            else
-            {
-                // Remove old word frequencies/positions and page links for the page before adding new ones to avoid duplicates
-                var oldPageWordFrequencies = context.PageWordFrequencies.Where(pwf => pwf.PageId.Equals(page.Id));
-                context.PageWordFrequencies.RemoveRange(oldPageWordFrequencies);
-                
-                var oldPageWordPositions = context.PageWordPositions.Where(pwf => pwf.PageId.Equals(page.Id));
-                context.PageWordPositions.RemoveRange(oldPageWordPositions);
-                
-                var oldLinkEntries = context.PageLinks.Where(pl => pl.FromPageId.Equals(page.Id));
-                context.PageLinks.RemoveRange(oldLinkEntries);
-
-                // Update page metadata
-                page.Title = document.Title;
-                page.LastCrawled = document.LastCrawl;
-                page.ContentHash = document.ContentHash;
-                page.WordCount = document.TotalWordCount;
-                page.Language = document.Language;            
-            }
+            var page = await GetOrCreatePageAsync(context, document);
 
             // Save to get a Page.Id 
             await context.SaveChangesAsync();
 
-            // -------------------------------- Handle WordFrequency relation --------------------------------------   
             var allUniqueTerms = document.TitleTerms.Keys
                 .Union(document.HeaderTerms.Keys)
                 .Union(document.ContentTerms.Keys)
                 .ToList();
 
             // Retrieve any Terms that already exist in the database.
-            var existingTerms = await context.Terms
-                .Where(t => allUniqueTerms.Contains(t.Word))
-                .ToDictionaryAsync(t => t.Word);
+            var termLookup = await SynchronizeTermsAsync(context, allUniqueTerms);
 
-            bool hasNewTerms = false;
-
-            foreach (var term in allUniqueTerms)
-            {
-                // Creates new Terms if current Term did not exist. 
-                if (!existingTerms.TryGetValue(term, out var termEntity))
-                {
-                    termEntity = new Term { Word = term };
-                    context.Terms.Add(termEntity);
-                    existingTerms[term] = termEntity;
-                    hasNewTerms = true;
-                }
-            }
-
-            if (hasNewTerms) await context.SaveChangesAsync();
-
-
-            foreach (var term in allUniqueTerms)
-            {
-                var termEntity = existingTerms[term];
-
-                document.TitleTerms.TryGetValue(term, out int titleFrequency);
-                document.HeaderTerms.TryGetValue(term, out int headerFrequency);
-                document.ContentTerms.TryGetValue(term, out int contentFrequency);
-
-                var pageWordFrequency = new PageWordFrequency
-                {
-                    PageId = page.Id,
-                    TermId = termEntity.Id,
-                    TitleFrequency = titleFrequency,
-                    HeaderFrequency = headerFrequency,
-                    BodyFrequency = contentFrequency
-                };
-
-                context.PageWordFrequencies.Add(pageWordFrequency);
-            }
-
-            // -------------------------------- Handle PageWordPosition relation --------------------------------------   
-
-            var sourceTermPosition = new Dictionary<TermSource, IReadOnlyList<string>>();
-            sourceTermPosition[TermSource.Title] = document.TitleTermPositions;
-            sourceTermPosition[TermSource.Header] = document.HeaderTermPositions;
-            sourceTermPosition[TermSource.Body] = document.ContentTermPositions;
-
-            foreach (var source in sourceTermPosition)
-            {
-
-                for (int i = 0; i < source.Value.Count; i++)
-                {
-                    var currentTerm = source.Value[i];
-
-                    if (existingTerms.TryGetValue(currentTerm, out var termEntity))
-                    {
-                        var pageWordPosition = new PageWordPosition
-                        {
-                            PageId = page.Id,
-                            TermId = termEntity.Id,
-                            Position = i,
-                            TermSource = source.Key
-                        };   
-
-                        context.PageWordPositions.Add(pageWordPosition);
-                    }
-                }
-            }
-
-
-            // -------------------------------- Handle PageLink relation -------------------------------------------
-            if (document.OutgoingLinks is not null && document.OutgoingLinks.Any())
-            {
-                var targetLinks = document.OutgoingLinks.Distinct().ToList();
-                var existingTargetPages = await context.Pages
-                    .Where(p => targetLinks.Contains(p.Url))
-                    .ToDictionaryAsync(p => p.Url);        
-
-                foreach (var url in targetLinks)
-                {
-                    // If no such page exist yet, create a stub in wait of crawl
-                    if (!existingTargetPages.TryGetValue(url, out var targetStubPage))
-                    {
-                        targetStubPage = new Page
-                        {
-                        Url = url,
-                        Title = "pending..",
-                        ContentHash = string.Empty,
-                        Language = string.Empty
-                        };
-
-                        context.Pages.Add(targetStubPage);
-                        existingTargetPages[url] = targetStubPage;
-                    }
-
-                    context.PageLinks.Add( new PageLink
-                    {
-                        FromPage = page,
-                        ToPage = targetStubPage   
-                    });
-                }
-            }
+            AddWordFrequencies(context, page.Id, document, termLookup);
+            AddWordPositions(context, page.Id, document, termLookup);
+            await AddPageLinksAsync(context, page, document.OutgoingLinks);
 
             // save everything at the same time        
             await context.SaveChangesAsync(); 
@@ -189,6 +54,152 @@ public class SqlIndexRepository : IIndexRepository
         {
             await transaction.RollbackAsync();
             throw;
+        }
+    }
+
+
+    private async Task<Page> GetOrCreatePageAsync(SearchDbContext context, IndexDocument document)
+    {
+        // Check if the Page already exists in the database
+        var page = await context.Pages.FirstOrDefaultAsync(p => p.Url.Equals(document.Url));
+
+        if (page is null)
+        {
+            page = new Page
+            {
+                Url = document.Url,
+                Title = document.Title,
+                LastCrawled = document.LastCrawl,
+                ContentHash = document.ContentHash,
+                WordCount = document.TotalWordCount,
+                Language = document.Language
+            };
+
+            context.Pages.Add(page);
+        }
+        else
+        {
+            // Remove old word frequencies/positions and page links for the page before adding new ones to avoid duplicates
+            var oldPageWordFrequencies = context.PageWordFrequencies.Where(pwf => pwf.PageId.Equals(page.Id));
+            context.PageWordFrequencies.RemoveRange(oldPageWordFrequencies);
+            
+            var oldPageWordPositions = context.PageWordPositions.Where(pwf => pwf.PageId.Equals(page.Id));
+            context.PageWordPositions.RemoveRange(oldPageWordPositions);
+            
+            var oldLinkEntries = context.PageLinks.Where(pl => pl.FromPageId.Equals(page.Id));
+            context.PageLinks.RemoveRange(oldLinkEntries);
+
+            // Update page metadata
+            page.Title = document.Title;
+            page.LastCrawled = document.LastCrawl;
+            page.ContentHash = document.ContentHash;
+            page.WordCount = document.TotalWordCount;
+            page.Language = document.Language;            
+        }
+
+        return page;
+    }
+
+
+    private async Task<Dictionary<string, Term>> SynchronizeTermsAsync(SearchDbContext context, List<string> words)
+    {
+        var existingTerms = await context.Terms
+            .Where(t => words.Contains(t.Word))
+            .ToDictionaryAsync(t => t.Word);
+
+        bool hasNewTerms = false;
+
+        foreach (var term in words)
+        {
+            // Creates new Terms if current Term did not exist. 
+            if (!existingTerms.TryGetValue(term, out var termEntity))
+            {
+                termEntity = new Term { Word = term };
+                context.Terms.Add(termEntity);
+                existingTerms[term] = termEntity;
+                hasNewTerms = true;
+            }
+        }
+
+        if (hasNewTerms) await context.SaveChangesAsync();
+        
+        return existingTerms;
+    }
+
+    private void AddWordFrequencies(
+        SearchDbContext context, 
+        int pageId, IndexDocument doc, 
+        Dictionary<string, Term> terms
+        )
+    {
+        foreach (var word in terms.Keys)
+        {
+            doc.TitleTerms.TryGetValue(word, out int titleFreq);
+            doc.HeaderTerms.TryGetValue(word, out int headerFreq);
+            doc.ContentTerms.TryGetValue(word, out int bodyFreq);
+
+            context.PageWordFrequencies.Add(new PageWordFrequency
+            {
+                PageId = pageId,
+                TermId = terms[word].Id,
+                TitleFrequency = titleFreq,
+                HeaderFrequency = headerFreq,
+                BodyFrequency = bodyFreq
+            });
+        }
+    }
+
+    private void AddWordPositions(
+        SearchDbContext context, 
+        int pageId, 
+        IndexDocument doc, 
+        Dictionary<string, Term> terms
+        )
+    {
+        var sources = new Dictionary<TermSource, IReadOnlyList<string>>
+        {
+            { TermSource.Title, doc.TitleTermPositions },
+            { TermSource.Header, doc.HeaderTermPositions },
+            { TermSource.Body, doc.ContentTermPositions }
+        };
+
+        foreach (var source in sources)
+        {
+            for (int i = 0; i < source.Value.Count; i++)
+            {
+                if (terms.TryGetValue(source.Value[i], out var termEntity))
+                {
+                    context.PageWordPositions.Add(new PageWordPosition
+                    {
+                        PageId = pageId,
+                        TermId = termEntity.Id,
+                        Position = i,
+                        TermSource = source.Key
+                    });
+                }
+            }
+        }
+    }
+
+    private async Task AddPageLinksAsync(SearchDbContext context, Page fromPage, IEnumerable<string> outgoingLinks)
+    {
+        if (outgoingLinks == null || !outgoingLinks.Any()) return;
+
+        var targetUrls = outgoingLinks.Distinct().ToList();
+        var existingPages = await context.Pages
+            .Where(p => targetUrls.Contains(p.Url))
+            .ToDictionaryAsync(p => p.Url);
+
+        foreach (var url in targetUrls)
+        {
+            if (!existingPages.TryGetValue(url, out var targetPage))
+            {
+                targetPage = new Page { Url = url, Title = "pending..", ContentHash = "", Language = "" };
+                context.Pages.Add(targetPage);
+                existingPages[url] = targetPage;
+            }
+
+            context.PageLinks.Add(new PageLink { FromPage = fromPage, ToPage = targetPage });
         }
     }
 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Core.Tests/TermPositionMapTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Core.Tests/TermPositionMapTests.cs
@@ -1,0 +1,94 @@
+using LTU.SearchEngine.Backend.Core.HelperClasses;
+
+namespace LTU.SearchEngine.Test.HelperClasses;
+
+public class TermPositionMapTests
+{
+    private readonly TermPositionMap _sut;
+
+    public TermPositionMapTests()
+    {
+        _sut = new TermPositionMap();
+    }
+
+    [Fact]
+    public void AddTerm_ShouldStoreTermsInCorrectOrder()
+    {
+        // Arrange
+        var terms = new[] { "small", "mark", "university" };
+
+        // Act
+        foreach (var term in terms)
+        {
+            _sut.AddTerm(term);
+        }
+
+        var result = _sut.ToReadOnly();
+
+        // Assert
+        Assert.Equal(3, result.Count);
+        Assert.Equal("small", result[0]);
+        Assert.Equal("mark", result[1]);
+        Assert.Equal("university", result[2]);
+    }
+
+    [Fact]
+    public void AddTerm_ShouldAllowDuplicateTerms_AndStorePositions()
+    {
+        // Arrange & Act
+        _sut.AddTerm("hello");
+        _sut.AddTerm("world");
+        _sut.AddTerm("hello");
+
+        var result = _sut.ToReadOnly();
+
+        // Assert
+        Assert.Equal(3, result.Count);
+        Assert.Equal("hello", result[0]);
+        Assert.Equal("hello", result[2]);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("NULL_TEST")]
+    public void AddTerm_InvalidInput_ShouldThrowException(string input)
+    {
+
+        string? invalidTerm = input.Equals("NULL_TEST") ? null : input;
+
+        // Act & Assert
+        if (invalidTerm == null)
+        {
+            Assert.Throws<ArgumentNullException>(() => _sut.AddTerm(invalidTerm!));
+        }
+        else
+        {
+            Assert.Throws<ArgumentException>(() => _sut.AddTerm(invalidTerm));
+        }
+    }
+
+    [Fact]
+    public void ToReadOnly_ShouldReturnImmutableWrapper()
+    {
+        // Arrange
+        _sut.AddTerm("test");
+        var readOnlyList = _sut.ToReadOnly();
+
+        // Act & Assert
+        Assert.False(readOnlyList is List<string>);
+    }
+
+    [Fact]
+    public void AddTerm_AfterToReadOnly_ShouldStillUpdateInternalState()
+    {
+        // Arrange
+        var resultBefore = _sut.ToReadOnly();
+        
+        // Act
+        _sut.AddTerm("new");
+
+        // Assert
+        Assert.Contains("new", resultBefore); 
+    }
+}

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/HelperClasses/IndexDocumentBuilder.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/HelperClasses/IndexDocumentBuilder.cs
@@ -7,6 +7,9 @@ public static class IndexDocumentBuilder
         IReadOnlyDictionary<string, int> titleTerms, 
         IReadOnlyDictionary<string, int> headerTerms, 
         IReadOnlyDictionary<string, int> contentTerms,
+        IReadOnlyList<string> titleTermPositions, 
+        IReadOnlyList<string> headerTermPositions, 
+        IReadOnlyList<string> contentTermPositions,  
         string url = "http://test.html", 
         string title = "Test Title",
         string language = "sv",
@@ -24,6 +27,9 @@ public static class IndexDocumentBuilder
             titleTerms: titleTerms, 
             headerTerms: headerTerms, 
             contentTerms: contentTerms,
+            titleTermPositions: titleTermPositions, 
+            headerTermPositions: headerTermPositions, 
+            contentTermPositions: contentTermPositions,  
             contentHash: contentHash,
             lastCrawl: tempCrawl
         );
@@ -42,6 +48,9 @@ public static class IndexDocumentBuilder
         var dummyTitleTerms = new Dictionary<string, int> { { "titleWord", 1 } };
         var dummyHeaderTerms = new Dictionary<string, int> { { "headerWord", 1 } };
         var dummyContentTerms = new Dictionary<string, int> { { "contentWord", 1 } };
+        var dummyTitleTermPositions = new List<string> { { "titleWord"} };
+        var dummyHeaderTermPositions = new List<string> { { "headerWord" } };
+        var dummyContentTermPositions = new List<string> { { "contentWord" } };
 
         return new IndexDocument(
             url: url, 
@@ -51,6 +60,9 @@ public static class IndexDocumentBuilder
             titleTerms: dummyTitleTerms, 
             headerTerms: dummyHeaderTerms, 
             contentTerms: dummyContentTerms,
+            titleTermPositions: dummyTitleTermPositions, 
+            headerTermPositions: dummyHeaderTermPositions, 
+            contentTermPositions: dummyContentTermPositions, 
             contentHash: contentHash,
             lastCrawl: tempCrawl
         );

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Indexing.Tests/IndexingPipelineTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Indexing.Tests/IndexingPipelineTests.cs
@@ -293,6 +293,9 @@ public class IndexingPipelineTests
         Assert.Equal(1, document.ContentTerms["run"]);
         Assert.Single(document.ContentTerms);
 
+        Assert.Single(document.ContentTermPositions); 
+        Assert.Equal("run", document.ContentTermPositions[0]);
+
         _normalizerMock.Verify(n => n.Normalize(It.IsAny<string>(), "en"), Times.Exactly(2));
     }
 
@@ -372,5 +375,7 @@ public class IndexingPipelineTests
         Assert.DoesNotContain("title", document.ContentTermPositions);
         Assert.DoesNotContain("header", document.ContentTermPositions);
     }
+
+
 }
 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Indexing.Tests/IndexingPipelineTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Indexing.Tests/IndexingPipelineTests.cs
@@ -340,5 +340,37 @@ public class IndexingPipelineTests
         Assert.Equal("second", document.ContentTermPositions[1]);
         Assert.Equal("third", document.ContentTermPositions[2]);
     }
+
+    [Fact]
+    public void Transform_TermsInDifferentSources_ShouldHaveSeparatePositionLists()
+    {
+        // Arrange 
+        _normalizerMock
+            .Setup(n => n.Normalize(It.IsAny<string>(), "en"))
+            .Returns<string, string>((s, l) => s.ToLower());
+        
+        var crawlResult = CreateCrawlResult(new List<IndexedTerm>
+        {
+            new IndexedTerm("title", TermSource.Title),
+            new IndexedTerm("header", TermSource.Header),
+            new IndexedTerm("body", TermSource.Body)
+        });
+
+        // Act 
+        var document = _pipeline.Transform(crawlResult);
+
+        // Assert
+        Assert.Contains("title", document.TitleTermPositions);
+        Assert.DoesNotContain("header", document.TitleTermPositions);
+        Assert.DoesNotContain("body", document.TitleTermPositions);
+        
+        Assert.Contains("header", document.HeaderTermPositions);
+        Assert.DoesNotContain("title", document.HeaderTermPositions);
+        Assert.DoesNotContain("body", document.HeaderTermPositions);
+        
+        Assert.Contains("body", document.ContentTermPositions);
+        Assert.DoesNotContain("title", document.ContentTermPositions);
+        Assert.DoesNotContain("header", document.ContentTermPositions);
+    }
 }
 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Indexing.Tests/IndexingPipelineTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Indexing.Tests/IndexingPipelineTests.cs
@@ -315,5 +315,30 @@ public class IndexingPipelineTests
 
         _normalizerMock.Verify(n => n.Normalize(It.IsAny<string>(), "en"), Times.Never());
     }
+
+    [Fact]
+    public void Transform_GivenMultipleTerms_ShouldPreservePositionOrder()
+    {
+        // Arrange 
+        _normalizerMock
+            .Setup(n => n.Normalize(It.IsAny<string>(), "en"))
+            .Returns<string, string>((s, l) => s.ToLower());
+        
+        var crawlResult = CreateCrawlResult(new List<IndexedTerm>
+        {
+            new IndexedTerm("First", TermSource.Body),
+            new IndexedTerm("Second", TermSource.Body),
+            new IndexedTerm("Third", TermSource.Body)
+        });
+
+        // Act 
+        var document = _pipeline.Transform(crawlResult);
+
+        // Assert
+        Assert.Equal(3, document.ContentTermPositions.Count);
+        Assert.Equal("first", document.ContentTermPositions[0]);
+        Assert.Equal("second", document.ContentTermPositions[1]);
+        Assert.Equal("third", document.ContentTermPositions[2]);
+    }
 }
 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Indexing.Tests/Model/IndexDocumentTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Indexing.Tests/Model/IndexDocumentTests.cs
@@ -99,8 +99,6 @@ public class IndexDocumentTests
         Assert.True(sut.ContentTerms.ContainsKey("dark"));
         Assert.Equal(1, sut.ContentTerms["dark"]);
         Assert.Equal("dark", contentTermPositions[2]);
-
-        
     }
 
 
@@ -154,4 +152,5 @@ public class IndexDocumentTests
         // Assert
         Assert.Equal(0, result);
     }
+    
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Indexing.Tests/Model/IndexDocumentTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Indexing.Tests/Model/IndexDocumentTests.cs
@@ -40,11 +40,11 @@ public class IndexDocumentTests
         var language = "sv";
         var links = new List<string> { "dummyLink" };
         var titleTerms = new Dictionary<string, int> { { "ltu", 1 } };
-        var headerTerms = new Dictionary<string, int> { { "fortuning", 2 } };
-        var contentTerms = new Dictionary<string, int> { { "student", 5 } };
-        var titleTermPositions = new List<string> { { "ltu" } };
-        var headerTermPositions = new List<string> { { "fortuning" } };
-        var contentTermPositions = new List<string> { { "student" } };
+        var headerTerms = new Dictionary<string, int> { { "fortuning", 1 }, { "fun", 1 }, { "fast", 1} };
+        var contentTerms = new Dictionary<string, int> { { "student", 2 }, { "mark", 1 }, { "dark", 1 }};
+        var titleTermPositions = new List<string> { "ltu" };
+        var headerTermPositions = new List<string> {  "fortuning", "fun", "fast" };
+        var contentTermPositions = new List<string> { "student", "mark", "dark", "student" };
         var hash = "ABC-123";
         var now = DateTime.UtcNow;
 
@@ -70,9 +70,39 @@ public class IndexDocumentTests
         Assert.Equal(language, sut.Language);
         Assert.Equal(hash, sut.ContentHash);
         Assert.Equal(now, sut.LastCrawl);
+
         Assert.True(sut.TitleTerms.ContainsKey("ltu"));
         Assert.Equal(1, sut.TitleTerms["ltu"]);
+        Assert.Equal("ltu", titleTermPositions[0]);
+
+        Assert.True(sut.HeaderTerms.ContainsKey("fortuning"));
+        Assert.Equal(1, sut.HeaderTerms["fortuning"]);
+        Assert.Equal("fortuning", headerTermPositions[0]);
+        
+        Assert.True(sut.HeaderTerms.ContainsKey("fun"));
+        Assert.Equal(1, sut.HeaderTerms["fun"]);
+        Assert.Equal("fun", headerTermPositions[1]);
+        
+        Assert.True(sut.HeaderTerms.ContainsKey("fast"));
+        Assert.Equal(1, sut.HeaderTerms["fast"]);
+        Assert.Equal("fast", headerTermPositions[2]);
+
+        Assert.True(sut.ContentTerms.ContainsKey("student"));
+        Assert.Equal(2, sut.ContentTerms["student"]);
+        Assert.Equal("student", contentTermPositions[0]);
+        Assert.Equal("student", contentTermPositions[3]);
+        
+        Assert.True(sut.ContentTerms.ContainsKey("mark"));
+        Assert.Equal(1, sut.ContentTerms["mark"]);
+        Assert.Equal("mark", contentTermPositions[1]);
+        
+        Assert.True(sut.ContentTerms.ContainsKey("dark"));
+        Assert.Equal(1, sut.ContentTerms["dark"]);
+        Assert.Equal("dark", contentTermPositions[2]);
+
+        
     }
+
 
     [Fact]
     public void TotalWordCount_ShouldCalculateSumOfAllFrequencies()

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Indexing.Tests/Model/IndexDocumentTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Indexing.Tests/Model/IndexDocumentTests.cs
@@ -9,7 +9,10 @@ public class IndexDocumentTests
         IEnumerable<string> outgoingLinks,
         Dictionary<string, int> titleTerms, 
         Dictionary<string, int> headerTerms, 
-        Dictionary<string, int> contentTerms
+        Dictionary<string, int> contentTerms,
+        List<string> titleTermsPositions, 
+        List<string> headerTermsPositions, 
+        List<string> contentTermPositions
         )
     {
         return IndexDocumentBuilder.BuildIndexDocument(
@@ -20,6 +23,9 @@ public class IndexDocumentTests
             titleTerms: titleTerms,
             headerTerms: headerTerms, 
             contentTerms: contentTerms, 
+            titleTermPositions: titleTermsPositions,
+            headerTermPositions: headerTermsPositions,
+            contentTermPositions: contentTermPositions,
             contentHash: "hash", 
             lastCrawl: DateTime.UtcNow
         );
@@ -36,6 +42,9 @@ public class IndexDocumentTests
         var titleTerms = new Dictionary<string, int> { { "ltu", 1 } };
         var headerTerms = new Dictionary<string, int> { { "fortuning", 2 } };
         var contentTerms = new Dictionary<string, int> { { "student", 5 } };
+        var titleTermPositions = new List<string> { { "ltu" } };
+        var headerTermPositions = new List<string> { { "fortuning" } };
+        var contentTermPositions = new List<string> { { "student" } };
         var hash = "ABC-123";
         var now = DateTime.UtcNow;
 
@@ -47,7 +56,10 @@ public class IndexDocumentTests
             outgoingLinks: links,
             titleTerms: titleTerms, 
             headerTerms: headerTerms, 
-            contentTerms: contentTerms, 
+            contentTerms: contentTerms,
+            titleTermPositions: titleTermPositions,
+            headerTermPositions: headerTermPositions,
+            contentTermPositions: contentTermPositions, 
             contentHash: hash, 
             lastCrawl: now
         );
@@ -70,8 +82,19 @@ public class IndexDocumentTests
         var titleTerms = new Dictionary<string, int> { { "a", 2 }, { "b", 3 } }; // 5 words
         var headerTerms = new Dictionary<string, int> { { "c", 10 } };            // 10 words
         var contentTerms = new Dictionary<string, int> { { "d", 1 }, { "e", 4 } }; // 5 words
+        var titleTermPositions = new List<string> { { "ltu" } };
+        var headerTermPositions = new List<string> { { "fortuning" } };
+        var contentTermPositions = new List<string> { { "student" } };
         
-        var doc = CreateTestDocument(outgoingLinks, titleTerms, headerTerms, contentTerms);
+        var doc = CreateTestDocument(
+            outgoingLinks, 
+            titleTerms, 
+            headerTerms, 
+            contentTerms,
+            titleTermPositions,
+            headerTermPositions,
+            contentTermPositions
+        );
 
         // Act
         var result = doc.TotalWordCount;
@@ -86,8 +109,14 @@ public class IndexDocumentTests
     {
         // Arrange
         var outgoingLinks = new List<string> { "dummyLink" };
-        var empty = new Dictionary<string, int>();
-        var doc = CreateTestDocument(outgoingLinks, empty, empty, empty);
+        var emptyDictionary = new Dictionary<string, int>();
+        var emptyList = new List<string>();
+        
+        var doc = CreateTestDocument(
+            outgoingLinks, 
+            emptyDictionary, emptyDictionary, emptyDictionary, 
+            emptyList, emptyList, emptyList
+        );
 
         // Act
         var result = doc.TotalWordCount;

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/IntegrationTesting/CrawlerIntegrationTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/IntegrationTesting/CrawlerIntegrationTests.cs
@@ -597,7 +597,7 @@ public class CrawlerIntegrationTests : IClassFixture<WebApplicationFactory<Progr
             () => indexedPages.Count > 1, 
             maxWaitMs: 10000
         );
-        await TestWait.UntilTrue(maxWaitMs: 1000);
+        //await TestWait.UntilTrue(maxWaitMs: 1000);
         
         cts.Cancel();
         

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/SqlIndexRepositoryTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/SqlIndexRepositoryTests.cs
@@ -53,7 +53,10 @@ public class SqlIndexRepositoryTests : IDisposable
             title: "LTU Start",
             titleTerms: new Dictionary<string, int>(){{"student", 1},{"ltu", 1}},
             headerTerms: new Dictionary<string, int>(){{"student", 3}},
-            contentTerms: new Dictionary<string, int>(){{"utbildning", 2}}
+            contentTerms: new Dictionary<string, int>(){{"utbildning", 2}},
+            titleTermPositions: new List<string>(){{"student"},{"ltu"}},
+            headerTermPositions: new List<string>(){{"student"}},
+            contentTermPositions: new List<string>(){{"utbildning"}}
         );
 
         // Act
@@ -239,6 +242,9 @@ public class SqlIndexRepositoryTests : IDisposable
             titleTerms: new Dictionary<string, int> { { oldTitle, 1 } },
             headerTerms: new Dictionary<string, int> { { oldHeader, 1 } },
             contentTerms: new Dictionary<string, int> { { oldContent, 1 } },
+            titleTermPositions: new List<string> { "term" },
+            headerTermPositions: new List<string> { "term" },
+            contentTermPositions: new List<string> { "term" },
             outgoingLinks: new List<string> { "dummyLink" }
         );
 
@@ -249,6 +255,9 @@ public class SqlIndexRepositoryTests : IDisposable
             titleTerms: new Dictionary<string, int> { { newTitle, 1 } },
             headerTerms: new Dictionary<string, int> { { oldHeader, 1 } },
             contentTerms: new Dictionary<string, int> { { oldContent, 1 } },
+            titleTermPositions: new List<string> { "term" },
+            headerTermPositions: new List<string> { "term" },
+            contentTermPositions: new List<string> { "term" },
             outgoingLinks: new List<string> { "dummyLink" }
         );
 
@@ -284,6 +293,9 @@ public class SqlIndexRepositoryTests : IDisposable
             titleTerms: new Dictionary<string, int>(),
             headerTerms: new Dictionary<string, int>(),
             contentTerms: new Dictionary<string, int>(),
+            titleTermPositions: new List<string>(),
+            headerTermPositions: new List<string>(),
+            contentTermPositions: new List<string>(),
             outgoingLinks: new List<string> { targetUrl }
         );
 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/SqlIndexRepositoryTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/SqlIndexRepositoryTests.cs
@@ -1,4 +1,5 @@
 ﻿using LTU.SearchEngine.Backend.Core.Entities;
+using LTU.SearchEngine.Backend.Core.Model;
 using LTU.SearchEngine.Backend.Core.Model.Entities;
 using LTU.SearchEngine.Infrastructure.Data;
 using LTU.SearchEngine.Infrastructure.Repositories;
@@ -359,6 +360,43 @@ public class SqlIndexRepositoryTests : IDisposable
         Assert.Equal("newTerm", positions[0].Term.Word);
         Assert.DoesNotContain(positions, pwp => pwp.Term.Word.Equals("oldTerm"));
     }
+
+
+
+    [Fact]
+    public async Task AddDocumentAsync_SameWordAtSamePositionInDifferentSources_ShouldSaveAll()
+    {
+         // Arrange 
+        var url = "http://cleanup-pos.se";
+        
+        var doc1 = IndexDocumentBuilder.BuildIndexDocument(
+            url: url, 
+            titleTerms: new Dictionary<string, int> { {"term", 1} },
+            headerTerms: new Dictionary<string, int> { {"term", 2} },
+            contentTerms: new Dictionary<string, int> { {"term", 1} },
+            titleTermPositions: new List<string> { "term" },
+            headerTermPositions: new List<string> { "term", "term" },
+            contentTermPositions: new List<string> { "term" },
+            outgoingLinks: new List<string>() 
+        );
+
+        // Act 
+        await _sut.AddDocumentAsync(doc1);
+
+        // Assert 
+        await using var context = await _factory.CreateDbContextAsync();
+
+        var positions = await context.PageWordPositions
+            .Where(pwp => pwp.Page.Url.Equals(url) && pwp.Term.Word.Equals("term"))
+            .ToListAsync();
+
+        Assert.Equal(4, positions.Count);
+        Assert.Contains(positions, p => p.TermSource.Equals(TermSource.Title) && p.Position.Equals(0));    
+        Assert.Contains(positions, p => p.TermSource.Equals(TermSource.Header) && p.Position.Equals(1));    
+        Assert.Contains(positions, p => p.TermSource.Equals(TermSource.Body) && p.Position.Equals(0));    
+    }
+
+
 
     public void Dispose()
     {

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/SqlIndexRepositoryTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/SqlIndexRepositoryTests.cs
@@ -314,6 +314,51 @@ public class SqlIndexRepositoryTests : IDisposable
     }
 
 
+    [Fact]
+    public async Task AddDocumentAsync_ReIndexing_ShouldCleanupOldPositions()
+    {
+        // Arrange 
+        var url = "http://cleanup-pos.se";
+        
+        var doc1 = IndexDocumentBuilder.BuildIndexDocument(
+            url: url, 
+            titleTerms: new Dictionary<string, int> { {"oldTerm", 1} },
+            headerTerms: new Dictionary<string, int>(),
+            contentTerms: new Dictionary<string, int>(),
+            titleTermPositions: new List<string> { "oldTerm" },
+            headerTermPositions: new List<string>(),
+            contentTermPositions: new List<string>(),
+            outgoingLinks: new List<string>() 
+        );
+
+        var doc2 = IndexDocumentBuilder.BuildIndexDocument(
+            url: url, 
+            titleTerms: new Dictionary<string, int>{ {"newTerm", 1} },
+            headerTerms: new Dictionary<string, int>(),
+            contentTerms: new Dictionary<string, int>(),
+            titleTermPositions: new List<string> { "newTerm" },
+            headerTermPositions: new List<string>(),
+            contentTermPositions: new List<string>(),
+            outgoingLinks: new List<string>() 
+        );
+
+        await _sut.AddDocumentAsync(doc1);
+
+        // Act 
+        await _sut.AddDocumentAsync(doc2);
+
+        // Assert 
+        await using var context = await _factory.CreateDbContextAsync();
+        
+        var positions = await context.PageWordPositions
+            .Include(pwp => pwp.Term)
+            .Where(pwp => pwp.Page.Url.Equals(url))
+            .ToListAsync();
+
+        Assert.Single(positions);
+        Assert.Equal("newTerm", positions[0].Term.Word);
+        Assert.DoesNotContain(positions, pwp => pwp.Term.Word.Equals("oldTerm"));
+    }
 
     public void Dispose()
     {

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/SqlIndexRepositoryTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/SqlIndexRepositoryTests.cs
@@ -397,6 +397,21 @@ public class SqlIndexRepositoryTests : IDisposable
     }
 
 
+    [Fact]
+    public async Task AddDocumentAsync_WhenErrorOccurs_ShouldRollbackEverything()
+    {
+        // Arrange
+        var invalidDoc = IndexDocumentBuilder.BuildIndexDocument(url: null!);
+
+        // Act & Assert
+        await Assert.ThrowsAnyAsync<Exception>(() => _sut.AddDocumentAsync(invalidDoc));
+
+        await using var context = await _factory.CreateDbContextAsync();
+        var pageCount = await context.Pages.CountAsync();
+        
+        Assert.Equal(0, pageCount);
+    }
+
 
     public void Dispose()
     {


### PR DESCRIPTION
What has been implemented.
- New entity `PageWordPosition`
  - **multi-Key values** PageId, TermId, Position, TermSource
  - has a one to many relationship with Page and Term
- `ITermMapper` extracted from `TermFrequencyMap` and implemented `TermPositionMap` derived from the interface.
- `AddDocumentAsync` and  `IndexDocument ` expanded to include position mapping
- Existing tests have been updated to accommodate the changes.
  - Missing tests to tests the added functionality were added as well. 
