### PR TITLE
128 update tableentity terms to include languagecode

### DIFF
--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/Entities/Term.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/Entities/Term.cs
@@ -3,9 +3,8 @@
 public class Term
 {
     public int Id { get; set; }
-
     public string Word { get; set; } = string.Empty;
-
+    public string LanguageCode { get; set; } = string.Empty;
     public double IdfScore { get; set; }
 
     public ICollection<PageWordFrequency> PageFrequencies { get; set; } = new List<PageWordFrequency>();

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Migrations/20260415090044_newMigration.Designer.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Migrations/20260415090044_newMigration.Designer.cs
@@ -12,7 +12,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace LTU.SearchEngine.Infrastructure.Migrations
 {
     [DbContext(typeof(SearchDbContext))]
-    [Migration("20260414091031_newMigration")]
+    [Migration("20260415090044_newMigration")]
     partial class newMigration
     {
         /// <inheritdoc />
@@ -142,6 +142,10 @@ namespace LTU.SearchEngine.Infrastructure.Migrations
 
                     b.Property<double>("IdfScore")
                         .HasColumnType("float");
+
+                    b.Property<string>("LanguageCode")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
 
                     b.Property<string>("Word")
                         .IsRequired()

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Migrations/20260415090044_newMigration.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Migrations/20260415090044_newMigration.cs
@@ -38,6 +38,7 @@ namespace LTU.SearchEngine.Infrastructure.Migrations
                     Id = table.Column<int>(type: "int", nullable: false)
                         .Annotation("SqlServer:Identity", "1, 1"),
                     Word = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    LanguageCode = table.Column<string>(type: "nvarchar(max)", nullable: false),
                     IdfScore = table.Column<double>(type: "float", nullable: false)
                 },
                 constraints: table =>

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Migrations/SearchDbContextModelSnapshot.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Migrations/SearchDbContextModelSnapshot.cs
@@ -140,6 +140,10 @@ namespace LTU.SearchEngine.Infrastructure.Migrations
                     b.Property<double>("IdfScore")
                         .HasColumnType("float");
 
+                    b.Property<string>("LanguageCode")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
                     b.Property<string>("Word")
                         .IsRequired()
                         .HasColumnType("nvarchar(450)");

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Repositories/SqlIndexRepository.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Repositories/SqlIndexRepository.cs
@@ -40,7 +40,7 @@ public class SqlIndexRepository : IIndexRepository
                 .ToList();
 
             // Retrieve any Terms that already exist in the database.
-            var termLookup = await SynchronizeTermsAsync(context, allUniqueTerms);
+            var termLookup = await SynchronizeTermsAsync(context, allUniqueTerms, page.Language);
 
             AddWordFrequencies(context, page.Id, document, termLookup);
             AddWordPositions(context, page.Id, document, termLookup);
@@ -101,7 +101,11 @@ public class SqlIndexRepository : IIndexRepository
     }
 
 
-    private async Task<Dictionary<string, Term>> SynchronizeTermsAsync(SearchDbContext context, List<string> words)
+    private async Task<Dictionary<string, Term>> SynchronizeTermsAsync(
+        SearchDbContext context, 
+        List<string> words, 
+        string language
+        )
     {
         var existingTerms = await context.Terms
             .Where(t => words.Contains(t.Word))
@@ -114,7 +118,7 @@ public class SqlIndexRepository : IIndexRepository
             // Creates new Terms if current Term did not exist. 
             if (!existingTerms.TryGetValue(term, out var termEntity))
             {
-                termEntity = new Term { Word = term };
+                termEntity = new Term { Word = term, LanguageCode = language };
                 context.Terms.Add(termEntity);
                 existingTerms[term] = termEntity;
                 hasNewTerms = true;
@@ -125,6 +129,7 @@ public class SqlIndexRepository : IIndexRepository
         
         return existingTerms;
     }
+
 
     private void AddWordFrequencies(
         SearchDbContext context, 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/IntegrationTesting/IndexerIntegrationTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/IntegrationTesting/IndexerIntegrationTests.cs
@@ -143,10 +143,7 @@ public class IndexerIntegrationTests : IClassFixture<WebApplicationFactory<Progr
 
         await ASecondsWait();
 
-
         cts.Cancel();
-
-
 
         // Assert 
         // Each unique term is stored exactly once in the index.
@@ -395,14 +392,15 @@ public class IndexerIntegrationTests : IClassFixture<WebApplicationFactory<Progr
 
 
     [Theory]
-    [InlineData("/IndexerNormalizingTextRun.html", "run", 5)]
-    [InlineData("/IndexerNormalizingTextSwim.html", "swim", 5)]
-    [InlineData("/IndexerNormalizingTextCat.html", "cat", 5)]
-    [InlineData("/IndexerNormalizingTextHäst.html", "häst", 8)]
-    [InlineData("/IndexerNormalizingTextArt.html", "art", 5)]
-    [InlineData("/IndexerNormalizingTextEat.html", "eat", 5)]
+    [InlineData("/IndexerNormalizingTextRun.html", "run", 5, "en")]
+    [InlineData("/IndexerNormalizingTextSwim.html", "swim", 5, "en")]
+    [InlineData("/IndexerNormalizingTextCat.html", "cat", 5, "en")]
+    [InlineData("/IndexerNormalizingTextEat.html", "eat", 5, "en")]
+    [InlineData("/IndexerNormalizingTextHäst.html", "häst", 8, "sv")]
+    [InlineData("/IndexerNormalizingTextArt.html", "art", 5, "sv")]
     [Trait("TestCase", "TC-FRQ-2007")]
-    public async Task Indexer_TextIsNormalizedOnIndex(string url, string expectedTerm, int expectedFrequency)
+    public async Task Indexer_TextIsNormalizedOnIndex(
+        string url, string expectedTerm, int expectedFrequency, string languageCode)
     {
         // Arrange
         string seedUrl = $"http://localhost{url}";
@@ -435,8 +433,14 @@ public class IndexerIntegrationTests : IClassFixture<WebApplicationFactory<Progr
             .Include(pwf => pwf.Term)
             .ToListAsync(); 
 
+        var termLanguage = await dbContext.Terms
+                .Where(t => t.Word.Equals(expectedTerm))
+                .Select(t => t.LanguageCode)
+                .FirstOrDefaultAsync();
+
         Assert.Equal(expectedTerm, termPageWordLink.First().Term.Word);
         Assert.Equal(expectedFrequency, termPageWordLink.First().HeaderFrequency);
+        Assert.Equal(languageCode, termLanguage);
     }
 
     private static async Task ASecondsWait()

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/SqlIndexRepositoryTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/SqlIndexRepositoryTests.cs
@@ -52,6 +52,7 @@ public class SqlIndexRepositoryTests : IDisposable
             outgoingLinks: new List<string> { "dummyLink" },
             url: "https://ltu.se", 
             title: "LTU Start",
+            language: "sv",
             titleTerms: new Dictionary<string, int>(){{"student", 1},{"ltu", 1}},
             headerTerms: new Dictionary<string, int>(){{"student", 3}},
             contentTerms: new Dictionary<string, int>(){{"utbildning", 2}},
@@ -76,6 +77,7 @@ public class SqlIndexRepositoryTests : IDisposable
         // Check that "student" was merged to frequency 4
         var studentTerm = await context.Terms.FirstOrDefaultAsync(t => t.Word == "student");
         Assert.NotNull(studentTerm);
+        Assert.Equal("sv", studentTerm.LanguageCode);
 
         var frequency = await context.PageWordFrequencies
             .FirstOrDefaultAsync(pwf => pwf.PageId == savedPage.Id && pwf.TermId == studentTerm.Id);


### PR DESCRIPTION
Work conducted: 
- The requested changes to the Term entity has been implemented.
- SqlIndexRepository now also set on Term creation.
- SqlIndexRepositoryTests updated to include language in tests.
- IndexerIntegrationTests also updated to test for language. 
