### PR TITLE
143 bug found in query parser term term with a space after the second term throws exception

### DIFF
--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Api/SearchController.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Api/SearchController.cs
@@ -50,7 +50,7 @@ namespace LTU.SearchEngine.Api
             if (pageNumber < 1) return BadRequest("Page number must be 1 or greater.");
             if (pageNumber > 100) return BadRequest("Deep pagination is restricted. Please refine your query!");
 
-            var responseDto = await _serviceManager.QueryService.GetSearchResultsAsync(query, language);
+            var responseDto = await _serviceManager.QueryService.GetSearchResultsAsync(query.Trim(), language);
 
             return Ok(responseDto);
         }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Api.Tests/SearchControllerTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Api.Tests/SearchControllerTests.cs
@@ -61,6 +61,29 @@ public class SearchControllerTests
         _mockQueryService.Verify(s => s.GetSearchResultsAsync(validQuery), Times.Once);
     }
 
+
+    [Theory]
+    [InlineData(" test search ", "test search")]
+    [InlineData("test search ", "test search")]
+    [InlineData(" test OR search", "test OR search")]
+    [InlineData("    test search ", "test search")]
+    [InlineData(" test search    ", "test search")]
+    [InlineData(" test AND search ", "test AND search")]
+    public async Task GetSearchResponses_ShouldTrimQuery_WhenQueryIsValidButHasLeadingOrTrailingWhiteSpaces(
+        string input, string expectedTrim)
+    {
+        // Arrange
+        _mockQueryService
+            .Setup(s => s.GetSearchResultsAsync(It.IsAny<string>()));
+      
+        // Act
+        var result = await _controller.GetSearchResponses(input);
+
+        // Assert
+        _mockQueryService.Verify(s => s.GetSearchResultsAsync(expectedTrim), Times.Once);
+    }
+
+
     [Fact]
     public async Task GetSearchResponses_ShouldReturnOkWithEmptyList_WhenNoMatchesFound()
     {


### PR DESCRIPTION
Added a trim to the query, before sending it to the next stage in the process, which solved the problem. 
Also added an additional test to the SearchControllerTests class to verify this.