### PR TITLE
148 add the phrase search feature

### DIFF
--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/Helpers/QueryStringTokenizer.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/Helpers/QueryStringTokenizer.cs
@@ -33,30 +33,30 @@ public class QueryStringTokenizer : IStringTokenizer<ExtractedQueryToken, QueryT
 	{
 		if (stringBuilder.Length == 0) return;
 
-
-		var token = stringBuilder.ToString().Trim();
-        var extractedToken = new ExtractedQueryToken(queryTokenType, token, languageCode);
-
-        // Normalize BEFORE creating ExtractedQueryToken
-        if (queryTokenType == QueryTokenType.Term ||
-			queryTokenType == QueryTokenType.Phrase)
+		var originalText = stringBuilder.ToString().Trim();
+		string finalToken;
+      
+	  	// Handles term and phrase normalization and token creation
+	    if (queryTokenType == QueryTokenType.Term || queryTokenType == QueryTokenType.Phrase)
 		{
-			token = _normalizer.Normalize(token, languageCode);
-			
-			if (token == null)
-			{
-				stringBuilder.Clear();
-				return;
-			}
-			else
-			{
-				extractedToken = new ExtractedQueryToken(queryTokenType, token, languageCode);	
-			}
+			var words = originalText.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+			var normalizedWords = words
+				.Select(word => _normalizer.Normalize(word, languageCode))
+				.Where(nWord => !string.IsNullOrWhiteSpace(nWord));  
+
+			finalToken = string.Join(' ', normalizedWords);	
+		}
+		else
+		{
+			finalToken = originalText;
 		}
 
-        if (token.Length > 0)
-			tokens.Add(extractedToken);
-
+		if (!string.IsNullOrWhiteSpace(finalToken))
+		{
+			tokens.Add(new ExtractedQueryToken(queryTokenType, finalToken, languageCode));
+		}
+        
 		stringBuilder.Clear();
 	}
 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Repositories/SqlIndexRepository.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Repositories/SqlIndexRepository.cs
@@ -74,9 +74,37 @@ public class SqlIndexRepository : IIndexRepository
 			.ToListAsync();
 	}
 
-	public Task<HashSet<int>> GetDocumentIdsForPhraseAsync(PhraseNode<HashSet<int>> phrase)
+	public async Task<HashSet<int>> GetDocumentIdsForPhraseAsync(PhraseNode<HashSet<int>> phraseNode)
 	{
-		throw new NotImplementedException();
+        await using var context = await _factory.CreateDbContextAsync();
+
+        var tokenStrings = phraseNode.Phrase
+            .Select(t => t.Token).ToList();
+
+
+        var firstTerm = tokenStrings[0];
+
+        // First part of a deferred execution of the phrase search.
+        var query = context.PageWordPositions
+            .Where(pwp => pwp.Term.Word.Equals(firstTerm))
+            .Select(pwp => new { pwp.PageId, firstWordPosition = pwp.Position});
+
+        // Build the rest of the query by chaining the subsequent words using Inner Joins
+        for (int i = 0; i < tokenStrings.Count; i++)
+        {
+            var currentTerm = tokenStrings[i];
+            int offset = i;
+
+            query = 
+                from q in query
+                join next in context.PageWordPositions on q.PageId equals next.PageId
+                where next.Term.Word.Equals(currentTerm)  && next.Position == q.firstWordPosition + offset
+                select new { q.PageId, q.firstWordPosition };
+        }    
+        
+        var result = await query.Select(q => q.PageId).ToHashSetAsync();
+
+		return result;
 	}
 
     public async Task<int?> GetExistingDocumentByHashAsync(string hash)

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/SqlIndexRepositoryTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/SqlIndexRepositoryTests.cs
@@ -1,8 +1,11 @@
-﻿using LTU.SearchEngine.Backend.Core;
+﻿using System.Diagnostics;
+using LTU.SearchEngine.Backend.Core;
 using LTU.SearchEngine.Backend.Core.Entities;
+using LTU.SearchEngine.Backend.Core.Enums;
 using LTU.SearchEngine.Backend.Core.Model;
 using LTU.SearchEngine.Backend.Core.Model.Entities;
 using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
+using LTU.SearchEngine.Backend.Core.Model.ValueObjects.QueryNodes;
 using LTU.SearchEngine.Infrastructure.Data;
 using LTU.SearchEngine.Infrastructure.Repositories;
 using LTU.SearchEngine.Test.HelperClasses;
@@ -190,6 +193,98 @@ public class SqlIndexRepositoryTests : IDisposable
         Assert.NotNull(resultId);
         Assert.Null(noMatch);
         Assert.Equal(resultId, 1);
+    }
+
+
+    [Fact]
+    public async Task GetDocumentIdsForPhraseAsync_ShouldReturnPagesWithExactOrderedSequence()
+    {
+        // Arrange: 
+        await using var setupContext = await _factory.CreateDbContextAsync();
+
+        var pageMatch = new Page { Url = "https://match.com", Title = "Exact Match" };
+        var pageWrongOrder = new Page { Url = "https://wrongorder.com", Title = "Wrong Order" };
+        var pageGap = new Page { Url = "https://gap.com", Title = "Has Gap" };
+
+        var termQuick = new Term { Word = "quick" };
+        var termBrown = new Term { Word = "brown" };
+        var termFox = new Term { Word = "fox" };
+
+        setupContext.Pages.AddRange(pageMatch, pageWrongOrder, pageGap);
+        setupContext.Terms.AddRange(termQuick, termBrown, termFox);
+        await setupContext.SaveChangesAsync();
+
+        // Setup exact match "quick" (pos 0), "brown" (pos 1), "fox" (pos 2)
+        SetupPhrase(
+            setupContext, pageMatch, 
+            0, 1, 2,
+            termQuick, termBrown, termFox
+        );
+
+        // Setup wrong match "fox" (0), "brown" (1), "quick" (2)
+        SetupPhrase(
+            setupContext, pageWrongOrder, 
+            2, 1, 0,
+            termQuick, termBrown, termFox
+        );
+
+        // Setup phrase with gap "quick" (0), "brown" (1), ... "fox" (5)
+        SetupPhrase(
+            setupContext, pageGap, 
+            0, 1, 5, 
+            termQuick, termBrown, termFox
+        );
+
+        await setupContext.SaveChangesAsync();
+
+        // Create the PhraseNode to search for "quick brown fox"
+        var tokens = new List<ExtractedQueryToken>
+        {
+            new ExtractedQueryToken(QueryTokenType.Phrase, "quick", "en"),
+            new ExtractedQueryToken(QueryTokenType.Phrase, "brown", "en"),
+            new ExtractedQueryToken(QueryTokenType.Phrase, "fox", "en")
+        };
+        
+        var phraseNode = new PhraseNode<HashSet<int>>(tokens);
+
+        // Act
+        var resultIds = await _sut.GetDocumentIdsForPhraseAsync(phraseNode);
+       
+        // Assert
+        Assert.Single(resultIds); // Only one page should match exactly
+        Assert.Contains(pageMatch.Id, resultIds);
+        Assert.DoesNotContain(pageWrongOrder.Id, resultIds);
+        Assert.DoesNotContain(pageGap.Id, resultIds);
+    }
+
+    private static void SetupPhrase(
+        SearchDbContext setupContext, 
+        Page page,
+        int termPosition1,
+        int termPosition2,
+        int termPosition3,
+        Term termQuick,
+        Term termBrown,
+        Term termFox
+        )
+    {
+        setupContext.PageWordPositions.AddRange(
+            new PageWordPosition{ 
+                PageId = page.Id, TermId = termQuick.Id, 
+                Position = termPosition1, 
+                TermSource = TermSource.Body 
+            },
+            new PageWordPosition{ 
+                PageId = page.Id, TermId = termBrown.Id, 
+                Position = termPosition2, 
+                TermSource = TermSource.Body
+            },
+            new PageWordPosition{ 
+                PageId = page.Id, TermId = termFox.Id, 
+                Position = termPosition3, 
+                TermSource = TermSource.Body 
+            }
+        );
     }
 
 


### PR DESCRIPTION
Replace NotImplementedException for GetDocumentIdsForPhraseAsync with an EF Core query that resolves phrase queries. 

The method (renamed parameter to phraseNode) extracts token strings from the phrase, seeds a query with the first term's PageWordPositions, then chains joins against PageWordPositions for each subsequent token ensuring consecutive position offsets. 

The query returns a HashSet<int> of matching PageIds. Uses the DbContext factory and ToHashSetAsync for execution.

A test case testing this feature was also implemented. Where 3 pages, only one of which has the correct term order, were created and a query gets conducted. only on result should return. 