### PR TITLE
151 bug query parser   stop word as token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -416,3 +416,4 @@ FodyWeavers.xsd
 *.msix
 *.msm
 *.msp
+.vscode/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -417,3 +417,4 @@ FodyWeavers.xsd
 *.msm
 *.msp
 .vscode/settings.json
+.vscode/settings.json

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Api/Program.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Api/Program.cs
@@ -86,7 +86,7 @@ public partial class Program
         builder.Services.AddTransient<IQuerySyntaxHelper, QuerySyntaxHelper>();
 
 		builder.Services.AddTransient<
-            IStringTokenizer<ExtractedQueryToken, QueryTokenType>, 
+            IStringTokenizer<ExtractedQueryToken, IgnoredTermsDTO>, 
             QueryStringTokenizer>();
 		
         builder.Services.AddTransient<

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/Helpers/IStringTokenizer.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/Helpers/IStringTokenizer.cs
@@ -1,17 +1,23 @@
-﻿namespace LTU.SearchEngine.Application.QueryParsing.Helpers;
+﻿using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
+
+namespace LTU.SearchEngine.Application.QueryParsing.Helpers;
 
 
 /// <summary>
 /// A generic interface for decomposing raw strings into a collection of categorized tokens.
 /// </summary>
 /// <typeparam name="TToken">The type representing the finalized token (e.g., ExtractedQueryToken).</typeparam>
-public interface IStringTokenizer<TToken, TType>
+/// <typeparam name="TIgnoredToken">The type representing the ignored token (e.g., IgnoredTermsDTO).</typeparam>
+public interface IStringTokenizer<TToken, TIgnoredToken>
 {
 	/// <summary>
 	/// Transforms a raw input string into a sequence of categorized tokens.
 	/// </summary>
 	/// <param name="input">The raw string to be tokenized.</param>
 	/// <param name="languageCode">The main language for the given query.</param>
-	/// <returns>A list of tokens of type <typeparamref name="TToken"/>.</returns>
-	List<TToken> Tokenize(string input, string languageCode = "sv");
+	/// <returns>
+	/// A <see cref="QueryStringTokenizingResult{TToken, TIgnoredToken}"/> which contains a list of tokens of type 
+	/// <typeparamref name="TToken"/> and an list of ignored tokens of type <typeparamref name="TIgnoredToken"/>.
+	/// </returns>
+	QueryStringTokenizingResult<TToken, TIgnoredToken> Tokenize(string input, string languageCode = "sv");
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/Helpers/IStringTokenizer.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/Helpers/IStringTokenizer.cs
@@ -1,34 +1,12 @@
-﻿using System.Text;
-
-namespace LTU.SearchEngine.Application.QueryParsing.Helpers;
+﻿namespace LTU.SearchEngine.Application.QueryParsing.Helpers;
 
 
 /// <summary>
 /// A generic interface for decomposing raw strings into a collection of categorized tokens.
 /// </summary>
 /// <typeparam name="TToken">The type representing the finalized token (e.g., ExtractedQueryToken).</typeparam>
-/// <typeparam name="TType">The enum or type representing the category (e.g., QueryTokenType).</typeparam>
 public interface IStringTokenizer<TToken, TType>
 {
-	/// <summary>
-	/// Processes the current character buffer, creates a token of type <typeparamref name="TToken"/>, 
-	/// and adds it to the collection.
-	/// </summary>
-	/// <param name="stringBuilder">The buffer holding characters for the token currently being built.</param>
-	/// <param name="tokens">The collection where the finalized token will be added.</param>
-	/// <param name="tokenType">The category to assign to the token (of type <typeparamref name="TType"/>).</param>
-	/// <param name="languageCode">The main language for the given query.</param>
-	/// <remarks>
-	/// Clears the <paramref name="stringBuilder"/> after the token is added. 
-	/// If the buffer is empty, no action is taken.
-	/// </remarks>
-	void Flush(
-		StringBuilder stringBuilder,
-		List<TToken> tokens,
-		TType tokenType,
-		string languageCode = "sv"
-	);
-
 	/// <summary>
 	/// Transforms a raw input string into a sequence of categorized tokens.
 	/// </summary>

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/Helpers/QueryStringTokenizer.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/Helpers/QueryStringTokenizer.cs
@@ -52,7 +52,7 @@ public class QueryStringTokenizer : IStringTokenizer<ExtractedQueryToken, QueryT
 			finalToken = originalText;
 		}
 
-		if (!string.IsNullOrWhiteSpace(finalToken))
+		if (/*!string.IsNullOrWhiteSpace(finalToken)*/finalToken is not null)
 		{
 			tokens.Add(new ExtractedQueryToken(queryTokenType, finalToken, languageCode));
 		}
@@ -139,7 +139,7 @@ public class QueryStringTokenizer : IStringTokenizer<ExtractedQueryToken, QueryT
 				continue;
 			}
 
-			// Appends phrase characters
+			// Appends phrase characters and flushes phrase if is edge of phrase
 			action = TryHandleIsEdgeOfPhrase(
 				input, tokens, stringBuilder, ref isBuildingAPhrase, index, character, ResolveLanguage(singleTermPhraseLanguage, globalLanguage)
 			);

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/Helpers/QueryStringTokenizer.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/Helpers/QueryStringTokenizer.cs
@@ -1,5 +1,6 @@
 ﻿using LTU.SearchEngine.Backend.Core;
 using LTU.SearchEngine.Backend.Core.Enums;
+using LTU.SearchEngine.Backend.Core.Model.DTOs;
 using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -10,7 +11,7 @@ namespace LTU.SearchEngine.Application.QueryParsing.Helpers;
 /// Implementation of <see cref="IStringTokenizer"/> that handles operator recognition, whitespace <br/>
 /// separation of terms and quote-aware grouping.
 /// </summary>
-public class QueryStringTokenizer : IStringTokenizer<ExtractedQueryToken, QueryTokenType>
+public class QueryStringTokenizer : IStringTokenizer<ExtractedQueryToken, IgnoredTermsDTO>
 {
 	private readonly IQuerySyntaxHelper _syntaxHelper;
     private readonly ITextNormalizer<string> _normalizer;
@@ -25,7 +26,7 @@ public class QueryStringTokenizer : IStringTokenizer<ExtractedQueryToken, QueryT
 
 
 	/// <inheritdoc/>
-	public List<ExtractedQueryToken> Tokenize(string input, string languageCode)
+	public QueryStringTokenizingResult<ExtractedQueryToken, IgnoredTermsDTO> Tokenize(string input, string languageCode)
 	{
 		var session = new QueryStringTokenizationSession(input, languageCode, _syntaxHelper, _normalizer);
 		return session.Execute();
@@ -39,7 +40,7 @@ public class QueryStringTokenizer : IStringTokenizer<ExtractedQueryToken, QueryT
 		private string _globalLanguage;
 		private readonly IQuerySyntaxHelper _querySyntaxHelper;
 		private readonly ITextNormalizer<string> _textNormalizer;
-		private readonly List<ExtractedQueryToken> _ignoredTokens = new();
+		private readonly List<IgnoredTermsDTO> _ignoredTokens = new();
 		private readonly List<ExtractedQueryToken> _tokens = new();
 		private StringBuilder _stringBuilder = new();
 		private bool _isBuildingAPhrase = false;
@@ -57,7 +58,7 @@ public class QueryStringTokenizer : IStringTokenizer<ExtractedQueryToken, QueryT
 			_textNormalizer = normalizer;
 		}
 
-		public List<ExtractedQueryToken> Execute()
+		public QueryStringTokenizingResult<ExtractedQueryToken, IgnoredTermsDTO> Execute()
 		{
 			for (_index = 0; _index < _input.Length; _index++)
 			{
@@ -137,7 +138,9 @@ public class QueryStringTokenizer : IStringTokenizer<ExtractedQueryToken, QueryT
 			
 			_querySyntaxHelper.ValidateGrouping(_tokens);
 
-			return _tokens;
+			return new QueryStringTokenizingResult<ExtractedQueryToken, IgnoredTermsDTO>(
+				_tokens, _ignoredTokens
+			); 
 		}
 
 
@@ -153,9 +156,18 @@ public class QueryStringTokenizer : IStringTokenizer<ExtractedQueryToken, QueryT
 			{
 				var words = originalText.Split(' ', StringSplitOptions.RemoveEmptyEntries);
 
-				var normalizedWords = words
-					.Select(word => _textNormalizer.Normalize(word, languageCode))
-					.Where(nWord => !string.IsNullOrWhiteSpace(nWord));  
+				var normalizedWords = new List<string>();
+
+				foreach (var word in words)
+				{
+					var normalizedWord = _textNormalizer.Normalize(word, languageCode);
+
+					if (!string.IsNullOrWhiteSpace(normalizedWord))
+						normalizedWords.Add(normalizedWord);
+					else
+						_ignoredTokens.Add(new IgnoredTermsDTO{Token = word, Language = languageCode });
+				}
+
 
 				finalToken = string.Join(' ', normalizedWords);	
 			}

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/Helpers/QueryStringTokenizer.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/Helpers/QueryStringTokenizer.cs
@@ -23,411 +23,378 @@ public class QueryStringTokenizer : IStringTokenizer<ExtractedQueryToken, QueryT
 			throw new ArgumentNullException(nameof(normalizer));
     }
 
-	// Finalizes a token build
-	/// <inheritdoc/>
-	public void Flush(
-		StringBuilder stringBuilder,
-		List<ExtractedQueryToken> tokens,
-		QueryTokenType queryTokenType,
-		string languageCode)
-	{
-		if (stringBuilder.Length == 0) return;
-
-		var originalText = stringBuilder.ToString().Trim();
-		string finalToken;
-      
-	  	// Handles term and phrase normalization and token creation
-	    if (queryTokenType == QueryTokenType.Term || queryTokenType == QueryTokenType.Phrase)
-		{
-			var words = originalText.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-
-			var normalizedWords = words
-				.Select(word => _normalizer.Normalize(word, languageCode))
-				.Where(nWord => !string.IsNullOrWhiteSpace(nWord));  
-
-			finalToken = string.Join(' ', normalizedWords);	
-		}
-		else
-		{
-			finalToken = originalText;
-		}
-
-		if (/*!string.IsNullOrWhiteSpace(finalToken)*/finalToken is not null)
-		{
-			tokens.Add(new ExtractedQueryToken(queryTokenType, finalToken, languageCode));
-		}
-        
-		stringBuilder.Clear();
-	}
-
 
 	/// <inheritdoc/>
 	public List<ExtractedQueryToken> Tokenize(string input, string languageCode)
 	{
-		var tokens = new List<ExtractedQueryToken>();
-		var stringBuilder = new StringBuilder();
-		bool isBuildingAPhrase = false;
+		var session = new QueryStringTokenizationSession(input, languageCode, _syntaxHelper, _normalizer);
+		return session.Execute();
+	}
 
-		string globalLanguage = languageCode;
-		string singleTermPhraseLanguage = null!;
 
-		for (int index = 0; index < input.Length; index++)
+
+	private class QueryStringTokenizationSession
+	{
+		private readonly string _input;
+		private string _globalLanguage;
+		private readonly IQuerySyntaxHelper _querySyntaxHelper;
+		private readonly ITextNormalizer<string> _textNormalizer;
+		private readonly List<ExtractedQueryToken> _ignoredTokens = new();
+		private readonly List<ExtractedQueryToken> _tokens = new();
+		private StringBuilder _stringBuilder = new();
+		private bool _isBuildingAPhrase = false;
+		private string _singleTermPhraseLanguage = null!;
+		private int _index;
+		private char _character; 
+
+		public QueryStringTokenizationSession(
+			string input, string languageCode, IQuerySyntaxHelper syntaxHelper, ITextNormalizer<string> normalizer 
+			)
 		{
-			int indexOut = 0;
-			LoopAction action = LoopAction.None;
-			var character = input[index];
+			_input = input;
+			_globalLanguage = languageCode;
+			_querySyntaxHelper = syntaxHelper;
+			_textNormalizer = normalizer;
+		}
 
-			// Checks Whole query language 
-			if (stringBuilder.Length == 0 && !isBuildingAPhrase && IsAtStartOfWordOrAfterColon(input, index))
+		public List<ExtractedQueryToken> Execute()
+		{
+			for (_index = 0; _index < _input.Length; _index++)
 			{
-				if (IsLanguagePreFix(input, index, out int jump, out string detectedLanguage))
+				LoopAction action = LoopAction.None;
+				_character = _input[_index];
+
+				// Checks Whole query language 
+				if (_stringBuilder.Length == 0 && !_isBuildingAPhrase && IsAtStartOfWordOrAfterColon(_index))
 				{
-					if (index.Equals(0)) 
-						globalLanguage = detectedLanguage;
-					
-					singleTermPhraseLanguage = detectedLanguage;
-					
-					index += jump;
-					
+					if (IsLanguagePreFix(_input, _index, out int jump, out string detectedLanguage))
+					{
+						if (_index.Equals(0)) _globalLanguage = detectedLanguage;
+						
+						_singleTermPhraseLanguage = detectedLanguage;
+						
+						_index += jump;
+						
+						continue;
+					}
+				}
+				
+				// Checks implicit OR
+				action = TryHandleImplicitOr();
+
+				if (action.Equals(LoopAction.Continue)) 
+				{
+					_singleTermPhraseLanguage = null!;
 					continue;
 				}
+
+				// Checks for grouping operators. ( ) [ ] { } 
+				action = TryHandleIsGroupingOperator();
+
+				if (action.Equals(LoopAction.Continue))	continue;
+
+				// AND, OR, NOT, are exceptions and are handled in the next method.
+				action = TryHandleLogicalOperator();
+
+				if (action.Equals(LoopAction.Continue)) continue;
+				
+
+				action = TryHandleIsCapitalLetterOperator();
+
+				if (action.Equals(LoopAction.Continue)) continue;
+				
+				// Found start of a phrase
+				if (IsEdgeOfPhrase())
+				{
+					_isBuildingAPhrase = !_isBuildingAPhrase; // ToDo: Move to IsEdgeOfPhrase?
+					continue;
+				}
+
+				// Appends phrase characters and flushes phrase if is edge of phrase
+				action = TryHandleIsEdgeOfPhrase(_character, ResolveLanguage(_singleTermPhraseLanguage, _globalLanguage));
+
+				if (action.Equals(LoopAction.Continue)) 
+				{
+					_singleTermPhraseLanguage = null!;
+					continue;
+				};
+
+				// If this is reached must be term
+				if (IsTokenTerm(_character))
+				{
+					Flush(QueryTokenType.Term, ResolveLanguage(_singleTermPhraseLanguage, _globalLanguage));
+					_singleTermPhraseLanguage = null!;
+					continue;
+				}
+				else
+				{
+					_stringBuilder.Append(_character);
+				}
 			}
+
+			// Handles the last term if there is one
+			Flush(QueryTokenType.Term, ResolveLanguage(_singleTermPhraseLanguage, _globalLanguage));
 			
-            // Checks implicit OR
-            action = TryHandleImplicitOr(
-				input, tokens, stringBuilder, ref isBuildingAPhrase, index, ResolveLanguage(singleTermPhraseLanguage, globalLanguage)
-			);
+			_querySyntaxHelper.ValidateGrouping(_tokens);
 
-            if (action.Equals(LoopAction.Continue)) 
+			return _tokens;
+		}
+
+
+		private void Flush( QueryTokenType queryTokenType, string languageCode)
+		{
+			if (_stringBuilder.Length == 0) return;
+
+			var originalText = _stringBuilder.ToString().Trim();
+			string finalToken;
+		
+			// Handles term and phrase normalization and token creation
+			if (queryTokenType == QueryTokenType.Term || queryTokenType == QueryTokenType.Phrase)
 			{
-				singleTermPhraseLanguage = null!;
-				continue;
-			}
+				var words = originalText.Split(' ', StringSplitOptions.RemoveEmptyEntries);
 
-            // Checks for grouping operators. ( ) [ ] { } 
-            action = TryHandleIsGroupingOperator(
-				tokens, stringBuilder, character, ResolveLanguage(singleTermPhraseLanguage, globalLanguage)
-			);
+				var normalizedWords = words
+					.Select(word => _textNormalizer.Normalize(word, languageCode))
+					.Where(nWord => !string.IsNullOrWhiteSpace(nWord));  
 
-			if (action.Equals(LoopAction.Continue))	continue;
-
-			// AND, OR, NOT, are exceptions and are handled in the next method.
-			(action, indexOut) = TryHandleLogicalOperator(
-				input, tokens, stringBuilder, index, character, ResolveLanguage(singleTermPhraseLanguage, globalLanguage)
-			);
-
-			if (action.Equals(LoopAction.Continue))
-			{
-				index += indexOut;
-				continue;
-			}
-
-			(action, indexOut) = TryHandleIsCapitalLetterOperator(
-				input, tokens, stringBuilder, index, ResolveLanguage(singleTermPhraseLanguage, globalLanguage)
-			);
-
-			if (action.Equals(LoopAction.Continue))
-			{
-				index += indexOut;
-				continue;
-			}
-
-			// Found start of a phrase
-			if (IsEdgeOfPhrase(input, index, character))
-			{
-				isBuildingAPhrase = !isBuildingAPhrase;
-				continue;
-			}
-
-			// Appends phrase characters and flushes phrase if is edge of phrase
-			action = TryHandleIsEdgeOfPhrase(
-				input, tokens, stringBuilder, ref isBuildingAPhrase, index, character, ResolveLanguage(singleTermPhraseLanguage, globalLanguage)
-			);
-
-			if (action.Equals(LoopAction.Continue)) 
-			{
-				singleTermPhraseLanguage = null!;
-				continue;
-			};
-
-			// If this is reached must be term
-			if (IsTokenTerm(character))
-			{
-				Flush(stringBuilder, tokens, QueryTokenType.Term, ResolveLanguage(singleTermPhraseLanguage, globalLanguage));
-				singleTermPhraseLanguage = null!;
-				continue;
+				finalToken = string.Join(' ', normalizedWords);	
 			}
 			else
 			{
-				stringBuilder.Append(character);
+				finalToken = originalText;
 			}
+
+			if (finalToken is not null)
+			{
+				_tokens.Add(new ExtractedQueryToken(queryTokenType, finalToken, languageCode));
+			}
+			
+			_stringBuilder.Clear();
 		}
 
-		// Handles the last term if there is one
-		Flush(stringBuilder, tokens, QueryTokenType.Term, ResolveLanguage(singleTermPhraseLanguage, globalLanguage));
-		
-		_syntaxHelper.ValidateGrouping(tokens);
 
-		return tokens;
-	}
-
-
-    private LoopAction TryHandleImplicitOr(
-       string input,
-       List<ExtractedQueryToken> tokens,
-       StringBuilder stringBuilder,
-       ref bool isBuildingAPhrase,
-       int index, 
-	   string languageCode)
-    {
-        char character = input[index];
-
-        // Only handle whitespace outside phrases
-        if (!char.IsWhiteSpace(character) || isBuildingAPhrase) return LoopAction.None;
-
-        // No term being built → nothing to separate
-        if (stringBuilder.Length == 0) return LoopAction.None;
-
-        // Prevent implicit OR when term starts with quote (unclosed phrase case)
-        if (stringBuilder[0] == '"') return LoopAction.None;
-
-        // Look ahead to next character
-        if (index + 1 < input.Length)
-        {
-            char next = input[index + 1];
-
-            // Do not insert OR before phrases or operators
-            if (next == '"' ||
-                "!+-&|".Contains(next) ||
-                IsCapitalLetterOperator(input, index + 1) ||
-				IsLanguagePreFix(input, index + 1))
-            {
-                return LoopAction.None;
-            }
-        }
-
-        int tokenCountBeforeFlush = tokens.Count;
-
-        Flush(stringBuilder, tokens, QueryTokenType.Term, languageCode);
-
-        // Flush may not add a token if normalization removes it
-        if (tokens.Count == tokenCountBeforeFlush) return LoopAction.Continue;
-
-        tokens.Add(new ExtractedQueryToken(QueryTokenType.LogicalOperator,"OR", languageCode));
-
-        return LoopAction.Continue;
-    }
-
-
-	private bool IsLanguagePreFix(string input, int index, out int jump, out string detectedLanguage)
-	{
-		jump = 0;		
-		detectedLanguage = null!;
-
-		if (index + 2 >= input.Length) return false;
-		
-		if (input[index + 2].Equals(':'))
+		private LoopAction TryHandleImplicitOr()
 		{
-			detectedLanguage = input.Substring(index, 2);
-			jump = 2;
-			return true;
-		}
+			// Only handle whitespace outside phrases
+			if (!char.IsWhiteSpace(_character) || _isBuildingAPhrase) return LoopAction.None;
 
-		return false;
-	}
+			// No term being built → nothing to separate
+			if (_stringBuilder.Length == 0) return LoopAction.None;
 
+			// Prevent implicit OR when term starts with quote (unclosed phrase case)
+			if (_stringBuilder[0] == '"') return LoopAction.None;
 
-	private bool IsLanguagePreFix(string input, int index) => 
-		IsLanguagePreFix(input, index, out _, out _);
+			// Look ahead to next character
+			if (_index + 1 < _input.Length)
+			{
+				char next = _input[_index + 1];
 
-	
-	private string ResolveLanguage(string active, string global) => active ?? global; 
+				// Do not insert OR before phrases or operators
+				if (next == '"' ||
+					"!+-&|".Contains(next) ||
+					IsCapitalLetterOperator(_input, _index + 1) ||
+					IsLanguagePreFix(_input, _index + 1))
+				{
+					return LoopAction.None;
+				}
+			}
 
+			int tokenCountBeforeFlush = _tokens.Count;
 
+			Flush(QueryTokenType.Term, ResolveLanguage(_singleTermPhraseLanguage, _globalLanguage));
 
-    private LoopAction TryHandleIsGroupingOperator(
-		List<ExtractedQueryToken> tokens, StringBuilder stringBuilder, char character, string languageCode)
-	{
-		if (IsGroupingOperator(character))
-		{
-			stringBuilder.Append(character);
-			Flush(stringBuilder, tokens, QueryTokenType.GroupingOperator, languageCode);
+			// Flush may not add a token if normalization removes it
+			if (_tokens.Count == tokenCountBeforeFlush) return LoopAction.Continue;
+
+			_tokens.Add(new ExtractedQueryToken(
+				QueryTokenType.LogicalOperator, "OR", ResolveLanguage(_singleTermPhraseLanguage, _globalLanguage)
+			));
+
 			return LoopAction.Continue;
 		}
 
-		return LoopAction.None;
-	}
 
-
-	private bool IsGroupingOperator(char character) => "(){}[]".Contains(character);
-
-
-	private (LoopAction loopAction, int indexJump) TryHandleLogicalOperator(
-		string input, 
-		List<ExtractedQueryToken> tokens, 
-		StringBuilder stringBuilder, 
-		int index, 
-		char character, 
-		string languageCode
-		)
-	{
-		if (IsLogicalOperator(input, index, character))
+		private bool IsLanguagePreFix(string input, int index, out int jump, out string detectedLanguage)
 		{
-			if (IsDoubleLogicalOperator(input, index, character))
+			jump = 0;		
+			detectedLanguage = null!;
+
+			if (index + 2 >= input.Length) return false;
+			
+			if (input[index + 2].Equals(':'))
 			{
-				stringBuilder.Append(input, index++, 2);
-				Flush(stringBuilder, tokens, QueryTokenType.LogicalOperator, languageCode);
-				return (LoopAction.Continue, 1);
+				detectedLanguage = input.Substring(index, 2);
+				jump = 2;
+				return true;
 			}
 
-			stringBuilder.Append(character);
-			Flush(stringBuilder, tokens, QueryTokenType.LogicalOperator, languageCode);
-			return (LoopAction.Continue, 0);
+			return false;
 		}
 
-		return (LoopAction.None, 0);
-	}
+
+		private bool IsLanguagePreFix(string input, int index) => IsLanguagePreFix(input, index, out _, out _);
+		
+		private string ResolveLanguage(string active, string global) => active ?? global; 
 
 
-	private (LoopAction loopAction, int indexOut ) TryHandleIsCapitalLetterOperator(
-		string input,
-		List<ExtractedQueryToken> tokens,
-		StringBuilder stringBuilder,
-		int index,
-		string languageCode
-		)
-	{
-		if (IsCapitalLetterOperator(input, index))
+
+		private LoopAction TryHandleIsGroupingOperator()
 		{
-			var span = input.AsSpan(index);
-			int length = (span.StartsWith("AND") || span.StartsWith("NOT")) ? 3 : 2;
-
-			stringBuilder.Append(input, index, length);
-			Flush(stringBuilder, tokens, QueryTokenType.LogicalOperator, languageCode);
-
-			index += (length - 1);
-			return (LoopAction.Continue, length - 1);
-		}
-
-		return (LoopAction.None, 0);
-	}
-
-
-	private LoopAction TryHandleIsEdgeOfPhrase(
-		string input,
-		List<ExtractedQueryToken> tokens,
-		StringBuilder stringBuilder,
-		ref bool isBuildingAPhrase,
-		int index,
-		char character,
-		string languageCode
-		)
-	{
-		if (isBuildingAPhrase)
-		{
-			// Found end of phrase, builds string
-			if (IsEdgeOfPhrase(input, index, character, checkEndPhrase: true))
+			if (IsGroupingOperator(_character))
 			{
-				isBuildingAPhrase = !isBuildingAPhrase;
-				Flush(stringBuilder, tokens, QueryTokenType.Phrase, languageCode);
+				_stringBuilder.Append(_character);
+				Flush(QueryTokenType.GroupingOperator, ResolveLanguage(_singleTermPhraseLanguage, _globalLanguage));
 				return LoopAction.Continue;
 			}
 
-			stringBuilder.Append(character);
-			return LoopAction.Continue;
+			return LoopAction.None;
 		}
 
-		return LoopAction.None;
-	}
+
+		private bool IsGroupingOperator(char character) => "(){}[]".Contains(character);
 
 
-	private bool IsLogicalOperator(string input, int index, char character)
-	{
-		if ((index.Equals(0) || char.IsWhiteSpace(input[index - 1])) &&
-			Regex.IsMatch(character.ToString(), @"[\+\-\!\&\|]")
-			)
+		private LoopAction TryHandleLogicalOperator()
 		{
-			return true;			
+			if (IsLogicalOperator(_character))
+			{
+				if (IsDoubleLogicalOperator(_character))
+				{
+					_stringBuilder.Append(_input, _index++, 2);
+					Flush(QueryTokenType.LogicalOperator, ResolveLanguage(_singleTermPhraseLanguage, _globalLanguage));
+					return LoopAction.Continue;
+				}
+
+				_stringBuilder.Append(_character);
+				Flush(QueryTokenType.LogicalOperator, ResolveLanguage(_singleTermPhraseLanguage, _globalLanguage));
+				return LoopAction.Continue;
+			}
+
+			return LoopAction.None;
 		}
 
-		return false;
-	}
 
-
-	private bool IsDoubleLogicalOperator(string input, int index, char character)
-	{
-		return 
-			IsNotNullIndex(index + 1, input.Length) && 
-			input[index + 1].Equals(character);
-	}
-
-
-	private bool IsCapitalLetterOperator(string input, int index)
-	{
-		bool isAtStartOrAfterSpace = IsAtStartOfWordOrAfterColon(input, index);
-
-		if (!isAtStartOrAfterSpace) return false;
-
-		var remaining = input.AsSpan(index);
-
-		
-		if (remaining.StartsWith("NOT") && IsFullWord(remaining, 3)) return true;
-		if (remaining.StartsWith("AND") && IsFullWord(remaining, 3)) return true;
-		if (remaining.StartsWith("OR") && IsFullWord(remaining, 2)) return true;
-
-		return false;
-	}
-
-
-	private bool IsAtStartOfWordOrAfterColon(string input, int index)
-	{
-		if (index == 0) return true;
-		
-		char prev = input[index - 1];
-   		
-		return char.IsWhiteSpace(prev) || prev == ':';
-	}
-
-
-	// Makes sure that the while word is as only as long as the operator
-	private bool IsFullWord(ReadOnlySpan<char> span, int length) =>	
-		span.Length == length || char.IsWhiteSpace(span[length]);
-
-
-	private bool IsEdgeOfPhrase(
-		string input,
-		int index,
-		char character,
-		bool checkEndPhrase = false
-		)
-	{
-		if (checkEndPhrase) 
+		private LoopAction TryHandleIsCapitalLetterOperator()
 		{
-			char c = input[index];
-			return c == '"' || c == '“' || c == '”';
+			if (IsCapitalLetterOperator(_input, _index))
+			{
+				var span = _input.AsSpan(_index);
+				int length = (span.StartsWith("AND") || span.StartsWith("NOT")) ? 3 : 2;
+
+				_stringBuilder.Append(_input, _index, length);
+				Flush(QueryTokenType.LogicalOperator, ResolveLanguage(_singleTermPhraseLanguage, _globalLanguage));
+
+				_index += (length - 1);
+				return LoopAction.Continue;
+			}
+
+			return LoopAction.None;
 		}
 
-		return input[index].Equals('"') &&
-				IsNotNullIndex(index + 1, input.Length) &&
-				ContainsEndQuote(input, index + 1);
+
+		private LoopAction TryHandleIsEdgeOfPhrase(char character, string languageCode)
+		{
+			if (_isBuildingAPhrase)
+			{
+				// Found end of phrase, builds string
+				if (IsEdgeOfPhrase(checkEndPhrase: true))
+				{
+					_isBuildingAPhrase = !_isBuildingAPhrase;
+					Flush(QueryTokenType.Phrase, languageCode);
+					return LoopAction.Continue;
+				}
+
+				_stringBuilder.Append(character);
+				return LoopAction.Continue;
+			}
+
+			return LoopAction.None;
+		}
+
+
+		private bool IsLogicalOperator(char character)
+		{
+			if ((_index.Equals(0) || char.IsWhiteSpace(_input[_index - 1])) &&
+				Regex.IsMatch(character.ToString(), @"[\+\-\!\&\|]")
+				)
+			{
+				return true;			
+			}
+
+			return false;
+		}
+
+
+		private bool IsDoubleLogicalOperator(char character)
+		{
+			return 
+				IsNotNullIndex(_index + 1, _input.Length) && 
+				_input[_index + 1].Equals(character);
+		}
+
+
+		private bool IsCapitalLetterOperator(string input, int index)
+		{
+			bool isAtStartOrAfterSpace = IsAtStartOfWordOrAfterColon(index);
+
+			if (!isAtStartOrAfterSpace) return false;
+
+			var remaining = input.AsSpan(index);
+
+			
+			if (remaining.StartsWith("NOT") && IsFullWord(remaining, 3)) return true;
+			if (remaining.StartsWith("AND") && IsFullWord(remaining, 3)) return true;
+			if (remaining.StartsWith("OR") && IsFullWord(remaining, 2)) return true;
+
+			return false;
+		}
+
+
+		private bool IsAtStartOfWordOrAfterColon(int index)
+		{
+			if (index == 0) return true;
+			
+			char prev = _input[index - 1];
+			
+			return char.IsWhiteSpace(prev) || prev == ':';
+		}
+
+
+		// Makes sure that the while word is as only as long as the operator
+		private bool IsFullWord(ReadOnlySpan<char> span, int length) =>	
+			span.Length == length || char.IsWhiteSpace(span[length]);
+
+
+		private bool IsEdgeOfPhrase(bool checkEndPhrase = false)
+		{
+			if (checkEndPhrase) 
+			{
+				char c = _input[_index];
+				return c == '"' || c == '“' || c == '”';
+			}
+
+			return _input[_index].Equals('"') &&
+					IsNotNullIndex(_index + 1, _input.Length) &&
+					ContainsEndQuote(_input, _index + 1);
+		}
+
+
+		private bool ContainsEndQuote(string input, int index)
+		{
+			if (index < 0 || index >= input.Length) return false;
+
+			for (int i = index; i < input.Length; i++)
+				if (input[i] == '"' || input[i] == '“' || input[i] == '”') return true;
+
+			return false;
+		}
+
+
+		private bool IsTokenTerm(char character) => char.IsWhiteSpace(character);
+
+
+		// ToDo: extract to own static helper class
+		private bool IsNotNullIndex(int index, int length)
+			=> index >= 0 && index < length;
 	}
-
-
-	private bool ContainsEndQuote(string input, int index)
-	{
-		if (index < 0 || index >= input.Length) return false;
-
-		for (int i = index; i < input.Length; i++)
-			if (input[i] == '"' || input[i] == '“' || input[i] == '”') return true;
-
-		return false;
-	}
-
-
-	private bool IsTokenTerm(char character) => char.IsWhiteSpace(character);
-
-
-	// ToDo: extract to own static helper class
-	private bool IsNotNullIndex(int index, int length)
-		=> index >= 0 && index < length;
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/IQueryParser.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/IQueryParser.cs
@@ -1,8 +1,9 @@
-﻿using LTU.SearchEngine.Backend.Core.Model.ValueObjects.QueryNodes;
+﻿using LTU.SearchEngine.Backend.Core.Model.DTOs;
+using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
 
 namespace LTU.SearchEngine.Application.QueryParsing;
 
 public interface IQueryParser
 {
-	QueryNode<HashSet<int>> Parse(string rawQuery, string languageCode = "sv");
+	QueryParsingResult<HashSet<int>, IgnoredTermsDTO> Parse(string rawQuery, string languageCode = "sv");
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/IQueryParser.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/IQueryParser.cs
@@ -3,7 +3,36 @@ using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
 
 namespace LTU.SearchEngine.Application.QueryParsing;
 
+/// <summary>
+/// Defines a service for transforming a raw search string into an executable query tree.
+/// </summary>
+/// <remarks>
+/// This component orchestrates the transition from unstructured text to a structured 
+/// logical representation by coordinating string tokenization and tree construction.
+/// </remarks>
 public interface IQueryParser
 {
+	/// <summary>
+    /// Parses a raw query string into a structured query result, including the logical root node and any ignored terms.
+    /// </summary>
+    /// <param name="rawQuery">The raw, unparsed string input provided by the user.</param>
+    /// <param name="languageCode">The ISO language code (e.g., "sv", "en") used to drive normalization and language-specific parsing rules.</param>
+    /// <returns>
+    /// A <see cref="QueryParsingResult{TResult, TIgnoredToken}"/> containing:
+    /// <list type="bullet">
+    /// 	<item>
+    /// 		<description><see cref="QueryParsingResult{TResult, TIgnoredToken}.RootNode"/>: 
+    /// 		The root of the constructed query tree used for document matching.</description>
+    /// 	</item>
+    /// 	<item>
+    /// 		<description><see cref="QueryParsingResult{TResult, TIgnoredToken}.IgnoredTokens"/>: 
+    /// 		A collection of terms that were identified but excluded (e.g., stop-words) during the tokenization process.</description>
+    /// 	</item>
+    /// </list>
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="rawQuery"/> is null.</exception>
+    /// <exception cref="Backend.Core.Exceptions.InvalidQueryStringException">
+    /// Thrown when the query contains syntax errors that prevent a valid tree from being constructed (e.g., mismatched grouping operators).
+    /// </exception>
 	QueryParsingResult<HashSet<int>, IgnoredTermsDTO> Parse(string rawQuery, string languageCode = "sv");
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/QueryParser.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/QueryParser.cs
@@ -1,5 +1,5 @@
 ﻿using LTU.SearchEngine.Application.QueryParsing.Helpers;
-using LTU.SearchEngine.Backend.Core.Enums;
+using LTU.SearchEngine.Backend.Core.Model.DTOs;
 using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
 using LTU.SearchEngine.Backend.Core.Model.ValueObjects.QueryNodes;
 using LTU.SearchEngine.Backend.Core.SearchQueryBuilder;
@@ -9,11 +9,11 @@ namespace LTU.SearchEngine.Application.QueryParsing;
 public class QueryParser : IQueryParser
 {
 	private readonly ITreeBuilder<HashSet<int>, ExtractedQueryToken> _treeBuilder;
-	private readonly IStringTokenizer<ExtractedQueryToken, QueryTokenType> _stringTokenizer;
+	private readonly IStringTokenizer<ExtractedQueryToken, IgnoredTermsDTO> _stringTokenizer;
 
 	public QueryParser(
 		ITreeBuilder<HashSet<int>, ExtractedQueryToken> treeBuilder,
-		IStringTokenizer<ExtractedQueryToken, QueryTokenType> stringTokenizer
+		IStringTokenizer<ExtractedQueryToken, IgnoredTermsDTO> stringTokenizer
 		)
 	{
 		_treeBuilder = treeBuilder ??
@@ -23,11 +23,14 @@ public class QueryParser : IQueryParser
 			throw new ArgumentNullException("String tokenizer cannot be null.", nameof(stringTokenizer));
 	}
 
-	public QueryNode<HashSet<int>> Parse(string rawQuery, string languageCode = "sv")
+	public QueryParsingResult<HashSet<int>, IgnoredTermsDTO> Parse(string rawQuery, string languageCode = "sv")
 	{
-		List<ExtractedQueryToken> tokens = _stringTokenizer.Tokenize(rawQuery, languageCode);
-		QueryNode<HashSet<int>> rootNode = _treeBuilder.BuildTree(tokens);
+		var tokenizerResult = _stringTokenizer.Tokenize(rawQuery, languageCode);
 
-		return rootNode;
+		QueryNode<HashSet<int>> rootNode = _treeBuilder.BuildTree(tokenizerResult.Tokens);
+
+		return new QueryParsingResult<HashSet<int>, IgnoredTermsDTO>(
+			rootNode, tokenizerResult.IgnoredTokens
+		); 
 	}
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/QueryParser.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/QueryParser.cs
@@ -6,11 +6,28 @@ using LTU.SearchEngine.Backend.Core.SearchQueryBuilder;
 
 namespace LTU.SearchEngine.Application.QueryParsing;
 
+/// <summary>
+/// Provides a concrete implementation of <see cref="IQueryParser"/> that orchestrates 
+/// the conversion of raw text into a structured query tree.
+/// </summary>
+/// <remarks>
+/// This implementation follows a two-step pipeline:
+/// <list type="number">
+/// 	<item><description>Tokenization and normalization via an <see cref="IStringTokenizer{TToken, TIgnoredToken}"/>.</description></item>
+/// 	<item><description>Tree construction via an <see cref="ITreeBuilder{TResult, TToken}"/>.</description></item>
+/// </list>
+/// </remarks>
 public class QueryParser : IQueryParser
 {
 	private readonly ITreeBuilder<HashSet<int>, ExtractedQueryToken> _treeBuilder;
 	private readonly IStringTokenizer<ExtractedQueryToken, IgnoredTermsDTO> _stringTokenizer;
 
+	/// <summary>
+    /// Initializes a new instance of the <see cref="QueryParser"/> class.
+    /// </summary>
+    /// <param name="treeBuilder">The builder responsible for transforming tokens into a logical tree structure.</param>
+    /// <param name="stringTokenizer">The tokenizer responsible for segmenting and normalizing the raw input string.</param>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="treeBuilder"/> or <paramref name="stringTokenizer"/> is null.</exception>
 	public QueryParser(
 		ITreeBuilder<HashSet<int>, ExtractedQueryToken> treeBuilder,
 		IStringTokenizer<ExtractedQueryToken, IgnoredTermsDTO> stringTokenizer
@@ -23,6 +40,7 @@ public class QueryParser : IQueryParser
 			throw new ArgumentNullException("String tokenizer cannot be null.", nameof(stringTokenizer));
 	}
 
+	/// <inheritdoc/>
 	public QueryParsingResult<HashSet<int>, IgnoredTermsDTO> Parse(string rawQuery, string languageCode = "sv")
 	{
 		var tokenizerResult = _stringTokenizer.Tokenize(rawQuery, languageCode);

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/QueryService.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/QueryService.cs
@@ -24,6 +24,7 @@ public class QueryService : IQueryService
 		_queryEvaluatorVisitor = queryEvaluatorVisitor;
 	}
 
+	/// <inheritdoc/>
 	public async Task<SearchResponseDTO> GetSearchResultsAsync(string rawQuery, string languageCode = "sv")
 	{
 		QueryNode<HashSet<int>> queryNode;
@@ -32,7 +33,13 @@ public class QueryService : IQueryService
 
 		queryNode = _queryParser.Parse(rawQuery, languageCode);
 		
-		var resultIds = await _queryEvaluatorVisitor.ExecuteAsync(queryNode);
+		HashSet<int> resultIds;
+		
+		if (queryNode is IIsVoidable voidableNode && voidableNode.IsVoid()) 
+			resultIds = new HashSet<int>();
+		else
+			resultIds = await _queryEvaluatorVisitor.ExecuteAsync(queryNode);
+		
 		
 		var documentResults = await _indexRepository
 			.GetDocumentsByIdAsync(resultIds.ToList());

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/QueryService.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/QueryService.cs
@@ -27,11 +27,10 @@ public class QueryService : IQueryService
 	/// <inheritdoc/>
 	public async Task<SearchResponseDTO> GetSearchResultsAsync(string rawQuery, string languageCode = "sv")
 	{
-		QueryNode<HashSet<int>> queryNode;
-
+		
 		var stopWatch = Stopwatch.StartNew();
 
-		queryNode = _queryParser.Parse(rawQuery, languageCode);
+		var (queryNode, ignoredTokens) = _queryParser.Parse(rawQuery, languageCode);
 		
 		HashSet<int> resultIds;
 		
@@ -61,7 +60,8 @@ public class QueryService : IQueryService
 			currentPage: 1,
 			pageSize: 1,
 			totalResults: documentResults.Count(),
-			message: timingMessage
+			message: timingMessage,
+			ignoredTokens: ignoredTokens
 		);
 	}
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/DTOs/IgnoredTermsDTO.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/DTOs/IgnoredTermsDTO.cs
@@ -1,0 +1,7 @@
+namespace LTU.SearchEngine.Backend.Core.Model.DTOs;
+
+public class IgnoredTermsDTO
+{
+    public string Token { get; set; } = null!;
+    public string Language { get; set; } = null!;
+}

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/DTOs/SearchResponseDTO.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/DTOs/SearchResponseDTO.cs
@@ -11,10 +11,12 @@ namespace LTU.SearchEngine.Backend.Core.Model.DTOs;
 /// <param name="pageSize">The maximum number of items requested per page.</param>
 /// <param name="totalResults">The total number of documents matching the search criteria across all pages.</param>
 /// <param name="message">An optional status or warning message (e.g., "No results found" or "Query expanded").</param>
+/// <param name="ignoredTokens">An optional collection of <see cref="IgnoredTermsDTO"/> representing any tokens that were ignored during query parsing.</param>
 public record SearchResponseDTO(
 	IEnumerable<DocumentDTO> searchResults,
 	int currentPage,
 	int pageSize,
 	int totalResults,
-	string? message
+	string? message,
+	IEnumerable<IgnoredTermsDTO>? ignoredTokens = null
 );

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/ExtractedQueryToken.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/ExtractedQueryToken.cs
@@ -10,8 +10,8 @@ public class ExtractedQueryToken
 
 	public ExtractedQueryToken(QueryTokenType tokenType, string token, string language = "sv")
 	{
-		if (string.IsNullOrWhiteSpace(token))
-			throw new ArgumentException("Token cannot be empty.", nameof(token));
+		// if (string.IsNullOrWhiteSpace(token))
+		// 	throw new ArgumentException("Token cannot be empty.", nameof(token));
 
 		if (tokenType.Equals(QueryTokenType.LogicalOperator) && token.Length > 3)
 			throw new ArgumentOutOfRangeException(

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/ExtractedQueryToken.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/ExtractedQueryToken.cs
@@ -10,18 +10,21 @@ public class ExtractedQueryToken
 
 	public ExtractedQueryToken(QueryTokenType tokenType, string token, string language = "sv")
 	{
-		// if (string.IsNullOrWhiteSpace(token))
-		// 	throw new ArgumentException("Token cannot be empty.", nameof(token));
-
 		if (tokenType.Equals(QueryTokenType.LogicalOperator) && token.Length > 3)
+		{
 			throw new ArgumentOutOfRangeException(
-				"Logical Operator cannot be longer than 3 characters.", nameof(token)
+				"Logical Operator cannot be longer than 3 characters.", 
+				nameof(token)
 			);
+		}
 
 		if (tokenType.Equals(QueryTokenType.GroupingOperator) && token.Length > 1)
+		{
 			throw new ArgumentOutOfRangeException(
-				"grouping Operator cannot be longer than a single characters.", nameof(token)
+				"grouping Operator cannot be longer than a single characters.", 
+				nameof(token)
 			);
+		}
 
 		Token = token;
 		TokenType = tokenType;

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/QueryNodes/IIsVoidable.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/QueryNodes/IIsVoidable.cs
@@ -1,0 +1,6 @@
+namespace LTU.SearchEngine.Backend.Core.Model.ValueObjects.QueryNodes;
+
+public interface IIsVoidable
+{
+    bool IsVoid();
+}

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/QueryNodes/IIsVoidable.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/QueryNodes/IIsVoidable.cs
@@ -1,6 +1,17 @@
 namespace LTU.SearchEngine.Backend.Core.Model.ValueObjects.QueryNodes;
 
+/// <summary>
+/// Defines a mechanism for query nodes to indicate whether they lack semantic value 
+/// and should be excluded from the final execution or tree transformation.
+/// </summary>
 public interface IIsVoidable
 {
+    /// <summary>
+    /// Determines whether the current node is considered "void" or logically non-existent.
+    /// </summary>
+    /// <returns>
+    /// <see langword="true"/> if the node lacks searchable content or logical operands 
+    /// and should be pruned from the query tree; otherwise, <see langword="false"/>.
+    /// </returns>
     bool IsVoid();
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/QueryNodes/PhraseNode.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/QueryNodes/PhraseNode.cs
@@ -1,4 +1,4 @@
-﻿using LTU.SearchEngine.Backend.Core.Model.Entities;
+﻿using System.Runtime.CompilerServices;
 using LTU.SearchEngine.Backend.Core.SearchQueryBuilder;
 
 namespace LTU.SearchEngine.Backend.Core.Model.ValueObjects.QueryNodes;
@@ -12,7 +12,7 @@ namespace LTU.SearchEngine.Backend.Core.Model.ValueObjects.QueryNodes;
 /// A PhraseNode is used to represent quoted strings from the user input, ensuring that the <br />
 /// included tokens are treated as a single, ordered unit during the search process.
 /// </remarks>
-public class PhraseNode<T> : QueryNode<T>
+public class PhraseNode<T> : QueryNode<T>, IIsVoidable
 {
 	public List<ExtractedQueryToken> Phrase { get; }
 
@@ -26,24 +26,27 @@ public class PhraseNode<T> : QueryNode<T>
 		Phrase = phrase;
 	}
 
-	/// <inheritdoc>/>
+	/// <inheritdoc/>
 	public override Task<T> AcceptAsync(IQueryVisitor<T> visitor)
 		=> visitor.VisitAsync(this);
+
+	public bool IsVoid() 
+		=>  Phrase == null || Phrase.Count == 0 || Phrase.All( t => string.IsNullOrWhiteSpace(t.Token));
 
 	/// <summary>
 	/// Used for debugging and visualization purposes, returns the phrase as a <br/>
 	/// single string contained in this node.
 	/// </summary>
 	/// <returns>The currently stored phrase as a single string.</returns>
-	public override string ToString() => 
-		$"\"{string.Join(" ", Phrase.Select(t => t.Token))}\"";
+	public override string ToString() 
+		=> $"\"{string.Join(" ", Phrase.Select(t => t.Token))}\"";
 
 	private void ValidatePhrase(List<ExtractedQueryToken> phrase)
 	{
 		if (phrase is null)
 			throw new ArgumentNullException(nameof(phrase), "must have a value.");
 
-		if (phrase.Count < 1)
-			throw new ArgumentException(nameof(phrase), "cannot be empty.");
+		// if (phrase.Count < 1)
+		// 	throw new ArgumentException(nameof(phrase), "cannot be empty.");
 	}
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/QueryNodes/PhraseNode.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/QueryNodes/PhraseNode.cs
@@ -1,5 +1,4 @@
-﻿using System.Runtime.CompilerServices;
-using LTU.SearchEngine.Backend.Core.SearchQueryBuilder;
+﻿using LTU.SearchEngine.Backend.Core.SearchQueryBuilder;
 
 namespace LTU.SearchEngine.Backend.Core.Model.ValueObjects.QueryNodes;
 
@@ -19,17 +18,16 @@ public class PhraseNode<T> : QueryNode<T>, IIsVoidable
 	/// <summary>Initializes a new instance of the <see cref="PhraseNode{T}"/> class.</summary>
 	/// <param name="phrase">A list of <see cref="ExtractedQueryToken"/> forming the phrase. Cannot be null.</param>
 	/// <exception cref="ArgumentNullException">Thrown if the provided phrase list is null.</exception>
-	/// <exception cref="ArgumentException">Thrown if the provided phrase list is empty.</exception>
 	public PhraseNode(List<ExtractedQueryToken> phrase)
 	{
-		ValidatePhrase(phrase);
-		Phrase = phrase;
+		Phrase = phrase ?? throw new ArgumentNullException(nameof(phrase), "must have a value.");
 	}
 
 	/// <inheritdoc/>
 	public override Task<T> AcceptAsync(IQueryVisitor<T> visitor)
 		=> visitor.VisitAsync(this);
 
+	/// <inheritdoc/>
 	public bool IsVoid() 
 		=>  Phrase == null || Phrase.Count == 0 || Phrase.All( t => string.IsNullOrWhiteSpace(t.Token));
 
@@ -40,13 +38,4 @@ public class PhraseNode<T> : QueryNode<T>, IIsVoidable
 	/// <returns>The currently stored phrase as a single string.</returns>
 	public override string ToString() 
 		=> $"\"{string.Join(" ", Phrase.Select(t => t.Token))}\"";
-
-	private void ValidatePhrase(List<ExtractedQueryToken> phrase)
-	{
-		if (phrase is null)
-			throw new ArgumentNullException(nameof(phrase), "must have a value.");
-
-		// if (phrase.Count < 1)
-		// 	throw new ArgumentException(nameof(phrase), "cannot be empty.");
-	}
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/QueryNodes/QueryNode.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/QueryNodes/QueryNode.cs
@@ -1,4 +1,5 @@
-﻿using LTU.SearchEngine.Backend.Core.SearchQueryBuilder;
+﻿using System.Runtime.CompilerServices;
+using LTU.SearchEngine.Backend.Core.SearchQueryBuilder;
 
 namespace LTU.SearchEngine.Backend.Core.Model.ValueObjects.QueryNodes;
 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/QueryNodes/QueryNode.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/QueryNodes/QueryNode.cs
@@ -1,5 +1,4 @@
-﻿using System.Runtime.CompilerServices;
-using LTU.SearchEngine.Backend.Core.SearchQueryBuilder;
+﻿using LTU.SearchEngine.Backend.Core.SearchQueryBuilder;
 
 namespace LTU.SearchEngine.Backend.Core.Model.ValueObjects.QueryNodes;
 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/QueryNodes/TermNode.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/QueryNodes/TermNode.cs
@@ -16,12 +16,11 @@ public class TermNode<T> : QueryNode<T>, IIsVoidable
 	public string Term { get; }
 
 	/// <summary>Initializes a new instance of the <see cref="TermNode{T}"/> class.</summary>
-	/// <param name="term">The search term string. Cannot be null or whitespace.</param>
-	/// <exception cref="ArgumentNullException">Thrown if the provided term is null or empty.</exception>
+	/// <param name="term">The search term string. Cannot be null.</param>
+	/// <exception cref="ArgumentNullException">Thrown if the provided term is null.</exception>
 	public TermNode(string term)
 	{
-		if (/*string.IsNullOrWhiteSpace(term)*/term is null)
-			throw new ArgumentNullException(nameof(term), "must have a value.");
+		if (term is null) throw new ArgumentNullException(nameof(term), "must have a value.");
 
 		Term = term;
 	}
@@ -31,6 +30,7 @@ public class TermNode<T> : QueryNode<T>, IIsVoidable
 	public override Task<T> AcceptAsync(IQueryVisitor<T> visitor)
 		=> visitor.VisitAsync(this);
     
+	/// <inheritdoc/>
 	public bool IsVoid() => string.IsNullOrWhiteSpace(Term);
 
 	/// <summary>
@@ -38,5 +38,4 @@ public class TermNode<T> : QueryNode<T>, IIsVoidable
 	/// </summary>
 	/// <returns>The currently stored term.</returns>
 	public override string ToString() => Term;
-
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/QueryNodes/TermNode.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/QueryNodes/TermNode.cs
@@ -11,7 +11,7 @@ namespace LTU.SearchEngine.Backend.Core.Model.ValueObjects.QueryNodes;
 /// A TermNode is an atomic element in the Abstract Syntax Tree (AST), representing <br />
 /// an unquoted keyword provided by the user.
 /// </remarks>
-public class TermNode<T> : QueryNode<T>
+public class TermNode<T> : QueryNode<T>, IIsVoidable
 {
 	public string Term { get; }
 
@@ -20,20 +20,23 @@ public class TermNode<T> : QueryNode<T>
 	/// <exception cref="ArgumentNullException">Thrown if the provided term is null or empty.</exception>
 	public TermNode(string term)
 	{
-		if (string.IsNullOrWhiteSpace(term))
+		if (/*string.IsNullOrWhiteSpace(term)*/term is null)
 			throw new ArgumentNullException(nameof(term), "must have a value.");
 
 		Term = term;
 	}
 
 
-	/// <inheritdoc>/>
+	/// <inheritdoc/>
 	public override Task<T> AcceptAsync(IQueryVisitor<T> visitor)
 		=> visitor.VisitAsync(this);
+    
+	public bool IsVoid() => string.IsNullOrWhiteSpace(Term);
 
 	/// <summary>
 	/// Used for debugging and visualization purposes, returns the term string contained in this node.
 	/// </summary>
 	/// <returns>The currently stored term.</returns>
 	public override string ToString() => Term;
+
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/QueryParsingResult.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/QueryParsingResult.cs
@@ -1,0 +1,8 @@
+using LTU.SearchEngine.Backend.Core.Model.ValueObjects.QueryNodes;
+
+namespace LTU.SearchEngine.Backend.Core.Model.ValueObjects;
+
+public record QueryParsingResult<TResult, TIgnoredToken>(
+    QueryNode<TResult> RootNode,
+    IEnumerable<TIgnoredToken> IgnoredTokens
+);

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/QueryStringTokenizingResult.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/QueryStringTokenizingResult.cs
@@ -1,0 +1,6 @@
+namespace LTU.SearchEngine.Backend.Core.Model.ValueObjects;
+
+public record QueryStringTokenizingResult<TToken, TIgnoredToken>(
+    IEnumerable<TToken> Tokens,
+    IEnumerable<TIgnoredToken> IgnoredTokens
+);

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/QueryEvaluatorVisitor.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/QueryEvaluatorVisitor.cs
@@ -1,6 +1,5 @@
 ﻿using LTU.SearchEngine.Api.ExtensionsUseExceptionHandler.CustomExceptions;
 using LTU.SearchEngine.Backend.Core.Enums;
-using LTU.SearchEngine.Backend.Core.Exceptions.SearchQueryExceptions;
 using LTU.SearchEngine.Backend.Core.Model.ValueObjects.QueryNodes;
 using LTU.SearchEngine.Backend.Core.SearchQueryBuilder;
 using LTU.SearchEngine.Infrastructure.Repositories;
@@ -58,21 +57,52 @@ public class QueryEvaluatorVisitor : IQueryVisitor<HashSet<int>>
 
 	/// <inheritdoc/>
 	public async Task<HashSet<int>> VisitAsync(LogicOperationNode<HashSet<int>> node)
-	{
-		var left = await node.LeftNode.AcceptAsync(this);
-		var right = await node.RightNode.AcceptAsync(this);
+    {
+        bool leftNodeIsVoid = IsNodeVoid(node.LeftNode);
+        bool rightNodeIsVoid = IsNodeVoid(node.RightNode);
 
-		return node.LogicalOperator switch
-		{
-			LogicalOperators.AND => left.Intersect(right).ToHashSet(),
-			LogicalOperators.OR => left.Union(right).ToHashSet(),
-			LogicalOperators.NOT => left.Except(right).ToHashSet(),
-			_ => throw new InvalidOperationException($"Unsupported logical operator: {node.LogicalOperator}")
-		};
+		if (IsWholeOperationVoid(leftNodeIsVoid, rightNodeIsVoid, node)) return new HashSet<int>();
+      	if (leftNodeIsVoid) return await node.RightNode.AcceptAsync(this);
+        if (rightNodeIsVoid) return await node.LeftNode.AcceptAsync(this);
+
+
+        var left = await node.LeftNode.AcceptAsync(this);
+        var right = await node.RightNode.AcceptAsync(this);
+
+        return node.LogicalOperator switch
+        {
+            LogicalOperators.AND => left.Intersect(right).ToHashSet(),
+            LogicalOperators.OR => left.Union(right).ToHashSet(),
+            LogicalOperators.NOT => left.Except(right).ToHashSet(),
+            _ => throw new InvalidOperationException($"Unsupported logical operator: {node.LogicalOperator}")
+        };
+    }
+
+	private bool IsWholeOperationVoid(bool leftNodeIsVoid, bool rightNodeIsVoid, LogicOperationNode<HashSet<int>> node)
+	{
+		if (leftNodeIsVoid && rightNodeIsVoid) return true;
+        if (IsRequiredPositiveLeftValueOnNotBroken(node, leftNodeIsVoid)) return true;
+
+		return false; 
 	}
 
-	/// <inheritdoc/>
-	public Task<HashSet<int>> VisitAsync(RequiredNode<HashSet<int>> node)
+    private static bool IsRequiredPositiveLeftValueOnNotBroken(LogicOperationNode<HashSet<int>> node, bool leftNodeIsVoid)
+   		=> node.LogicalOperator == LogicalOperators.NOT && leftNodeIsVoid;
+    
+
+    private static bool IsNodeVoid(QueryNode<HashSet<int>> node)
+    {
+        if (node is IIsVoidable)
+        {
+            var isVoidable = node as IIsVoidable;
+            if (isVoidable!.IsVoid()) return true;
+        }
+
+        return false;
+    }
+
+    /// <inheritdoc/>
+    public Task<HashSet<int>> VisitAsync(RequiredNode<HashSet<int>> node)
 	{
 		throw new NotImplementedException();
 	}

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/QueryEvaluatorVisitor.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/QueryEvaluatorVisitor.cs
@@ -55,7 +55,17 @@ public class QueryEvaluatorVisitor : IQueryVisitor<HashSet<int>>
 		}
 	}
 
+
 	/// <inheritdoc/>
+	/// <remarks>
+	/// This implementation evaluates the <see cref="IIsVoidable.IsVoid"/> state of the child nodes before processing.
+	/// <list type="bullet">
+	/// <item>If both nodes are void, an empty result is returned.</item>
+	/// <item>If only one node is void, the operation is bypassed and the non-void node is evaluated directly.</item>
+	/// <item>Otherwise, a set operation (Intersect, Union, or Except) is performed on the results of both branches.</item>
+	/// <item>Special handling for NOT operations ensures that if the left node is void, the entire operation is treated as void to prevent incorrect result sets.</item>
+	/// </list>
+	/// </remarks> 
 	public async Task<HashSet<int>> VisitAsync(LogicOperationNode<HashSet<int>> node)
     {
         bool leftNodeIsVoid = IsNodeVoid(node.LeftNode);
@@ -92,12 +102,9 @@ public class QueryEvaluatorVisitor : IQueryVisitor<HashSet<int>>
 
     private static bool IsNodeVoid(QueryNode<HashSet<int>> node)
     {
-        if (node is IIsVoidable)
-        {
-            var isVoidable = node as IIsVoidable;
-            if (isVoidable!.IsVoid()) return true;
-        }
-
+        if (node is IIsVoidable voidableNode && voidableNode.IsVoid()) 
+			return true;
+        
         return false;
     }
 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/SearchQueryBuilder/IQueryVisitor.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/SearchQueryBuilder/IQueryVisitor.cs
@@ -32,9 +32,15 @@ public interface IQueryVisitor<TResult>
 	/// <returns>The result of the operation on the phrase node.</returns>
 	Task<TResult> VisitAsync(PhraseNode<TResult> node);
 
-	/// <summary>Processes a binary logical operation (e.g., AND, OR) or a NOT operation.</summary>
+	/// <summary>
+	/// Processes a binary logical operation (e.g., AND, OR) or a NOT operation.
+	/// </summary>
 	/// <param name="node">The node representing the logical connection between two query branches.</param>
-	/// <returns>The combined result of the binary operation.</returns>
+	/// <returns>
+	/// The combined result of the binary operation. 
+	/// If one branch is void, the visitor may return the result of the non-void branch to simplify the execution.
+	/// If however, both branches are void, then an empty <see cref="TResult"/> is returned.
+	/// </returns> 
 	Task<TResult> VisitAsync(LogicOperationNode<TResult> node);
 
 	/// <summary>Processes a node marked with the required operator (+).</summary>

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Application.Tests/QueryParserTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Application.Tests/QueryParserTests.cs
@@ -51,7 +51,7 @@ public class QueryParserTests
 
 		_tokenizerMock
 			.Setup(t => t.Tokenize(query))
-			.Returns(queryStringTokenizingResult/*tokens*/);
+			.Returns(queryStringTokenizingResult);
 
 		_treeBuilderMock
 			.Setup(t => t.BuildTree(queryStringTokenizingResult.Tokens))
@@ -123,13 +123,11 @@ public class QueryParserTests
 	{
 		// Arrange
 		string query = "cat";
-		// var tokens = new List<ExtractedQueryToken>();
 		var queryStringTokenizingResult = 
 				QueryStringTokenizingResultBuilder.BuildQueryStringTokenizingResult();
 
 		var expectedResult = QueryParsingResultBuilder.BuildQueryParsingResult();
-		// var expectedNode = Mock.Of<QueryNode<HashSet<int>>>();
-
+	
 		_tokenizerMock
 			.Setup(t => t.Tokenize(query, languageCode: expected))
 			.Returns(queryStringTokenizingResult);
@@ -138,7 +136,7 @@ public class QueryParserTests
 			.Setup(t => t.BuildTree(queryStringTokenizingResult.Tokens))
 			.Returns(expectedResult.RootNode);
 
-		Func</*QueryNode<HashSet<int>>*/QueryParsingResult<HashSet<int>, IgnoredTermsDTO>> act = input switch
+		Func<QueryParsingResult<HashSet<int>, IgnoredTermsDTO>> act = input switch
         {
             "NO_INPUT"  => () => _parser.Parse(query),
             _           => () => _parser.Parse(query, languageCode: input)
@@ -152,5 +150,51 @@ public class QueryParserTests
 			input: It.IsAny<string>(),
 			languageCode: expected
 		));
+	}
+
+	[Fact]
+	public void Parse_ShouldIncludeIgnoredTokensInResult()
+	{
+		// Arrange
+		var query = "test";
+		var ignored = new List<IgnoredTermsDTO> { new() { Token = "stopword", Language = "sv" } };
+		
+		var tokenizerResult = new QueryStringTokenizingResult<ExtractedQueryToken, IgnoredTermsDTO>(
+			new List<ExtractedQueryToken>(), 
+			ignored
+		);
+
+		_tokenizerMock.Setup(t => t.Tokenize(query, It.IsAny<string>()))
+			.Returns(tokenizerResult);
+
+		_treeBuilderMock.Setup(t => t.BuildTree(It.IsAny<IEnumerable<ExtractedQueryToken>>()))
+			.Returns(Mock.Of<QueryNode<HashSet<int>>>());
+
+		// Act
+		var result = _parser.Parse(query);
+
+		// Assert
+		Assert.Equal(ignored, result.IgnoredTokens);
+	}
+
+	[Fact]
+	public void Parse_WhenNoTokens_ShouldStillReturnResultWithRootNode()
+	{
+		// Arrange
+		var tokenizerResult = new QueryStringTokenizingResult<ExtractedQueryToken, IgnoredTermsDTO>(
+			Enumerable.Empty<ExtractedQueryToken>(),
+			Enumerable.Empty<IgnoredTermsDTO>()
+		);
+
+		_tokenizerMock.Setup(t => t.Tokenize(It.IsAny<string>(), It.IsAny<string>())).Returns(tokenizerResult);
+		_treeBuilderMock.Setup(t => t.BuildTree(It.IsAny<IEnumerable<ExtractedQueryToken>>()))
+						.Returns(Mock.Of<QueryNode<HashSet<int>>>());
+
+		// Act
+		var result = _parser.Parse(" ");
+
+		// Assert
+		Assert.NotNull(result.RootNode);
+		Assert.Empty(result.IgnoredTokens);
 	}
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Application.Tests/QueryParserTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Application.Tests/QueryParserTests.cs
@@ -1,9 +1,10 @@
 ﻿using LTU.SearchEngine.Application.QueryParsing;
 using LTU.SearchEngine.Application.QueryParsing.Helpers;
-using LTU.SearchEngine.Backend.Core.Enums;
+using LTU.SearchEngine.Backend.Core.Model.DTOs;
 using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
 using LTU.SearchEngine.Backend.Core.Model.ValueObjects.QueryNodes;
 using LTU.SearchEngine.Backend.Core.SearchQueryBuilder;
+using LTU.SearchEngine.Test.HelperClasses;
 using Moq;
 
 namespace LTU.SearchEngine.Test.Application.Tests;
@@ -11,7 +12,7 @@ namespace LTU.SearchEngine.Test.Application.Tests;
 public class QueryParserTests
 {
 	private readonly Mock<ITreeBuilder<HashSet<int>, ExtractedQueryToken>> _treeBuilderMock;
-	private readonly Mock<IStringTokenizer<ExtractedQueryToken, QueryTokenType>> _tokenizerMock;
+	private readonly Mock<IStringTokenizer<ExtractedQueryToken, IgnoredTermsDTO>> _tokenizerMock;
 
 	private readonly QueryParser _parser;
 
@@ -20,7 +21,7 @@ public class QueryParserTests
 		_treeBuilderMock = 
 			new Mock<ITreeBuilder<HashSet<int>, ExtractedQueryToken>>();
 		_tokenizerMock = 
-			new Mock<IStringTokenizer<ExtractedQueryToken, QueryTokenType>>();
+			new Mock<IStringTokenizer<ExtractedQueryToken, IgnoredTermsDTO>>();
 
 		_parser = new QueryParser(_treeBuilderMock.Object, _tokenizerMock.Object);
 	}
@@ -44,14 +45,16 @@ public class QueryParserTests
 	{
 		// Arrange
 		string query = "cat AND dog";
-		var tokens = new List<ExtractedQueryToken>();
+		
+		var queryStringTokenizingResult = 
+			QueryStringTokenizingResultBuilder.BuildQueryStringTokenizingResult();
 
 		_tokenizerMock
 			.Setup(t => t.Tokenize(query))
-			.Returns(tokens);
+			.Returns(queryStringTokenizingResult/*tokens*/);
 
 		_treeBuilderMock
-			.Setup(t => t.BuildTree(tokens))
+			.Setup(t => t.BuildTree(queryStringTokenizingResult.Tokens))
 			.Returns(Mock.Of<QueryNode<HashSet<int>>>());
 
 		// Act
@@ -66,21 +69,23 @@ public class QueryParserTests
 	{
 		// Arrange
 		string query = "cat";
-		var tokens = new List<ExtractedQueryToken>();
+	
+		var queryStringTokenizingResult = 
+			QueryStringTokenizingResultBuilder.BuildQueryStringTokenizingResult();
 
 		_tokenizerMock
 			.Setup(t => t.Tokenize(query))
-			.Returns(tokens);
+			.Returns(queryStringTokenizingResult);
 
 		_treeBuilderMock
-			.Setup(t => t.BuildTree(tokens))
+			.Setup(t => t.BuildTree(queryStringTokenizingResult.Tokens))
 			.Returns(Mock.Of<QueryNode<HashSet<int>>>());
 
 		// Act
 		_parser.Parse(query);
 
 		// Assert
-		_treeBuilderMock.Verify(t => t.BuildTree(tokens), Times.Once);
+		_treeBuilderMock.Verify(t => t.BuildTree(queryStringTokenizingResult.Tokens), Times.Once);
 	}
 
 	[Fact]
@@ -88,23 +93,25 @@ public class QueryParserTests
 	{
 		// Arrange
 		string query = "cat";
-		var tokens = new List<ExtractedQueryToken>();
+		
+		var queryStringTokenizingResult = 
+			QueryStringTokenizingResultBuilder.BuildQueryStringTokenizingResult();
 
-		var expectedNode = Mock.Of<QueryNode<HashSet<int>>>();
-
+		var expectedResult = QueryParsingResultBuilder.BuildQueryParsingResult();
+	
 		_tokenizerMock
 			.Setup(t => t.Tokenize(query))
-			.Returns(tokens);
+			.Returns(queryStringTokenizingResult);
 
 		_treeBuilderMock
-			.Setup(t => t.BuildTree(tokens))
-			.Returns(expectedNode);
+			.Setup(t => t.BuildTree(queryStringTokenizingResult.Tokens))
+			.Returns(expectedResult.RootNode);
 
 		// Act
 		var result = _parser.Parse(query);
 
 		// Assert
-		Assert.Equal(expectedNode, result);
+		Assert.Equivalent(expectedResult, result);
 	}
 	
 	
@@ -116,19 +123,22 @@ public class QueryParserTests
 	{
 		// Arrange
 		string query = "cat";
-		var tokens = new List<ExtractedQueryToken>();
+		// var tokens = new List<ExtractedQueryToken>();
+		var queryStringTokenizingResult = 
+				QueryStringTokenizingResultBuilder.BuildQueryStringTokenizingResult();
 
-		var expectedNode = Mock.Of<QueryNode<HashSet<int>>>();
+		var expectedResult = QueryParsingResultBuilder.BuildQueryParsingResult();
+		// var expectedNode = Mock.Of<QueryNode<HashSet<int>>>();
 
 		_tokenizerMock
 			.Setup(t => t.Tokenize(query, languageCode: expected))
-			.Returns(tokens);
+			.Returns(queryStringTokenizingResult);
 
 		_treeBuilderMock
-			.Setup(t => t.BuildTree(tokens))
-			.Returns(expectedNode);
+			.Setup(t => t.BuildTree(queryStringTokenizingResult.Tokens))
+			.Returns(expectedResult.RootNode);
 
-		Func<QueryNode<HashSet<int>>> act = input switch
+		Func</*QueryNode<HashSet<int>>*/QueryParsingResult<HashSet<int>, IgnoredTermsDTO>> act = input switch
         {
             "NO_INPUT"  => () => _parser.Parse(query),
             _           => () => _parser.Parse(query, languageCode: input)

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Application.Tests/QueryServiceTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Application.Tests/QueryServiceTests.cs
@@ -6,6 +6,7 @@ using LTU.SearchEngine.Backend.Core.Model.Entities;
 using LTU.SearchEngine.Backend.Core.Model.ValueObjects.QueryNodes;
 using LTU.SearchEngine.Backend.Core.SearchQueryBuilder;
 using LTU.SearchEngine.Infrastructure.Repositories;
+using LTU.SearchEngine.Test.HelperClasses;
 using Moq;
 
 namespace LTU.SearchEngine.Application.QueryParsing;
@@ -60,9 +61,12 @@ public class QueryServiceTests
         List<Page> fakeDocumentList
         )
     {
+        var fakeQueryParsingResult = 
+            QueryParsingResultBuilder.BuildQueryParsingResult(rootNode: fakeOperatorNode);
+        
         _mockQueryParser
             .Setup(p => p.Parse(rawQuery, languageCode))
-            .Returns(fakeOperatorNode);
+            .Returns(fakeQueryParsingResult);
 
         _mockQueryEvaluatorVisitor
             .Setup(qe => qe.ExecuteAsync(fakeOperatorNode))

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/HelperClasses/QueryParsingResultBuilder.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/HelperClasses/QueryParsingResultBuilder.cs
@@ -1,0 +1,41 @@
+using LTU.SearchEngine.Backend.Core.Enums;
+using LTU.SearchEngine.Backend.Core.Model.DTOs;
+using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
+using LTU.SearchEngine.Backend.Core.Model.ValueObjects.QueryNodes;
+
+namespace LTU.SearchEngine.Test.HelperClasses;
+
+public static class QueryParsingResultBuilder
+{
+    public static QueryParsingResult<HashSet<int>, IgnoredTermsDTO> BuildQueryParsingResult(
+        QueryNode<HashSet<int>> rootNode,
+        IEnumerable<IgnoredTermsDTO> ignoredTokens
+    )
+    {
+        return new QueryParsingResult<HashSet<int>, IgnoredTermsDTO>(
+            RootNode: rootNode,
+            IgnoredTokens: ignoredTokens
+        );
+    }
+    
+    public static QueryParsingResult<HashSet<int>, IgnoredTermsDTO> BuildQueryParsingResult(
+        QueryNode<HashSet<int>> rootNode
+    )
+    {
+        return new QueryParsingResult<HashSet<int>, IgnoredTermsDTO>(
+            RootNode: rootNode,
+            IgnoredTokens: new List<IgnoredTermsDTO>()
+        );
+    }
+   
+    public static QueryParsingResult<HashSet<int>, IgnoredTermsDTO> BuildQueryParsingResult()    {
+        return new QueryParsingResult<HashSet<int>, IgnoredTermsDTO>(
+            RootNode: new LogicOperationNode<HashSet<int>>(
+                leftNode: new TermNode<HashSet<int>>(""),
+                rightNode: new TermNode<HashSet<int>>(""),
+                logicalOperator: LogicalOperators.AND
+            ),
+            IgnoredTokens: new List<IgnoredTermsDTO>()
+        );
+    }
+}

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/HelperClasses/QueryStringTokenizingResultBuilder.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/HelperClasses/QueryStringTokenizingResultBuilder.cs
@@ -1,0 +1,36 @@
+using LTU.SearchEngine.Backend.Core.Model.DTOs;
+using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
+
+namespace LTU.SearchEngine.Test.HelperClasses;
+
+public static class QueryStringTokenizingResultBuilder
+{
+    public static QueryStringTokenizingResult<ExtractedQueryToken, IgnoredTermsDTO> BuildQueryStringTokenizingResult(
+        IEnumerable<ExtractedQueryToken> tokens,
+        IEnumerable<IgnoredTermsDTO> ignoredTokens
+    )
+    {
+        return new QueryStringTokenizingResult<ExtractedQueryToken, IgnoredTermsDTO>(
+            Tokens: tokens,
+            IgnoredTokens: ignoredTokens
+        );
+    }
+    
+    public static QueryStringTokenizingResult<ExtractedQueryToken, IgnoredTermsDTO> BuildQueryStringTokenizingResult(
+        IEnumerable<ExtractedQueryToken> tokens
+    )
+    {
+        return new QueryStringTokenizingResult<ExtractedQueryToken, IgnoredTermsDTO>(
+            Tokens: tokens,
+            IgnoredTokens: new List<IgnoredTermsDTO>()
+        );
+    }
+   
+    public static QueryStringTokenizingResult<ExtractedQueryToken, IgnoredTermsDTO> BuildQueryStringTokenizingResult()    
+    {
+        return new QueryStringTokenizingResult<ExtractedQueryToken, IgnoredTermsDTO>(
+            Tokens: new List<ExtractedQueryToken>(),
+            IgnoredTokens: new List<IgnoredTermsDTO>()
+        );
+    }
+}

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/ExtractedQueryTokenTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/ExtractedQueryTokenTests.cs
@@ -28,19 +28,6 @@ public class ExtractedQueryTokenTests
 		Assert.Equal(token, result.Token);
 	}
 
-	[Fact]
-	public void Constructor_NullToken_ThrowsArgumentNullException()
-	{
-		// Arrange
-		var tokenType = QueryTokenType.Term;
-
-		// Act & Assert
-		var exception = Assert.Throws<ArgumentException>(
-			() => new ExtractedQueryToken(tokenType, null!)
-		);
-
-		Assert.Equal("token", exception.ParamName);
-	}
 
 	[Theory]
 	[InlineData(QueryTokenType.GroupingOperator, "((")]
@@ -58,18 +45,6 @@ public class ExtractedQueryTokenTests
 			() => new ExtractedQueryToken(type, token)
 		);
 	}
-
-	//[Theory]
-	//[InlineData("")]
-	//[InlineData(" ")]
-	//[InlineData("   ")]
-	//public void Constructor_EmptyOrWhitespaceToken_ThrowsArgumentException(string token)
-	//{
-	//	Assert.Throws<ArgumentException>(
-	//		() => new ArgumentOutOfRangeException(QueryTokenType.Term, token)
-	//	);
-	//}
-
 
 
 	[Theory]
@@ -89,4 +64,56 @@ public class ExtractedQueryTokenTests
 		// Assert
 		Assert.Equal(tokenType, result.TokenType);
 	}
+
+	[Fact]
+    public void Constructor_WithLanguage_SetsLanguageProperty()
+    {
+        // Arrange
+        var token = "search";
+        var type = QueryTokenType.Term;
+        var language = "en";
+
+        // Act
+        var result = new ExtractedQueryToken(type, token, language);
+
+        // Assert
+        Assert.Equal(language, result.Language);
+    }
+
+    [Fact]
+    public void Constructor_DefaultLanguage_IsSwedish()
+    {
+        // Act
+        var result = new ExtractedQueryToken(QueryTokenType.Term, "test");
+
+        // Assert
+        Assert.Equal("sv", result.Language);
+    }
+
+    [Theory]
+    [InlineData(QueryTokenType.LogicalOperator, "AND")] // 3 chars - OK
+    [InlineData(QueryTokenType.LogicalOperator, "NOT")] // 3 chars - OK
+    [InlineData(QueryTokenType.LogicalOperator, "OR")]  // 2 chars - OK
+    [InlineData(QueryTokenType.LogicalOperator, "&&")]  // 2 chars - OK
+    [InlineData(QueryTokenType.LogicalOperator, "+")]   // 1 char - OK
+    public void Constructor_LogicalOperatorLengthBoundaries_AllowCorrectLengths(QueryTokenType type, string token)
+    {
+        // Act
+        var result = new ExtractedQueryToken(type, token);
+
+        // Assert
+        Assert.Equal(token, result.Token);
+    }
+
+    [Theory]
+    [InlineData(QueryTokenType.GroupingOperator, "")] // 0 chars is technically > 1 false
+    [InlineData(QueryTokenType.Term, "VeryLongTermThatShouldBeAllowedBecauseItIsNotAnOperator")]
+    public void Constructor_NonOperatorTypes_IgnoreLengthRestrictions(QueryTokenType type, string token)
+    {
+        // Act
+        var result = new ExtractedQueryToken(type, token);
+
+        // Assert
+        Assert.Equal(token, result.Token);
+    }
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/PhraseAndTermNormalizerTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/PhraseAndTermNormalizerTests.cs
@@ -87,18 +87,5 @@ namespace LTU.SearchEngine.Test.QueryParsing.Tests
             // Assert
             Assert.Equal(op, result);
         }
-
-        [Fact]
-        public void CreatingToken_ShouldThrowException_WhenValueIsEmpty()
-        {
-            // Arrange
-            string emptyValue = "";
-
-            // Act & Assert
-            var exception = Assert.Throws<System.ArgumentException>(() =>
-                new ExtractedQueryToken(QueryTokenType.Term, emptyValue));
-
-            Assert.Equal("Token cannot be empty. (Parameter 'token')", exception.Message);
-        }
     }
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/QueryEvaluatorVisitorTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/QueryEvaluatorVisitorTests.cs
@@ -1,4 +1,5 @@
-﻿using LTU.SearchEngine.Backend.Core;
+﻿using LTU.SearchEngine.Api.ExtensionsUseExceptionHandler.CustomExceptions;
+using LTU.SearchEngine.Backend.Core;
 using LTU.SearchEngine.Backend.Core.Enums;
 using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
 using LTU.SearchEngine.Backend.Core.Model.ValueObjects.QueryNodes;
@@ -161,6 +162,7 @@ public class QueryEvaluatorVisitorTests
 	[Fact]
 	public async Task ExecuteAsync_PhraseNode_ReturnsRepositoryResult()
 	{
+		// Arrange
 		var phrase = new PhraseNode<HashSet<int>>(
 			new List<ExtractedQueryToken>()
 			{
@@ -171,12 +173,85 @@ public class QueryEvaluatorVisitorTests
 
 		var expected = new HashSet<int> { 5, 6 };
 
+
 		_repositoryMock
 			.Setup(r => r.GetDocumentIdsForPhraseAsync(phrase))
 			.ReturnsAsync(expected);
 
+		// Act 
 		var result = await _sut.ExecuteAsync(phrase);
 
+		// Assert
 		Assert.Equal(expected, result);
+	}
+
+	[Fact]
+	public async Task VisitAsync_LogicNode_NOT_WithVoidLeft_ShouldReturnEmptySet()
+	{
+		// Arrange: "" NOT "dog" -> Void
+		var leftNode = new TermNode<HashSet<int>>(string.Empty); // Assumed to implement IIsVoidable and return true
+		var rightNode = new TermNode<HashSet<int>>("dog");
+		
+		_repositoryMock.Setup(r => r.GetDocumentIdsForTermAsync("dog"))
+					.ReturnsAsync(new HashSet<int> { 1 });
+
+		var node = new LogicOperationNode<HashSet<int>>(leftNode, rightNode, LogicalOperators.NOT);
+
+		// Act
+		var result = await _sut.VisitAsync(node);
+
+		// Assert
+		Assert.Empty(result);
+		_repositoryMock.Verify(r => r.GetDocumentIdsForTermAsync("dog"), Times.Never);
+	}
+
+	[Fact]
+	public async Task VisitAsync_LogicNode_WithOneVoidChild_ShouldReturnOtherChildResult()
+	{
+		// Arrange: "cat" OR "" -> Should just evaluate "cat"
+		var expectedIds = new HashSet<int> { 1, 2 };
+		var leftNode = new TermNode<HashSet<int>>("cat");
+		var rightNode = new TermNode<HashSet<int>>(string.Empty); // Void node
+
+		_repositoryMock.Setup(r => r.GetDocumentIdsForTermAsync("cat"))
+					.ReturnsAsync(expectedIds);
+
+		var node = new LogicOperationNode<HashSet<int>>(leftNode, rightNode, LogicalOperators.OR);
+
+		// Act
+		var result = await _sut.VisitAsync(node);
+
+		// Assert
+		Assert.Equal(expectedIds, result);
+		_repositoryMock.Verify(r => r.GetDocumentIdsForTermAsync("cat"), Times.Once);
+	}
+
+	[Fact]
+	public async Task VisitAsync_LogicNode_BothChildrenVoid_ShouldReturnEmptySet()
+	{
+		// Arrange: "" AND ""
+		var leftNode = new TermNode<HashSet<int>>(string.Empty);
+		var rightNode = new TermNode<HashSet<int>>(string.Empty);
+		var node = new LogicOperationNode<HashSet<int>>(leftNode, rightNode, LogicalOperators.AND);
+
+		// Act
+		var result = await _sut.VisitAsync(node);
+
+		// Assert
+		Assert.Empty(result);
+		_repositoryMock.VerifyNoOtherCalls();
+	}
+
+	[Fact]
+	public async Task VisitAsync_TermNode_WhenRepositoryThrows_ShouldThrowQueryEvaluationException()
+	{
+		// Arrange
+		_repositoryMock.Setup(r => r.GetDocumentIdsForTermAsync(It.IsAny<string>()))
+					.ThrowsAsync(new Exception("Database down"));
+		var node = new TermNode<HashSet<int>>("fail");
+
+		// Act & Assert
+		var ex = await Assert.ThrowsAsync<QueryEvaluationException>(() => _sut.VisitAsync(node));
+		Assert.Contains("Failed evaluating term 'fail'", ex.Message);
 	}
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/QueryNode.Tests/PhraseNodeTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/QueryNode.Tests/PhraseNodeTests.cs
@@ -34,15 +34,6 @@ public class PhraseNodeTests
 	}
 
 	[Fact]
-	public void Constructor_EmptyPhrase_ThrowsArgumentNullException()
-	{
-		// Act & Assert
-		Assert.Throws<ArgumentException>(
-			() => new PhraseNode<string>(new List<ExtractedQueryToken>())
-		);
-	}
-
-	[Fact]
 	public async Task Accept_CallsVisitOnVisitor_ReturnsExpectedValueAsync()
 	{
 		// Arrange
@@ -63,4 +54,65 @@ public class PhraseNodeTests
 		Assert.Same(expectedResult, result);
 		mockVisitor.Verify(v => v.VisitAsync(node), Times.Once);
 	}
+
+	[Fact]
+    public void IsVoid_EmptyList_ReturnsTrue()
+    {
+        // Arrange
+        var node = new PhraseNode<string>(new List<ExtractedQueryToken>());
+
+        // Act & Assert
+        Assert.True(node.IsVoid());
+    }
+
+    [Fact]
+    public void IsVoid_ValidTokens_ReturnsFalse()
+    {
+        // Arrange
+        var tokens = new List<ExtractedQueryToken> 
+        { 
+            new ExtractedQueryToken(QueryTokenType.Term, "quick"),
+            new ExtractedQueryToken(QueryTokenType.Term, "brown"),
+            new ExtractedQueryToken(QueryTokenType.Term, "fox")
+        };
+        var node = new PhraseNode<string>(tokens);
+
+        // Act & Assert
+        Assert.False(node.IsVoid());
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("\t")]
+    public void IsVoid_ListWithOnlyWhitespaceTokens_ReturnsTrue(string whitespace)
+    {
+        // Arrange
+        var tokens = new List<ExtractedQueryToken> 
+        { 
+            new ExtractedQueryToken(QueryTokenType.Term, whitespace),
+            new ExtractedQueryToken(QueryTokenType.Term, "  ") 
+        };
+        var node = new PhraseNode<string>(tokens);
+
+        // Act & Assert
+        Assert.True(node.IsVoid());
+    }
+
+    [Fact]
+    public void IsVoid_MixedValidAndEmptyTokens_ReturnsFalse()
+    {
+        // Arrange
+        // A phrase is only void if ALL tokens are void/whitespace. 
+        // If there is at least one valid token, the phrase has semantic value.
+        var tokens = new List<ExtractedQueryToken> 
+        { 
+            new ExtractedQueryToken(QueryTokenType.Term, "  "),
+            new ExtractedQueryToken(QueryTokenType.Term, "valid-term") 
+        };
+        var node = new PhraseNode<string>(tokens);
+
+        // Act & Assert
+        Assert.False(node.IsVoid());
+    }
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/QueryNode.Tests/TermNodeTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/QueryNode.Tests/TermNodeTests.cs
@@ -19,17 +19,12 @@ public class TermNodeTests
 		Assert.Equal(expectedTerm, node.Term);
 	}
 
-	[Theory]
-	[InlineData("NULL_TEST")]
-	[InlineData("")]
-	[InlineData(" ")]
-	public void Constructor_InvalidTerm_ThrowsArgumentNullException(string input)
+	[Fact]
+	public void Constructor_InvalidTerm_ThrowsArgumentNullException()
 	{
-		string? invalidTerm = input.Equals("NULL_TEST") ? null : input;
-
 		// Act & Assert
 		Assert.Throws<ArgumentNullException>(
-			() => new TermNode<string>(invalidTerm!)
+			() => new TermNode<string>(null!)
 		);
 	}
 
@@ -53,4 +48,24 @@ public class TermNodeTests
 		Assert.Equal(expectedResult, result);
 		mockVisitor.Verify(v => v.VisitAsync(node), Times.Once);
 	}
+
+	[Theory]
+    [InlineData("apple", false)]      // Normal word
+    [InlineData("a", false)]          // Single character
+    [InlineData("123", false)]        // Numbers
+    [InlineData("", true)]            // Empty string
+    [InlineData(" ", true)]           // Single space
+    [InlineData("\t\n\r", true)]      // Whitespace characters
+    public void IsVoid_ReturnsExpectedResult(string inputTerm, bool expectedIsVoid)
+    {
+        // Arrange
+        // Note: Constructor allows empty/whitespace but not null
+        var node = new TermNode<string>(inputTerm);
+
+        // Act
+        var result = node.IsVoid();
+
+        // Assert
+        Assert.Equal(expectedIsVoid, result);
+    }
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/QueryTokenizerTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/QueryTokenizerTests.cs
@@ -4,7 +4,6 @@ using LTU.SearchEngine.Backend.Core.Enums;
 using LTU.SearchEngine.Backend.Core.Exceptions;
 using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
 using Moq;
-using System.Text;
 
 namespace LTU.SearchEngine.Test.QueryParsing.Tests;
 
@@ -73,7 +72,7 @@ public class QueryTokenizerTests
 		var result = _sut.Tokenize(input, "en");
 
 		// Assert 
-		Assert.Equivalent(expected, result);
+		Assert.Equivalent(expected, result.Tokens);
 	}
 
 	[Fact]
@@ -88,12 +87,13 @@ public class QueryTokenizerTests
 
 		// Act 
 		var result = _sut.Tokenize(input, "en");
+		var resultList = result.Tokens.ToList();
 
 		// Assert
-		Assert.Equal(3, result.Count);
-		Assert.Equivalent(cat, result[0]);
-		Assert.Equivalent(helloDolly, result[1]);
-		Assert.Equivalent(dog, result[2]);
+		Assert.Equal(3, resultList.Count);
+		Assert.Equivalent(cat, resultList[0]);
+		Assert.Equivalent(helloDolly, resultList[1]);
+		Assert.Equivalent(dog, resultList[2]);
 	}
 
 	[Fact]
@@ -108,7 +108,7 @@ public class QueryTokenizerTests
 		var result = _sut.Tokenize(input, "en");
 
 		// Assert
-		Assert.Equivalent(new[] { word1, word2}, result);
+		Assert.Equivalent(new[] { word1, word2}, result.Tokens);
 	}
 
 
@@ -116,8 +116,8 @@ public class QueryTokenizerTests
 	public void Tokenize_EmptyInput_ReturnsEmptyList()
 	{
 		// Act & Assert 
-		Assert.Empty(_sut.Tokenize("", "en"));
-		Assert.Empty(_sut.Tokenize("   ", "en"));
+		Assert.Empty(_sut.Tokenize("", "en").Tokens);
+		Assert.Empty(_sut.Tokenize("   ", "en").Tokens);
 	}
 
 
@@ -133,12 +133,13 @@ public class QueryTokenizerTests
 
 		// Act
 		var result = _sut.Tokenize(input, "en");
+		var resultList = result.Tokens.ToList();
 
 		// Assert
-		Assert.Equal(3, result.Count);
-		Assert.Equivalent(start, result[0]);
-		Assert.Equivalent(unclosed, result[1]);
-		Assert.Equivalent(phrase, result[2]);
+		Assert.Equal(3, resultList.Count);
+		Assert.Equivalent(start, resultList[0]);
+		Assert.Equivalent(unclosed, resultList[1]);
+		Assert.Equivalent(phrase, resultList[2]);
 	}
 
     [Fact]
@@ -146,33 +147,44 @@ public class QueryTokenizerTests
     {
         // Arrange
         var input = "apple banana";
-        var result = _sut.Tokenize(input, "en");
+        
+		// Act 
+		var result = _sut.Tokenize(input, "en");
 
-        Assert.Equal(3, result.Count);
-        Assert.Equal(QueryTokenType.Term, result[0].TokenType);
-        Assert.Equal("apple", result[0].Token);
 
-        Assert.Equal(QueryTokenType.LogicalOperator, result[1].TokenType);
-        Assert.Equal("OR", result[1].Token);
+		// Assert 
+		var resultList = result.Tokens.ToList();
+        
+		Assert.Equal(3, resultList.Count);
+        Assert.Equal(QueryTokenType.Term, resultList[0].TokenType);
+        Assert.Equal("apple", resultList[0].Token);
 
-        Assert.Equal(QueryTokenType.Term, result[2].TokenType);
-        Assert.Equal("banana", result[2].Token);
+        Assert.Equal(QueryTokenType.LogicalOperator, resultList[1].TokenType);
+        Assert.Equal("OR", resultList[1].Token);
+
+        Assert.Equal(QueryTokenType.Term, resultList[2].TokenType);
+        Assert.Equal("banana", resultList[2].Token);
     }
 
     [Fact]
     public void Tokenize_MultipleTermsSeparatedBySpaces_InsertsImplicitOrBetweenAll()
     {
-		//Arrange
+		// Arrange
 		var input = "apple banana orange";
-        var result = _sut.Tokenize(input, "en");
+        
+		// Act 
+		var result = _sut.Tokenize(input, "en");
 
-        Assert.Equal(5, result.Count);
+		// Assert 
+		var resultList = result.Tokens.ToList();
 
-        Assert.Equal("apple", result[0].Token);
-        Assert.Equal("OR", result[1].Token);
-        Assert.Equal("banana", result[2].Token);
-        Assert.Equal("OR", result[3].Token);
-        Assert.Equal("orange", result[4].Token);
+        Assert.Equal(5, resultList.Count);
+
+        Assert.Equal("apple", resultList[0].Token);
+        Assert.Equal("OR", resultList[1].Token);
+        Assert.Equal("banana", resultList[2].Token);
+        Assert.Equal("OR", resultList[3].Token);
+        Assert.Equal("orange", resultList[4].Token);
     }
 
     [Fact]
@@ -180,26 +192,36 @@ public class QueryTokenizerTests
     {
 		// Arrange
 		var input = "start AND phrase";
+
+		// Act 
         var result = _sut.Tokenize(input, "en");
 
-        Assert.Equal(3, result.Count);
+		// Assert 
+		var resultList = result.Tokens.ToList();
 
-        Assert.Equal("start", result[0].Token);
-        Assert.Equal("AND", result[1].Token);
-        Assert.Equal("phrase", result[2].Token);
+        Assert.Equal(3, resultList.Count);
+
+        Assert.Equal("start", resultList[0].Token);
+        Assert.Equal("AND", resultList[1].Token);
+        Assert.Equal("phrase", resultList[2].Token);
     }
 
     [Fact]
     public void Tokenize_TermPhraseTerm_DoesNotInsertImplicitOr()
     {
+		// Arrange 
         var input = "cat \"hello dolly\" dog";
 
+		// Act 
         var result = _sut.Tokenize(input, "en");
 
-        Assert.Equal(3, result.Count);
-        Assert.Equal(QueryTokenType.Term, result[0].TokenType);
-        Assert.Equal(QueryTokenType.Phrase, result[1].TokenType);
-        Assert.Equal(QueryTokenType.Term, result[2].TokenType);
+		// Assert 
+		var resultList = result.Tokens.ToList();
+		
+        Assert.Equal(3, resultList.Count);
+        Assert.Equal(QueryTokenType.Term, resultList[0].TokenType);
+        Assert.Equal(QueryTokenType.Phrase, resultList[1].TokenType);
+        Assert.Equal(QueryTokenType.Term, resultList[2].TokenType);
     }
 
     [Fact]
@@ -207,13 +229,18 @@ public class QueryTokenizerTests
     {
 		// Arrange 
 		var input = "start \"unclosed phrase";
-        var result = _sut.Tokenize(input, "en");
+        
+		// Act 
+		var result = _sut.Tokenize(input, "en");
 
-        Assert.Equal(3, result.Count);
+		// Assert 
+		var resultList = result.Tokens.ToList();
 
-        Assert.Equal("start", result[0].Token);
-        Assert.Equal("\"unclosed", result[1].Token);
-        Assert.Equal("phrase", result[2].Token);
+        Assert.Equal(3, resultList.Count);
+
+        Assert.Equal("start", resultList[0].Token);
+        Assert.Equal("\"unclosed", resultList[1].Token);
+        Assert.Equal("phrase", resultList[2].Token);
     }
 
     [Fact]
@@ -221,13 +248,18 @@ public class QueryTokenizerTests
     {
 		// Arrange
 		var input = "start && phrase";
+
+		// Act 
         var result = _sut.Tokenize(input, "en");
 
-        Assert.Equal(3, result.Count);
+		// Assert 
+		var resultList = result.Tokens.ToList();
+        
+		Assert.Equal(3, resultList.Count);
 
-        Assert.Equal("start", result[0].Token);
-        Assert.Equal("&&", result[1].Token);
-        Assert.Equal("phrase", result[2].Token);
+        Assert.Equal("start", resultList[0].Token);
+        Assert.Equal("&&", resultList[1].Token);
+        Assert.Equal("phrase", resultList[2].Token);
     }
 
     [Theory]
@@ -250,13 +282,14 @@ public class QueryTokenizerTests
 
 		// Act
 		var result = _sut.Tokenize(input, "en");
+		var resultList = result.Tokens.ToList();
 
 		// Assert
-		Assert.Equal(3, result.Count);
-		Assert.Equivalent(start, result[0]);
-		Assert.Equivalent(expectedOperator, result[1]);
-		Assert.Equivalent(phrase, result[2]);
-		Assert.Equal(expectedOperator.TokenType, result[1].TokenType);
+		Assert.Equal(3, resultList.Count);
+		Assert.Equivalent(start, resultList[0]);
+		Assert.Equivalent(expectedOperator, resultList[1]);
+		Assert.Equivalent(phrase, resultList[2]);
+		Assert.Equal(expectedOperator.TokenType, resultList[1].TokenType);
 	}
 
 	[Theory]
@@ -275,11 +308,13 @@ public class QueryTokenizerTests
 		var result = _sut.Tokenize(input, "en");
 
 		// Assert
-		Assert.Equal(3, result.Count);
-		Assert.Equivalent(first, result[0]);
-		Assert.Equivalent(expectedOperator, result[1]);
-		Assert.Equivalent(second, result[2]);
-		Assert.Equal(expectedOperator.TokenType, result[1].TokenType);
+		var resultList = result.Tokens.ToList();
+
+		Assert.Equal(3, resultList.Count);
+		Assert.Equivalent(first, resultList[0]);
+		Assert.Equivalent(expectedOperator, resultList[1]);
+		Assert.Equivalent(second, resultList[2]);
+		Assert.Equal(expectedOperator.TokenType, resultList[1].TokenType);
 	}
 
 	[Theory]
@@ -299,12 +334,14 @@ public class QueryTokenizerTests
 		var result = _sut.Tokenize(input, "en");
 
 		// Assert
-		Assert.Equal(3, result.Count);
-		Assert.Equivalent(expectedOperator1, result[0]);
-		Assert.Equivalent(expectedPhrase, result[1]);
-		Assert.Equivalent(expectedOperator2, result[2]);
-		Assert.Equal(expectedOperator1.TokenType, result[0].TokenType);
-		Assert.Equal(expectedOperator2.TokenType, result[2].TokenType);
+		var resultList = result.Tokens.ToList();
+
+		Assert.Equal(3, resultList.Count);
+		Assert.Equivalent(expectedOperator1, resultList[0]);
+		Assert.Equivalent(expectedPhrase, resultList[1]);
+		Assert.Equivalent(expectedOperator2, resultList[2]);
+		Assert.Equal(expectedOperator1.TokenType, resultList[0].TokenType);
+		Assert.Equal(expectedOperator2.TokenType, resultList[2].TokenType);
 	}
 
 
@@ -338,10 +375,11 @@ public class QueryTokenizerTests
     {
         // Arrange
         var result = _sut.Tokenize(input, "en");
+		var resultList = result.Tokens.ToList();
 
 		// Act 
-        Assert.Single(result);
-        Assert.Equal(QueryTokenType.LogicalOperator, result[0].TokenType);
+        Assert.Single(resultList);
+        Assert.Equal(QueryTokenType.LogicalOperator, resultList[0].TokenType);
 		
 		// Assert 
         _mockNormalizer.Verify(
@@ -359,9 +397,10 @@ public class QueryTokenizerTests
 	{
 		// Act 
 		var result = _sut.Tokenize(input, "sv");
+		var resultList = result.Tokens.ToList();
 
 		// Assert 
-		var swedishTokens = result.Where(est => est.Language.Equals("sv"));
+		var swedishTokens = resultList.Where(est => est.Language.Equals("sv"));
 
 		Assert.Empty(swedishTokens);
 	}
@@ -376,9 +415,10 @@ public class QueryTokenizerTests
 	{
 		// Act 
 		var result = _sut.Tokenize(input, "sv");
+		var resultList = result.Tokens.ToList();
 
 		// Assert 
-		var englishTokens = result.Where(est => est.Language.Equals("en"));
+		var englishTokens = resultList.Where(est => est.Language.Equals("en"));
 
 		Assert.Single(englishTokens);
 	}
@@ -393,9 +433,10 @@ public class QueryTokenizerTests
 	{
 		// Act 
 		var result = _sut.Tokenize(input, "sv");
+		var resultList = result.Tokens.ToList();
 
 		// Assert 
-		var swedishTokens = result.Where(est => est.Language.Equals("sv"));
+		var swedishTokens = resultList.Where(est => est.Language.Equals("sv"));
 
 		Assert.Equal(instances, swedishTokens.Count());
 	}
@@ -414,8 +455,10 @@ public class QueryTokenizerTests
 		var result = _sut.Tokenize(input, "en");
 
 		// Assert
-		Assert.Single(result);
-		Assert.Equal("", result.First().Token);
+		var resultList = result.Tokens.ToList();
+
+		Assert.Single(resultList);
+		Assert.Equal("", resultList.First().Token);
 	}
 
 	[Fact]
@@ -429,11 +472,12 @@ public class QueryTokenizerTests
 
 		// Act
 		var result = _sut.Tokenize(input, "en");
+		var resultList = result.Tokens.ToList();
 
 		// Assert
-		var apple = result.First(t => t.Token == "apple");
-		var banan = result.First(t => t.Token == "banan");
-		var orange = result.First(t => t.Token == "orange");
+		var apple = resultList.First(t => t.Token == "apple");
+		var banan = resultList.First(t => t.Token == "banan");
+		var orange = resultList.First(t => t.Token == "orange");
 
 		Assert.Equal("en", apple.Language);
 		Assert.Equal("sv", banan.Language);

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/QueryTokenizerTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/QueryTokenizerTests.cs
@@ -483,5 +483,24 @@ public class QueryTokenizerTests
 		Assert.Equal("sv", banan.Language);
 		Assert.Equal("en", orange.Language);
 	}
+
+	[Fact]
+	public void Flush_WhenWordIsNormalizedToEmpty_ShouldStillAddTokenAndTrackIgnored()
+	{
+		// Arrange
+		_mockNormalizer.Setup(n => n.Normalize("the", "en")).Returns("");
+		var input = "the";
+
+		// Act
+		var result = _sut.Tokenize(input, "en");
+
+		// Assert
+		Assert.Single(result.Tokens); 
+		Assert.Equal(string.Empty, result.Tokens.First().Token);
+		
+		Assert.Single(result.IgnoredTokens);
+		Assert.Equal("the", result.IgnoredTokens.First().Token);
+	}
+
 }
 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/QueryTokenizerTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/QueryTokenizerTests.cs
@@ -308,51 +308,6 @@ public class QueryTokenizerTests
 	}
 
 
-	[Theory]
-	[InlineData(QueryTokenType.Term)]
-	[InlineData(QueryTokenType.Phrase)]
-	[InlineData(QueryTokenType.LogicalOperator)]
-	public void Flush_EmptyBuilder_DoesNotAddToken(QueryTokenType type)
-	{
-		// Arrange
-		var tokens = new List<ExtractedQueryToken>();
-		var sb = new StringBuilder();
-
-		// Act
-		_sut.Flush(sb, tokens, queryTokenType: type, "en");
-
-		// Assert
-		Assert.Empty(tokens);
-	}
-
-	[Theory]
-	[InlineData("   term   ",  QueryTokenType.Term)]
-	[InlineData("  \" phrase \"  ", QueryTokenType.Phrase)]
-	[InlineData("  !  ", QueryTokenType.LogicalOperator)]
-	[InlineData("  -  ", QueryTokenType.LogicalOperator)]
-	[InlineData("  +  ", QueryTokenType.LogicalOperator)]
-	[InlineData("  &&  ", QueryTokenType.LogicalOperator)]
-	[InlineData("  ||  ", QueryTokenType.LogicalOperator)]
-	public void Flush_WithContent_AddsTrimmedTokenAndClearsBuilder(
-		string termOrPhrase,
-		QueryTokenType type
-		)
-	{
-		// Arrange
-		var tokens = new List<ExtractedQueryToken>();
-		var sb = new StringBuilder(termOrPhrase);
-
-		var token = new ExtractedQueryToken(type, termOrPhrase.Trim(), "en");
-
-		// Act
-		_sut.Flush(sb, tokens, queryTokenType: type, "en");
-
-		// Assert
-		Assert.Single(tokens);
-		Assert.Equivalent(token, tokens[0]);
-		Assert.Equal(0, sb.Length);
-	}
-
     [Fact]
     public void Tokenize_Should_Call_Normalizer_For_Term()
     {
@@ -443,6 +398,46 @@ public class QueryTokenizerTests
 		var swedishTokens = result.Where(est => est.Language.Equals("sv"));
 
 		Assert.Equal(instances, swedishTokens.Count());
+	}
+
+	[Fact]
+	public void Tokenize_PhraseWithOnlyStopWords_CreatesSingleEmptyToken()
+	{
+		// Arrange
+		_mockNormalizer
+			.Setup(n => n.Normalize(It.IsAny<string>(), "en"))
+			.Returns(""); // Everything is a stop-word
+
+		var input = "\"the and a\"";
+
+		// Act
+		var result = _sut.Tokenize(input, "en");
+
+		// Assert
+		Assert.Single(result);
+		Assert.Equal("", result.First().Token);
+	}
+
+	[Fact]
+	public void Tokenize_MixedLanguagesInSameQuery_AssignsCorrectLanguages()
+	{
+		// Arrange
+		var input = "en:apple sv:banan orange"; 
+		// en:apple -> English
+		// sv:banan -> Swedish
+		// orange   -> English (falls back to global)
+
+		// Act
+		var result = _sut.Tokenize(input, "en");
+
+		// Assert
+		var apple = result.First(t => t.Token == "apple");
+		var banan = result.First(t => t.Token == "banan");
+		var orange = result.First(t => t.Token == "orange");
+
+		Assert.Equal("en", apple.Language);
+		Assert.Equal("sv", banan.Language);
+		Assert.Equal("en", orange.Language);
 	}
 }
 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/SqlIndexRepositoryTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/SqlIndexRepositoryTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics;
-using LTU.SearchEngine.Backend.Core;
+﻿using LTU.SearchEngine.Backend.Core;
 using LTU.SearchEngine.Backend.Core.Entities;
 using LTU.SearchEngine.Backend.Core.Enums;
 using LTU.SearchEngine.Backend.Core.Model;


### PR DESCRIPTION
The problem stemmed from the fact that stopping words were removed from the "query" and the Term & Phrase token had to have values on creation. Thus creating situations where all values can be removed while still keeping the logical operation. Which was unexpected behaviour. 

I conducted a major refactor for to make handling these scenarios manageable. 

1. Term & Phrase Nodes can now have non-null empty values, such as "", which they will receive when converted in `QueryStringTokenizer`. These will be filtered out at the at a later stage. 
2. I have streamlined `QueryStringTokenizer` to help in keeping track of the stopping words and made it easier to follow.
   - both `QueryStringTokenizer` and `QueryParser` now return valueobjects which also contain a list of the ignored stopwords. 
3. "Empty" Terms or Phrases, can now be "Voidable". Meaning that they are to be ignored.  The `QueryEvaluatorVisitor`  "prune" these branches as needed depending on the scenario.

This give the additional feature that we now can tell the user which parts of the query was ignored. see example: 
<img width="823" height="761" alt="image" src="https://github.com/user-attachments/assets/f4a8dabf-348a-48f4-8cb9-bb5dbfe6d746" />
