### PR TITLE
137 the crawler no longer works as it should go trough the crawling process to see why that is

### DIFF
--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/SemaphoreProvider.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/SemaphoreProvider.cs
@@ -29,6 +29,8 @@ namespace LTU.SearchEngine.Backend.Core;
 public class SemaphoreProvider
 {
 	private readonly ConcurrentDictionary<string, SemaphoreSlim> _semaphores = new();
+	private readonly SemaphoreSlim _termSyncSemaphore = new SemaphoreSlim(1, 1);
+	private readonly SemaphoreSlim _pageSyncSemaphore = new SemaphoreSlim(1, 1);
 
 	/// <summary>
 	/// Gets an existing semaphore for the specified key, or creates a new one if it does not exist.
@@ -50,4 +52,8 @@ public class SemaphoreProvider
 	/// </remarks>
 	public SemaphoreSlim GetOrAddSemaphore(string key, int maxConcurrency) => 
 		_semaphores.GetOrAdd(key, _ => new SemaphoreSlim(maxConcurrency));
+
+	public SemaphoreSlim GetTermSyncSemaphore() => _termSyncSemaphore;
+
+	public SemaphoreSlim GetPageSyncSemaphore() => _pageSyncSemaphore;
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/TextNormalization/LuceneAnalyzerFilter.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/TextNormalization/LuceneAnalyzerFilter.cs
@@ -27,7 +27,11 @@ public class LuceneAnalyzerFilter : ITextFilter
 
         if (tokenStream.IncrementToken())
         {
-            var result = termAttr.ToString();
+            var result = termAttr
+                .ToString()
+                .ToLowerInvariant()
+                .Normalize(System.Text.NormalizationForm.FormC);
+                
             tokenStream.End();
             return string.IsNullOrWhiteSpace(result) ? null : result;
         }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Configurations/TermConfiguration.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Configurations/TermConfiguration.cs
@@ -8,6 +8,9 @@ public class TermConfiguration : IEntityTypeConfiguration<Term>
 {
     public void Configure(EntityTypeBuilder<Term> builder)
     {
-        builder.HasIndex(t => t.Word).IsUnique();
+        
+        builder
+            .HasIndex(t => new { t.Word, t.LanguageCode })
+            .IsUnique();
     }
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/HapHtmlParser.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/HapHtmlParser.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Diagnostics;
+using System.Text.RegularExpressions;
 using HtmlAgilityPack;
 using LTU.SearchEngine.Backend.Core;
 using LTU.SearchEngine.Backend.Core.Exceptions;
@@ -66,7 +67,14 @@ public class HapHtmlParser : IHtmlParser
                 
                 if (isHttp && IsSupportedResourceType(resultUri))
                 {
-                    string url = resultUri.AbsoluteUri;
+                    // string url = resultUri.AbsoluteUri;
+                    string url = resultUri.GetLeftPart(UriPartial.Path).ToLowerInvariant();
+
+                    // removes trailing backslashes making /start and /start/ count as the same 
+                    if (url.EndsWith('/') && url.Length > (resultUri.Scheme.Length + 3 + resultUri.Host.Length)) 
+                    {
+                        url = url.TrimEnd('/');
+                    }
 
                     try
                     {
@@ -176,11 +184,11 @@ public class HapHtmlParser : IHtmlParser
     
     private bool IsSupportedResourceType(Uri uri)
     {
-        string path = uri.AbsolutePath;
+        string path = uri.AbsolutePath.ToLowerInvariant();
         string extension = Path.GetExtension(path);
 
-        // If path == /, regard it as html (i,e,. http://domain.se/)
-        if (string.IsNullOrEmpty(path) || path.Equals("/")) return true;
+        // If no path regard it as html (i,e,. http://domain.se/)
+        if (string.IsNullOrEmpty(extension)) return true;
 
         return AllowedExtensions.Any(ext => extension.EndsWith(ext, StringComparison.OrdinalIgnoreCase));
     }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Migrations/20260416141136_newMigration.Designer.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Migrations/20260416141136_newMigration.Designer.cs
@@ -12,7 +12,7 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace LTU.SearchEngine.Infrastructure.Migrations
 {
     [DbContext(typeof(SearchDbContext))]
-    [Migration("20260415090044_newMigration")]
+    [Migration("20260416141136_newMigration")]
     partial class newMigration
     {
         /// <inheritdoc />
@@ -145,7 +145,7 @@ namespace LTU.SearchEngine.Infrastructure.Migrations
 
                     b.Property<string>("LanguageCode")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("Word")
                         .IsRequired()
@@ -153,7 +153,7 @@ namespace LTU.SearchEngine.Infrastructure.Migrations
 
                     b.HasKey("Id");
 
-                    b.HasIndex("Word")
+                    b.HasIndex("Word", "LanguageCode")
                         .IsUnique();
 
                     b.ToTable("Terms");

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Migrations/20260416141136_newMigration.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Migrations/20260416141136_newMigration.cs
@@ -38,7 +38,7 @@ namespace LTU.SearchEngine.Infrastructure.Migrations
                     Id = table.Column<int>(type: "int", nullable: false)
                         .Annotation("SqlServer:Identity", "1, 1"),
                     Word = table.Column<string>(type: "nvarchar(450)", nullable: false),
-                    LanguageCode = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    LanguageCode = table.Column<string>(type: "nvarchar(450)", nullable: false),
                     IdfScore = table.Column<double>(type: "float", nullable: false)
                 },
                 constraints: table =>
@@ -146,9 +146,9 @@ namespace LTU.SearchEngine.Infrastructure.Migrations
                 column: "TermId");
 
             migrationBuilder.CreateIndex(
-                name: "IX_Terms_Word",
+                name: "IX_Terms_Word_LanguageCode",
                 table: "Terms",
-                column: "Word",
+                columns: new[] { "Word", "LanguageCode" },
                 unique: true);
         }
 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Migrations/SearchDbContextModelSnapshot.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Migrations/SearchDbContextModelSnapshot.cs
@@ -142,7 +142,7 @@ namespace LTU.SearchEngine.Infrastructure.Migrations
 
                     b.Property<string>("LanguageCode")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("nvarchar(450)");
 
                     b.Property<string>("Word")
                         .IsRequired()
@@ -150,7 +150,7 @@ namespace LTU.SearchEngine.Infrastructure.Migrations
 
                     b.HasKey("Id");
 
-                    b.HasIndex("Word")
+                    b.HasIndex("Word", "LanguageCode")
                         .IsUnique();
 
                     b.ToTable("Terms");

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Repositories/SqlIndexRepository.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Repositories/SqlIndexRepository.cs
@@ -5,7 +5,7 @@ using LTU.SearchEngine.Backend.Core.Model.Entities;
 using LTU.SearchEngine.Backend.Core.Model.ValueObjects.QueryNodes;
 using LTU.SearchEngine.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
-using System.Text;
+
 
 namespace LTU.SearchEngine.Infrastructure.Repositories;
 
@@ -18,7 +18,6 @@ public class SqlIndexRepository : IIndexRepository
     private readonly IDbContextFactory<SearchDbContext> _factory;
     private readonly SemaphoreProvider _semaphoreProvider;
 
-    public SqlIndexRepository(IDbContextFactory<SearchDbContext> factory)
     public SqlIndexRepository(IDbContextFactory<SearchDbContext> factory, SemaphoreProvider semaphoreProvider)
     {
         _factory = factory;
@@ -29,33 +28,10 @@ public class SqlIndexRepository : IIndexRepository
     // Merge words from the title, headers and body content.
     public async Task AddDocumentAsync(IndexDocument document)
     {
-
-        // Normalize all terms to ensure consistency
-        var normalizedTitleTerms = document.TitleTerms.ToDictionary(
-            kvp => kvp.Key.ToLowerInvariant().Normalize(NormalizationForm.FormC), 
-            kvp => kvp.Value);
-        var normalizedHeaderTerms = document.HeaderTerms.ToDictionary(
-            kvp => kvp.Key.ToLowerInvariant().Normalize(NormalizationForm.FormC), 
-            kvp => kvp.Value);
-        var normalizedContentTerms = document.ContentTerms.ToDictionary(
-            kvp => kvp.Key.ToLowerInvariant().Normalize(NormalizationForm.FormC), 
-            kvp => kvp.Value);
-        var normalizedTitleTermPositions = document.TitleTermPositions
-            .Select(w => w.ToLowerInvariant().Normalize(NormalizationForm.FormC))
+        var allUniqueTerms = document.TitleTerms.Keys
+            .Union(document.HeaderTerms.Keys)
+            .Union(document.ContentTerms.Keys)
             .ToList();
-        var normalizedHeaderTermPositions = document.HeaderTermPositions
-            .Select(w => w.ToLowerInvariant().Normalize(NormalizationForm.FormC))
-            .ToList();
-        var normalizedContentTermPositions = document.ContentTermPositions
-            .Select(w => w.ToLowerInvariant().Normalize(NormalizationForm.FormC))
-            .ToList();
-
-        var allUniqueTerms = normalizedTitleTerms.Keys
-            .Union(normalizedHeaderTerms.Keys)
-            .Union(normalizedContentTerms.Keys)
-            .ToList();
-
-
 
         await using var context = await _factory.CreateDbContextAsync();
 
@@ -70,18 +46,8 @@ public class SqlIndexRepository : IIndexRepository
             // Save to get a Page.Id 
             await context.SaveChangesAsync();
 
-            var allUniqueTerms = document.TitleTerms.Keys
-                .Union(document.HeaderTerms.Keys)
-                .Union(document.ContentTerms.Keys)
-                .ToList();
-
-            // Retrieve any Terms that already exist in the database.
-            var termLookup = await SynchronizeTermsAsync(context, allUniqueTerms, page.Language);
-
             AddWordFrequencies(context, page.Id, document, termLookup);
             AddWordPositions(context, page.Id, document, termLookup);
-            AddWordFrequencies(context, page.Id, normalizedTitleTerms, normalizedHeaderTerms, normalizedContentTerms, termLookup);
-            AddWordPositions(context, page.Id, normalizedTitleTermPositions, normalizedHeaderTermPositions, normalizedContentTermPositions, termLookup);
             await AddPageLinksAsync(context, page, document.OutgoingLinks);
 
             // save everything at the same time        
@@ -176,17 +142,13 @@ public class SqlIndexRepository : IIndexRepository
     }
 
 
-    private async Task<Dictionary<string, LTU.SearchEngine.Backend.Core.Model.Entities.Term>> SynchronizeTermsAsync(
+    private async Task<Dictionary<string, Term>> SynchronizeTermsAsync(
         SearchDbContext context, 
         List<string> words, 
         string language
         )
     {
-        var cleanWords = words
-        .Distinct()
-        .ToList();
-
-        // using var context = await _factory.CreateDbContextAsync();
+        var cleanWords = words.Distinct().ToList();
         
         await _semaphoreProvider.GetTermSyncSemaphore().WaitAsync();
         try
@@ -222,18 +184,15 @@ public class SqlIndexRepository : IIndexRepository
 
     private void AddWordFrequencies(
         SearchDbContext context, 
-        int pageId, 
-        Dictionary<string, int> normalizedTitleTerms,
-        Dictionary<string, int> normalizedHeaderTerms,
-        Dictionary<string, int> normalizedContentTerms,
-        Dictionary<string, LTU.SearchEngine.Backend.Core.Model.Entities.Term> terms
+        int pageId, IndexDocument doc, 
+        Dictionary<string, Term> terms
         )
     {
         foreach (var word in terms.Keys)
         {
-            normalizedTitleTerms.TryGetValue(word, out int titleFreq);
-            normalizedHeaderTerms.TryGetValue(word, out int headerFreq);
-            normalizedContentTerms.TryGetValue(word, out int bodyFreq);
+            doc.TitleTerms.TryGetValue(word, out int titleFreq);
+            doc.HeaderTerms.TryGetValue(word, out int headerFreq);
+            doc.ContentTerms.TryGetValue(word, out int bodyFreq);
 
             context.PageWordFrequencies.Add(new PageWordFrequency
             {
@@ -246,13 +205,12 @@ public class SqlIndexRepository : IIndexRepository
         }
     }
 
+    
     private void AddWordPositions(
         SearchDbContext context, 
         int pageId, 
-        IReadOnlyList<string> normalizedTitleTermPositions,
-        IReadOnlyList<string> normalizedHeaderTermPositions,
-        IReadOnlyList<string> normalizedContentTermPositions,
-        Dictionary<string, LTU.SearchEngine.Backend.Core.Model.Entities.Term> terms
+        IndexDocument doc, 
+        Dictionary<string, Term> terms
         )
     {
         var sources = new Dictionary<TermSource, IReadOnlyList<string>>
@@ -280,25 +238,35 @@ public class SqlIndexRepository : IIndexRepository
         }
     }
 
+
     private async Task AddPageLinksAsync(SearchDbContext context, Page fromPage, IEnumerable<string> outgoingLinks)
     {
         if (outgoingLinks == null || !outgoingLinks.Any()) return;
 
         var targetUrls = outgoingLinks.Distinct().ToList();
-        var existingPages = await context.Pages
-            .Where(p => targetUrls.Contains(p.Url))
-            .ToDictionaryAsync(p => p.Url);
 
-        foreach (var url in targetUrls)
+        await _semaphoreProvider.GetPageSyncSemaphore().WaitAsync();
+        try
         {
-            if (!existingPages.TryGetValue(url, out var targetPage))
-            {
-                targetPage = new Page { Url = url, Title = "pending..", ContentHash = "", Language = "" };
-                context.Pages.Add(targetPage);
-                existingPages[url] = targetPage;
-            }
+            var existingPages = await context.Pages
+                .Where(p => targetUrls.Contains(p.Url))
+                .ToDictionaryAsync(p => p.Url);
 
-            context.PageLinks.Add(new PageLink { FromPage = fromPage, ToPage = targetPage });
+            foreach (var url in targetUrls)
+            {
+                if (!existingPages.TryGetValue(url, out var targetPage))
+                {
+                    targetPage = new Page { Url = url, Title = "pending..", ContentHash = "", Language = "" };
+                    context.Pages.Add(targetPage);
+                    existingPages[url] = targetPage;
+                }
+
+                context.PageLinks.Add(new PageLink { FromPage = fromPage, ToPage = targetPage });
+            }
+        }
+        finally
+        {
+            _semaphoreProvider.GetPageSyncSemaphore().Release();
         }
     }
 
@@ -308,11 +276,11 @@ public class SqlIndexRepository : IIndexRepository
     /// </summary>
     public async Task<HashSet<int>> GetDocumentIdsForTermAsync(string term)
     {
+        var normalizedTerm = term;
         await using var context = await _factory.CreateDbContextAsync();
 
-        // Go through the junction table PageWordFrequency to find matching pages
         return await context.PageWordFrequencies
-            .Where(pwf => pwf.Term.Word == term)
+            .Where(pwf => pwf.Term.Word == normalizedTerm)
             .Select(pwf => pwf.PageId)
             .ToHashSetAsync();
     }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Repositories/SqlIndexRepository.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Repositories/SqlIndexRepository.cs
@@ -1,9 +1,11 @@
-﻿using LTU.SearchEngine.Backend.Core.Entities;
+﻿using LTU.SearchEngine.Backend.Core;
+using LTU.SearchEngine.Backend.Core.Entities;
 using LTU.SearchEngine.Backend.Core.Model;
 using LTU.SearchEngine.Backend.Core.Model.Entities;
 using LTU.SearchEngine.Backend.Core.Model.ValueObjects.QueryNodes;
 using LTU.SearchEngine.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
+using System.Text;
 
 namespace LTU.SearchEngine.Infrastructure.Repositories;
 
@@ -14,17 +16,51 @@ namespace LTU.SearchEngine.Infrastructure.Repositories;
 public class SqlIndexRepository : IIndexRepository
 {
     private readonly IDbContextFactory<SearchDbContext> _factory;
+    private readonly SemaphoreProvider _semaphoreProvider;
 
     public SqlIndexRepository(IDbContextFactory<SearchDbContext> factory)
+    public SqlIndexRepository(IDbContextFactory<SearchDbContext> factory, SemaphoreProvider semaphoreProvider)
     {
         _factory = factory;
+        _semaphoreProvider = semaphoreProvider;
     }
 
     // Saves a fully processed document from the pipeline to the database.
     // Merge words from the title, headers and body content.
     public async Task AddDocumentAsync(IndexDocument document)
     {
+
+        // Normalize all terms to ensure consistency
+        var normalizedTitleTerms = document.TitleTerms.ToDictionary(
+            kvp => kvp.Key.ToLowerInvariant().Normalize(NormalizationForm.FormC), 
+            kvp => kvp.Value);
+        var normalizedHeaderTerms = document.HeaderTerms.ToDictionary(
+            kvp => kvp.Key.ToLowerInvariant().Normalize(NormalizationForm.FormC), 
+            kvp => kvp.Value);
+        var normalizedContentTerms = document.ContentTerms.ToDictionary(
+            kvp => kvp.Key.ToLowerInvariant().Normalize(NormalizationForm.FormC), 
+            kvp => kvp.Value);
+        var normalizedTitleTermPositions = document.TitleTermPositions
+            .Select(w => w.ToLowerInvariant().Normalize(NormalizationForm.FormC))
+            .ToList();
+        var normalizedHeaderTermPositions = document.HeaderTermPositions
+            .Select(w => w.ToLowerInvariant().Normalize(NormalizationForm.FormC))
+            .ToList();
+        var normalizedContentTermPositions = document.ContentTermPositions
+            .Select(w => w.ToLowerInvariant().Normalize(NormalizationForm.FormC))
+            .ToList();
+
+        var allUniqueTerms = normalizedTitleTerms.Keys
+            .Union(normalizedHeaderTerms.Keys)
+            .Union(normalizedContentTerms.Keys)
+            .ToList();
+
+
+
         await using var context = await _factory.CreateDbContextAsync();
+
+        var termLookup = await SynchronizeTermsAsync(context, allUniqueTerms, document.Language);
+        
         await using var transaction = await context.Database.BeginTransactionAsync();
 
         try
@@ -44,6 +80,8 @@ public class SqlIndexRepository : IIndexRepository
 
             AddWordFrequencies(context, page.Id, document, termLookup);
             AddWordPositions(context, page.Id, document, termLookup);
+            AddWordFrequencies(context, page.Id, normalizedTitleTerms, normalizedHeaderTerms, normalizedContentTerms, termLookup);
+            AddWordPositions(context, page.Id, normalizedTitleTermPositions, normalizedHeaderTermPositions, normalizedContentTermPositions, termLookup);
             await AddPageLinksAsync(context, page, document.OutgoingLinks);
 
             // save everything at the same time        
@@ -55,6 +93,43 @@ public class SqlIndexRepository : IIndexRepository
             await transaction.RollbackAsync();
             throw;
         }
+    }
+
+
+    // Retrieves a list of documents based on their unique IDs
+	public async Task<List<Page>> GetDocumentsByIdAsync(List<int> pageIds)
+	{
+		//Creates a new database context based on their unique IDs
+		await using var context = await _factory.CreateDbContextAsync();
+
+		return await context.Pages
+			.Where(p => pageIds.Contains(p.Id))
+			.ToListAsync();
+	}
+
+	public Task<HashSet<int>> GetDocumentIdsForPhraseAsync(PhraseNode<HashSet<int>> phrase)
+	{
+		throw new NotImplementedException();
+	}
+
+    public async Task<int?> GetExistingDocumentByHashAsync(string hash)
+    {
+        await using var context = await _factory.CreateDbContextAsync();
+        
+        return await context.Pages
+            .Where(p => p.ContentHash.Equals(hash))
+            .Select(p => (int?)p.Id)
+            .FirstOrDefaultAsync();
+    }
+
+    public async Task UpdateLastCrawledAsync(int id, DateTime newCrawl)
+    {
+        await using var context = await _factory.CreateDbContextAsync();
+        await context.Pages
+            .Where(p => p.Id.Equals(id))
+            .ExecuteUpdateAsync(setter => 
+                setter.SetProperty(p => p.LastCrawled, newCrawl)
+            );
     }
 
 
@@ -101,47 +176,64 @@ public class SqlIndexRepository : IIndexRepository
     }
 
 
-    private async Task<Dictionary<string, Term>> SynchronizeTermsAsync(
+    private async Task<Dictionary<string, LTU.SearchEngine.Backend.Core.Model.Entities.Term>> SynchronizeTermsAsync(
         SearchDbContext context, 
         List<string> words, 
         string language
         )
     {
-        var existingTerms = await context.Terms
-            .Where(t => words.Contains(t.Word))
+        var cleanWords = words
+        .Distinct()
+        .ToList();
+
+        // using var context = await _factory.CreateDbContextAsync();
+        
+        await _semaphoreProvider.GetTermSyncSemaphore().WaitAsync();
+        try
+        {
+            var existingTerms = await context.Terms
+            .Where(t => cleanWords.Contains(t.Word) && t.LanguageCode == language)
             .ToDictionaryAsync(t => t.Word);
 
-        bool hasNewTerms = false;
+            bool hasNewTerms = false;
 
-        foreach (var term in words)
-        {
-            // Creates new Terms if current Term did not exist. 
-            if (!existingTerms.TryGetValue(term, out var termEntity))
+            foreach (var term in cleanWords)
             {
-                termEntity = new Term { Word = term, LanguageCode = language };
-                context.Terms.Add(termEntity);
-                existingTerms[term] = termEntity;
-                hasNewTerms = true;
+                // Creates new Terms if current Term did not exist. 
+                if (!existingTerms.TryGetValue(term, out var termEntity))
+                {
+                    termEntity = new Term { Word = term, LanguageCode = language };
+                    context.Terms.Add(termEntity);
+                    existingTerms[term] = termEntity;
+                    hasNewTerms = true;
+                }
             }
-        }
 
-        if (hasNewTerms) await context.SaveChangesAsync();
-        
-        return existingTerms;
+            if (hasNewTerms) await context.SaveChangesAsync();    
+                  
+            return existingTerms;   
+        }
+        finally
+        {
+            _semaphoreProvider.GetTermSyncSemaphore().Release();
+        }
     }
 
 
     private void AddWordFrequencies(
         SearchDbContext context, 
-        int pageId, IndexDocument doc, 
-        Dictionary<string, Term> terms
+        int pageId, 
+        Dictionary<string, int> normalizedTitleTerms,
+        Dictionary<string, int> normalizedHeaderTerms,
+        Dictionary<string, int> normalizedContentTerms,
+        Dictionary<string, LTU.SearchEngine.Backend.Core.Model.Entities.Term> terms
         )
     {
         foreach (var word in terms.Keys)
         {
-            doc.TitleTerms.TryGetValue(word, out int titleFreq);
-            doc.HeaderTerms.TryGetValue(word, out int headerFreq);
-            doc.ContentTerms.TryGetValue(word, out int bodyFreq);
+            normalizedTitleTerms.TryGetValue(word, out int titleFreq);
+            normalizedHeaderTerms.TryGetValue(word, out int headerFreq);
+            normalizedContentTerms.TryGetValue(word, out int bodyFreq);
 
             context.PageWordFrequencies.Add(new PageWordFrequency
             {
@@ -157,8 +249,10 @@ public class SqlIndexRepository : IIndexRepository
     private void AddWordPositions(
         SearchDbContext context, 
         int pageId, 
-        IndexDocument doc, 
-        Dictionary<string, Term> terms
+        IReadOnlyList<string> normalizedTitleTermPositions,
+        IReadOnlyList<string> normalizedHeaderTermPositions,
+        IReadOnlyList<string> normalizedContentTermPositions,
+        Dictionary<string, LTU.SearchEngine.Backend.Core.Model.Entities.Term> terms
         )
     {
         var sources = new Dictionary<TermSource, IReadOnlyList<string>>
@@ -221,41 +315,5 @@ public class SqlIndexRepository : IIndexRepository
             .Where(pwf => pwf.Term.Word == term)
             .Select(pwf => pwf.PageId)
             .ToHashSetAsync();
-    }
-
-	// Retrieves a list of documents based on their unique IDs
-	public async Task<List<Page>> GetDocumentsByIdAsync(List<int> pageIds)
-	{
-		//Creates a new database context based on their unique IDs
-		await using var context = await _factory.CreateDbContextAsync();
-
-		return await context.Pages
-			.Where(p => pageIds.Contains(p.Id))
-			.ToListAsync();
-	}
-
-	public Task<HashSet<int>> GetDocumentIdsForPhraseAsync(PhraseNode<HashSet<int>> phrase)
-	{
-		throw new NotImplementedException();
-	}
-
-    public async Task<int?> GetExistingDocumentByHashAsync(string hash)
-    {
-        await using var context = await _factory.CreateDbContextAsync();
-        
-        return await context.Pages
-            .Where(p => p.ContentHash.Equals(hash))
-            .Select(p => (int?)p.Id)
-            .FirstOrDefaultAsync();
-    }
-
-    public async Task UpdateLastCrawledAsync(int id, DateTime newCrawl)
-    {
-        await using var context = await _factory.CreateDbContextAsync();
-        await context.Pages
-            .Where(p => p.Id.Equals(id))
-            .ExecuteUpdateAsync(setter => 
-                setter.SetProperty(p => p.LastCrawled, newCrawl)
-            );
     }
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Repositories/SqlIndexRepository.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Repositories/SqlIndexRepository.cs
@@ -276,11 +276,10 @@ public class SqlIndexRepository : IIndexRepository
     /// </summary>
     public async Task<HashSet<int>> GetDocumentIdsForTermAsync(string term)
     {
-        var normalizedTerm = term;
         await using var context = await _factory.CreateDbContextAsync();
 
         return await context.PageWordFrequencies
-            .Where(pwf => pwf.Term.Word == normalizedTerm)
+            .Where(pwf => pwf.Term.Word == term)
             .Select(pwf => pwf.PageId)
             .ToHashSetAsync();
     }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Crawling.Tests/ParserTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Crawling.Tests/ParserTests.cs
@@ -45,9 +45,9 @@ public class ParserTests
         );
 
 		// Assert
-		Assert.Contains("http://localhost/Linked.html", links);
-		Assert.Contains("http://localhost/HelloWorld.pdf", links);
-        Assert.Contains(new Uri("https://google.com").AbsoluteUri, links);
+		Assert.Contains("http://localhost/linked.html", links);
+		Assert.Contains("http://localhost/helloworld.pdf", links);
+        Assert.Contains("https://google.com", links);
         Assert.DoesNotContain(links, l => l.Equals("http://localhost/style.css"));
         Assert.DoesNotContain(links, l => l.Equals("http://localhost/image1.jpg"));
         Assert.DoesNotContain(links, l => l.Equals("http://localhost/image2.png"));

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/IntegrationTesting/CrawlerIntegrationTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/IntegrationTesting/CrawlerIntegrationTests.cs
@@ -522,7 +522,7 @@ public class CrawlerIntegrationTests : IClassFixture<WebApplicationFactory<Progr
             logLevel: LogLevel.Information,
             eventId: It.IsAny<EventId>(),
             state: It.Is<It.IsAnyType>((v, t) => 
-                v.ToString()!.Contains("http://localhost/ignoreThisRule/ignored.html") &&
+                v.ToString()!.Contains("http://localhost/ignorethisrule/ignored.html") &&
                 v.ToString()!.Contains("localhost") 
             ),  
             exception: null,
@@ -550,7 +550,7 @@ public class CrawlerIntegrationTests : IClassFixture<WebApplicationFactory<Progr
     {
         // Arrange
         string seedUrl = "http://localhost/dirtySeed.html";
-        string validPage = "http://localhost/validPage.html";
+        string validPage = "http://localhost/validpage.html";
         
         var tracker = new CallTracker();
         var httpClient = _webHostBuilder.CreateFakeInternetClient(callTracker: tracker);
@@ -597,8 +597,7 @@ public class CrawlerIntegrationTests : IClassFixture<WebApplicationFactory<Progr
             () => indexedPages.Count > 1, 
             maxWaitMs: 10000
         );
-        //await TestWait.UntilTrue(maxWaitMs: 1000);
-        
+           
         cts.Cancel();
         
         // Relevant pages were visited

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/IntegrationTesting/IndexerIntegrationTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/IntegrationTesting/IndexerIntegrationTests.cs
@@ -181,7 +181,7 @@ public class IndexerIntegrationTests : IClassFixture<WebApplicationFactory<Progr
             .Select(pwl => pwl.Page.Url);
 
         Assert.Contains("http://localhost/InvertedIndexTestFile1.html", term1PageAssociation);
-        Assert.Contains("http://localhost/InvertedIndexTestFile2.html", term1PageAssociation);
+        Assert.Contains("http://localhost/invertedindextestfile2.html", term1PageAssociation);
     }
 
 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/SqlIndexRepositoryTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/SqlIndexRepositoryTests.cs
@@ -1,4 +1,5 @@
-﻿using LTU.SearchEngine.Backend.Core.Entities;
+﻿using LTU.SearchEngine.Backend.Core;
+using LTU.SearchEngine.Backend.Core.Entities;
 using LTU.SearchEngine.Backend.Core.Model;
 using LTU.SearchEngine.Backend.Core.Model.Entities;
 using LTU.SearchEngine.Infrastructure.Data;
@@ -24,16 +25,18 @@ public class SqlIndexRepositoryTests : IDisposable
         var services = new ServiceCollection();
         services.AddDbContextFactory<SearchDbContext>(options =>
             options.UseSqlite(_connection));
+        services.AddSingleton<SemaphoreProvider>();
 
         var provider = services.BuildServiceProvider();
         _factory = provider.GetRequiredService<IDbContextFactory<SearchDbContext>>();
+        var semaphoreProvider = provider.GetRequiredService<SemaphoreProvider>();
 
         using (var context = _factory.CreateDbContext())
         {
             context.Database.EnsureCreated();
         }
 
-        _sut = new SqlIndexRepository(_factory);
+        _sut = new SqlIndexRepository(_factory, semaphoreProvider);
     }
 
     
@@ -277,10 +280,10 @@ public class SqlIndexRepositoryTests : IDisposable
         
         // Verify that old words are gone and new have taken their place 
         Assert.Equal(3, page!.WordFrequencies.Count);
-        Assert.DoesNotContain(page.WordFrequencies, wf => wf.Term.Word.Equals(oldTitle));
-        Assert.Contains(page.WordFrequencies, wf => wf.Term.Word.Equals(newTitle));
-        Assert.Contains(page.WordFrequencies, wf => wf.Term.Word.Equals(oldHeader));
-        Assert.Contains(page.WordFrequencies, wf => wf.Term.Word.Equals(oldContent));
+        Assert.DoesNotContain(page.WordFrequencies, wf => wf.Term.Word.Equals("oldtitle"));
+        Assert.Contains(page.WordFrequencies, wf => wf.Term.Word.Equals("newtitle"));
+        Assert.Contains(page.WordFrequencies, wf => wf.Term.Word.Equals("oldheader"));
+        Assert.Contains(page.WordFrequencies, wf => wf.Term.Word.Equals("oldcontent"));
     }
 
 
@@ -359,8 +362,8 @@ public class SqlIndexRepositoryTests : IDisposable
             .ToListAsync();
 
         Assert.Single(positions);
-        Assert.Equal("newTerm", positions[0].Term.Word);
-        Assert.DoesNotContain(positions, pwp => pwp.Term.Word.Equals("oldTerm"));
+        Assert.Equal("newterm", positions[0].Term.Word);
+        Assert.DoesNotContain(positions, pwp => pwp.Term.Word.Equals("oldterm"));
     }
 
 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/SqlIndexRepositoryTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/SqlIndexRepositoryTests.cs
@@ -234,11 +234,11 @@ public class SqlIndexRepositoryTests : IDisposable
     public async Task AddDocumentAsync_WhenPageExists_ShouldCleanupOldFrequenciesAndLinks()
     {
         // Arrange
-        string oldTitle = "oldTitle";
-        string oldHeader = "oldHeader";
-        string oldContent = "oldContent";
+        string oldTitle = "oldtitle";
+        string oldHeader = "oldheader";
+        string oldContent = "oldcontent";
 
-        string newTitle = "newTitle";
+        string newTitle = "newtitle";
 
         var url = "https://update.se";
         

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/SqlIndexRepositoryTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/SqlIndexRepositoryTests.cs
@@ -328,10 +328,10 @@ public class SqlIndexRepositoryTests : IDisposable
         
         var doc1 = IndexDocumentBuilder.BuildIndexDocument(
             url: url, 
-            titleTerms: new Dictionary<string, int> { {"oldTerm", 1} },
+            titleTerms: new Dictionary<string, int> { {"oldterm", 1} },
             headerTerms: new Dictionary<string, int>(),
             contentTerms: new Dictionary<string, int>(),
-            titleTermPositions: new List<string> { "oldTerm" },
+            titleTermPositions: new List<string> { "oldterm" },
             headerTermPositions: new List<string>(),
             contentTermPositions: new List<string>(),
             outgoingLinks: new List<string>() 
@@ -339,10 +339,10 @@ public class SqlIndexRepositoryTests : IDisposable
 
         var doc2 = IndexDocumentBuilder.BuildIndexDocument(
             url: url, 
-            titleTerms: new Dictionary<string, int>{ {"newTerm", 1} },
+            titleTerms: new Dictionary<string, int>{ {"newterm", 1} },
             headerTerms: new Dictionary<string, int>(),
             contentTerms: new Dictionary<string, int>(),
-            titleTermPositions: new List<string> { "newTerm" },
+            titleTermPositions: new List<string> { "newterm" },
             headerTermPositions: new List<string>(),
             contentTermPositions: new List<string>(),
             outgoingLinks: new List<string>() 


### PR DESCRIPTION
The issue has been solved. The problem seems to have been in relation to how the urls were validated.
The previous implementation did not take into account that many pages nowadays can end without an explicit ending such as .html .pdf.

While debugging this problem, i also noticed that the indexing process failed as it tried to insert terms that were already in the database. This was a problem with many layers:
1. The ER diagram shows that the Term.Id and Term.Language act as a Unique pair. This was not registered in the Term Configuration. I fixed that issue but introducing a semaphore and using the correct mapping. 
2. With that fixed I kept running into the same problem where a specific word "för" consistently seemed ended up trying to insert even though the word already existed. Turns out that it was a normalization issue with Unicode. To solve this I used NormalizationForm.FormC to normalize the text, which seem to have solved the isssue.

Solving that, I noticed a similar issue with the registration of pagelinks. I solved this by using the semaphore method mentioned before here as well. 

As a final note, i updated the tests were needed to be more in line with the changes introduced. (mostly just changing expected result to lowercase letter)