### PR TITLE
88 implement query parser feature that enforce that the a not operation must be preceded by a positive term

### DIFF
--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/Helpers/QueryStringTokenizer.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/Helpers/QueryStringTokenizer.cs
@@ -80,8 +80,20 @@ public class QueryStringTokenizer : IStringTokenizer<ExtractedQueryToken, Ignore
 					}
 				}
 				
-				// Checks implicit OR
-				action = TryHandleImplicitOr();
+
+				bool isWhitespace = char.IsWhiteSpace(_character);
+
+				if ((isWhitespace || ShouldBreakTerm(_character, _index)) && !_isBuildingAPhrase)
+				{
+					Flush(QueryTokenType.Term, ResolveLanguage(_singleTermPhraseLanguage, _globalLanguage));
+					_singleTermPhraseLanguage = null!;
+				}
+
+				if (isWhitespace && !_isBuildingAPhrase) 
+				{
+					HandleWhiteSpace();
+					continue;
+				}
 
 				if (action.Equals(LoopAction.Continue)) 
 				{
@@ -120,17 +132,7 @@ public class QueryStringTokenizer : IStringTokenizer<ExtractedQueryToken, Ignore
 					continue;
 				};
 
-				// If this is reached must be term
-				if (IsTokenTerm(_character))
-				{
-					Flush(QueryTokenType.Term, ResolveLanguage(_singleTermPhraseLanguage, _globalLanguage));
-					_singleTermPhraseLanguage = null!;
-					continue;
-				}
-				else
-				{
-					_stringBuilder.Append(_character);
-				}
+				_stringBuilder.Append(_character);
 			}
 
 			// Handles the last term if there is one
@@ -143,8 +145,15 @@ public class QueryStringTokenizer : IStringTokenizer<ExtractedQueryToken, Ignore
 			); 
 		}
 
+        private bool ShouldBreakTerm(char character, int index)
+        {
+			if (IsGroupingOperator(character)) return true;
+			if ("!+-&|".Contains(character) && IsAtStartOfWordOrAfterColon(index)) return true;
 
-		private void Flush( QueryTokenType queryTokenType, string languageCode)
+			return false;
+        }
+
+        private void Flush( QueryTokenType queryTokenType, string languageCode)
 		{
 			if (_stringBuilder.Length == 0) return;
 
@@ -162,12 +171,11 @@ public class QueryStringTokenizer : IStringTokenizer<ExtractedQueryToken, Ignore
 				{
 					var normalizedWord = _textNormalizer.Normalize(word, languageCode);
 
-					if (!string.IsNullOrWhiteSpace(normalizedWord))
+					if (!string.IsNullOrWhiteSpace(normalizedWord)) 
 						normalizedWords.Add(normalizedWord);
-					else
+					else 
 						_ignoredTokens.Add(new IgnoredTermsDTO{Token = word, Language = languageCode });
 				}
-
 
 				finalToken = string.Join(' ', normalizedWords);	
 			}
@@ -185,45 +193,33 @@ public class QueryStringTokenizer : IStringTokenizer<ExtractedQueryToken, Ignore
 		}
 
 
-		private LoopAction TryHandleImplicitOr()
-		{
-			// Only handle whitespace outside phrases
-			if (!char.IsWhiteSpace(_character) || _isBuildingAPhrase) return LoopAction.None;
+		private void HandleWhiteSpace()
+        {
+			if (_isBuildingAPhrase || _tokens.Count == 0) return; 
 
-			// No term being built → nothing to separate
-			if (_stringBuilder.Length == 0) return LoopAction.None;
+            var lastToken = _tokens.Last();
 
-			// Prevent implicit OR when term starts with quote (unclosed phrase case)
-			if (_stringBuilder[0] == '"') return LoopAction.None;
+			bool lastTokenWasOperand = 	
+				lastToken.TokenType.Equals(QueryTokenType.Term) ||
+				lastToken.TokenType.Equals(QueryTokenType.Phrase) || 
+				(lastToken.TokenType.Equals(QueryTokenType.GroupingOperator) && ")}]".Contains(lastToken.Token));
 
-			// Look ahead to next character
+			if(!lastTokenWasOperand) return;
+
 			if (_index + 1 < _input.Length)
 			{
 				char next = _input[_index + 1];
 
-				// Do not insert OR before phrases or operators
-				if (next == '"' ||
-					"!+-&|".Contains(next) ||
+				// Do not insert OR before operators
+				if ("!+-&|".Contains(next) ||
 					IsCapitalLetterOperator(_input, _index + 1) ||
-					IsLanguagePreFix(_input, _index + 1))
-				{
-					return LoopAction.None;
-				}
+					IsGroupingOperator(next) ||
+					IsLanguagePreFix(_input, _index +1)
+				) return; 
+
+				_tokens.Add(new ExtractedQueryToken(QueryTokenType.LogicalOperator, "OR", _globalLanguage));
 			}
-
-			int tokenCountBeforeFlush = _tokens.Count;
-
-			Flush(QueryTokenType.Term, ResolveLanguage(_singleTermPhraseLanguage, _globalLanguage));
-
-			// Flush may not add a token if normalization removes it
-			if (_tokens.Count == tokenCountBeforeFlush) return LoopAction.Continue;
-
-			_tokens.Add(new ExtractedQueryToken(
-				QueryTokenType.LogicalOperator, "OR", ResolveLanguage(_singleTermPhraseLanguage, _globalLanguage)
-			));
-
-			return LoopAction.Continue;
-		}
+        }
 
 
 		private bool IsLanguagePreFix(string input, int index, out int jump, out string detectedLanguage)
@@ -270,14 +266,9 @@ public class QueryStringTokenizer : IStringTokenizer<ExtractedQueryToken, Ignore
 		{
 			if (IsLogicalOperator(_character))
 			{
-				if (IsDoubleLogicalOperator(_character))
-				{
-					_stringBuilder.Append(_input, _index++, 2);
-					Flush(QueryTokenType.LogicalOperator, ResolveLanguage(_singleTermPhraseLanguage, _globalLanguage));
-					return LoopAction.Continue;
-				}
+				if (IsDoubleLogicalOperator(_character)) _stringBuilder.Append(_input, _index++, 2);
+				else _stringBuilder.Append(_character);
 
-				_stringBuilder.Append(_character);
 				Flush(QueryTokenType.LogicalOperator, ResolveLanguage(_singleTermPhraseLanguage, _globalLanguage));
 				return LoopAction.Continue;
 			}
@@ -400,9 +391,6 @@ public class QueryStringTokenizer : IStringTokenizer<ExtractedQueryToken, Ignore
 
 			return false;
 		}
-
-
-		private bool IsTokenTerm(char character) => char.IsWhiteSpace(character);
 
 
 		// ToDo: extract to own static helper class

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/SearchQueryBuilder/SearchQueryShuntingYardParser.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/SearchQueryBuilder/SearchQueryShuntingYardParser.cs
@@ -14,69 +14,131 @@ public class SearchQueryShuntingYardParser : IShuntingYardParser<ExtractedQueryT
 	public Queue<ExtractedQueryToken> ConvertToPostfix(IEnumerable<ExtractedQueryToken> tokens)
 	{
 		// ToDo: Figure out a solution to handle required tokens.
-		// ToDo: Figure out a solution to handle implicit OR (word1 word2).
 		VerifyTokens(tokens);
 
 		Queue<ExtractedQueryToken> outputQueue = new();
 		Stack<ExtractedQueryToken> operatorStack = new();
 
+		ExtractedQueryToken? lastNonGroupingToken = null;
+		bool firstTermPhraseSet = false;
+		
 		foreach (ExtractedQueryToken token in tokens)
-		{
-			if (IsTermOrPhrase(token))
-			{
-				outputQueue.Enqueue(token);
-			}
-			else if (IsStartParentheses(token))
-			{
-				operatorStack.Push(token);
-			}
-			else if (IsEndParentheses(token))
-			{
-				// Move operators to output until the matching start parenthesis is found.
-				while (ShouldPopOperator(operatorStack))
-				{
-					outputQueue.Enqueue(operatorStack.Pop());
-				}
+        {
+            bool currTokenIsLogicalOperator = IsLogicalOperator(token);
 
-				// If stack is empty then there is a "(" missing.
-				if (operatorStack.Count == 0 || !IsStartParentheses(operatorStack.Peek()))
-				{
-					throw new FormatException(
-						"Mismatched parentheses: Found closing parenthesis ')' without a matching opening parenthesis."
-					);
-				}
+            HandleLogicalOperatorBeforeFirstTermOrPhrase(firstTermPhraseSet, token, currTokenIsLogicalOperator);
+            HandleLogicalOperatorsInSequence(lastNonGroupingToken, token);
 
-				// Discard the start parenthesis from the stack.
-				if (operatorStack.Count > 0) operatorStack.Pop();
-			}
-			else if (IsLogicalOperator(token))
-			{
-				int currentOperatorValue = GetPrecedenceValue(token.Token);
+            if (IsTermOrPhrase(token))
+            {
+                outputQueue.Enqueue(token);
+                firstTermPhraseSet = true;
+            }
+            else if (IsStartParentheses(token))
+            {
+                operatorStack.Push(token);
+            }
+            else if (IsEndParentheses(token))
+            {
+                // Move operators to output until the matching start parenthesis is found.
+                while (ShouldPopOperator(operatorStack))
+                {
+                    outputQueue.Enqueue(operatorStack.Pop());
+                }
 
-				while (NextPopDoesNotHavePrecedence(operatorStack, currentOperatorValue))
-					outputQueue.Enqueue(operatorStack.Pop());
+                HandleMismatchingClosingParentheses(operatorStack);
 
-				operatorStack.Push(token);
-			}
-		}
+                // Discard the start parenthesis from the stack.
+                if (operatorStack.Count > 0) operatorStack.Pop();
+            }
+            else if (IsLogicalOperator(token))
+            {
+                int currentOperatorValue = GetPrecedenceValue(token.Token);
 
-		// Empty any remaining operators into the output queue
-		while (operatorStack.Count > 0)
-		{
-			var remainingToken = operatorStack.Pop();
+                while (NextPopDoesNotHavePrecedence(operatorStack, currentOperatorValue))
+                    outputQueue.Enqueue(operatorStack.Pop());
 
-			if (IsStartParentheses(remainingToken))
-				throw new FormatException(
-					"Mismatched parentheses: Found opening parenthesis '(' without a matching closing parenthesis."
-				);
+                operatorStack.Push(token);
+            }
 
-			outputQueue.Enqueue(remainingToken);
-		}
+            if (!IsGroupingOperator(token)) lastNonGroupingToken = token;
+        }
 
-		return outputQueue;
+        // Empty any remaining operators into the output queue
+        while (operatorStack.Count > 0)
+        {
+            var remainingToken = operatorStack.Pop();
+
+            HandleMismatchingStartParentheses(remainingToken);
+
+            outputQueue.Enqueue(remainingToken);
+        }
+
+        return outputQueue;
 	}
 
-	private void VerifyTokens(IEnumerable<ExtractedQueryToken> tokens)
+    private void HandleMismatchingStartParentheses(ExtractedQueryToken remainingToken)
+    {
+        if (IsStartParentheses(remainingToken))
+            throw new FormatException(
+                "Mismatched parentheses: Found opening parenthesis '(' without a matching closing parenthesis."
+            );
+    }
+
+    private void HandleMismatchingClosingParentheses(Stack<ExtractedQueryToken> operatorStack)
+    {
+		// If stack is empty then there is a "(" missing.
+        if (operatorStack.Count == 0 || !IsStartParentheses(operatorStack.Peek()))
+        {
+            throw new FormatException(
+                "Mismatched parentheses: Found closing parenthesis ')' without a matching opening parenthesis."
+            );
+        }
+    }
+
+    private void HandleLogicalOperatorsInSequence(
+		ExtractedQueryToken? lastNonGroupingToken, 
+		ExtractedQueryToken token)
+    {
+        if (lastNonGroupingToken is not null && 
+			IsLogicalOperator(lastNonGroupingToken) && 
+			IsLogicalOperator(token))
+        {
+            throw new FormatException(
+                "Invalid query format: Consecutive logical operators are not allowed. " +
+                $"Found '{lastNonGroupingToken.Token}' and '{token.Token}' in sequence."
+            );
+        }
+    }
+
+    private static void HandleLogicalOperatorBeforeFirstTermOrPhrase(
+		bool firstTermPhraseSet, 
+		ExtractedQueryToken token, 
+		bool currTokenIsLogicalOperator)
+    {
+        if (currTokenIsLogicalOperator && !firstTermPhraseSet)
+        {
+            throw new FormatException(
+                "Invalid query format: Query cannot start with a logical operator. " +
+                $"Found '{token.Token}' at the beginning of the query."
+            );
+        }
+    }
+
+    private bool IsGroupingOperator(ExtractedQueryToken token) 
+		=> token.TokenType.Equals(QueryTokenType.GroupingOperator);
+    
+
+    private bool IsANotOperator(ExtractedQueryToken token)
+	{
+		return token.Token switch
+		{
+			"NOT" or "!" or "-" => true,
+			_ => false	
+		};
+	}
+
+    private void VerifyTokens(IEnumerable<ExtractedQueryToken> tokens)
 	{
 		if (tokens is null)
 			throw new ArgumentNullException(nameof(tokens), "must have a value.");
@@ -104,6 +166,7 @@ public class SearchQueryShuntingYardParser : IShuntingYardParser<ExtractedQueryT
 			_ => 0
 		};
 	}
+	
 	private bool ShouldPopOperator(Stack<ExtractedQueryToken> operatorStack)
 		=> operatorStack.TryPeek(out ExtractedQueryToken? result) &&
 							!IsStartParentheses(result);

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/QueryTokenizerTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/QueryTokenizerTests.cs
@@ -90,10 +90,10 @@ public class QueryTokenizerTests
 		var resultList = result.Tokens.ToList();
 
 		// Assert
-		Assert.Equal(3, resultList.Count);
+		Assert.Equal(5, resultList.Count);
 		Assert.Equivalent(cat, resultList[0]);
-		Assert.Equivalent(helloDolly, resultList[1]);
-		Assert.Equivalent(dog, resultList[2]);
+		Assert.Equivalent(helloDolly, resultList[2]);
+		Assert.Equivalent(dog, resultList[4]);
 	}
 
 	[Fact]
@@ -122,7 +122,7 @@ public class QueryTokenizerTests
 
 
 	[Fact]
-	public void Tokenize_UnclosedQuotes_TreatsAllWordsAsTerms()
+	public void Tokenize_UnclosedQuotes_TreatsAllWordsAsTerms_AddsImplicitOr()
 	{
 		// Arrange
 		var input = "start \"unclosed phrase";
@@ -130,16 +130,18 @@ public class QueryTokenizerTests
 		var start = new ExtractedQueryToken(QueryTokenType.Term, "start", "en");
 		var unclosed = new ExtractedQueryToken(QueryTokenType.Term, "\"unclosed", "en");
 		var phrase = new ExtractedQueryToken(QueryTokenType.Term, "phrase", "en");
-
+		var or = new ExtractedQueryToken(QueryTokenType.LogicalOperator, "OR", "en");
 		// Act
 		var result = _sut.Tokenize(input, "en");
 		var resultList = result.Tokens.ToList();
 
 		// Assert
-		Assert.Equal(3, resultList.Count);
+		Assert.Equal(5, resultList.Count);
 		Assert.Equivalent(start, resultList[0]);
-		Assert.Equivalent(unclosed, resultList[1]);
-		Assert.Equivalent(phrase, resultList[2]);
+		Assert.Equivalent(or, resultList[1]);
+		Assert.Equivalent(unclosed, resultList[2]);
+		Assert.Equivalent(or, resultList[3]);
+		Assert.Equivalent(phrase, resultList[4]);
 	}
 
     [Fact]
@@ -207,7 +209,7 @@ public class QueryTokenizerTests
     }
 
     [Fact]
-    public void Tokenize_TermPhraseTerm_DoesNotInsertImplicitOr()
+    public void Tokenize_TermPhraseTerm_DoesNotInsertImplicitOrInPhrase()
     {
 		// Arrange 
         var input = "cat \"hello dolly\" dog";
@@ -218,29 +220,12 @@ public class QueryTokenizerTests
 		// Assert 
 		var resultList = result.Tokens.ToList();
 		
-        Assert.Equal(3, resultList.Count);
+        Assert.Equal(5, resultList.Count);
         Assert.Equal(QueryTokenType.Term, resultList[0].TokenType);
-        Assert.Equal(QueryTokenType.Phrase, resultList[1].TokenType);
-        Assert.Equal(QueryTokenType.Term, resultList[2].TokenType);
-    }
-
-    [Fact]
-    public void Tokenize_UnclosedQuote_DoesNotInsertImplicitOr()
-    {
-		// Arrange 
-		var input = "start \"unclosed phrase";
-        
-		// Act 
-		var result = _sut.Tokenize(input, "en");
-
-		// Assert 
-		var resultList = result.Tokens.ToList();
-
-        Assert.Equal(3, resultList.Count);
-
-        Assert.Equal("start", resultList[0].Token);
-        Assert.Equal("\"unclosed", resultList[1].Token);
-        Assert.Equal("phrase", resultList[2].Token);
+		Assert.Equal(QueryTokenType.LogicalOperator, resultList[1].TokenType);
+        Assert.Equal(QueryTokenType.Phrase, resultList[2].TokenType);
+		Assert.Equal(QueryTokenType.LogicalOperator, resultList[3].TokenType);
+        Assert.Equal(QueryTokenType.Term, resultList[4].TokenType);
     }
 
     [Fact]
@@ -426,7 +411,7 @@ public class QueryTokenizerTests
 	[Theory]
 	[InlineData("term1", 1)]
 	[InlineData("\"term1 term2\"", 1)]
-	[InlineData("term1 \"term2 term3\"", 2)]
+	[InlineData("term1 \"term2 term3\"", 3)] // implicit OR +1
 	[InlineData("term1 en:AND term3", 2)]
 	[InlineData("term1 AND term3", 3)]
 	public void Tokenize_IsLanguagePreFix_FindsNoLanguage_UsesDefault(string input, int instances)

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/SearchQueryShuntingYardParserTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/SearchQueryShuntingYardParserTests.cs
@@ -131,16 +131,17 @@ public class SearchQueryShuntingYardParserTests
 	public void ConvertToPostfix_PrecedenceNotOverAnd_ReturnsNotFirst()
 	{
 		// Arrange
-		// Infix: NOT Java AND Luleå -> Postfix: Java NOT Luleå AND
+		// Infix: Ltu NOT Java AND Luleå -> Postfix: Ltu Java NOT Luleå AND
 		var tokens = new List<ExtractedQueryToken>
 		{
+			CreateToken("Ltu", QueryTokenType.Term),
 			CreateToken("NOT", QueryTokenType.LogicalOperator),
 			CreateToken("Java", QueryTokenType.Term),
 			CreateToken("AND", QueryTokenType.LogicalOperator),
 			CreateToken("Luleå", QueryTokenType.Term)
 		};
 
-		var expected = new List<string> { "Java", "NOT", "Luleå", "AND" };
+		var expected = new List<string> { "Ltu", "Java", "NOT", "Luleå", "AND" };
 
 		// Act 
 		var result = _sut
@@ -185,20 +186,21 @@ public class SearchQueryShuntingYardParserTests
 	public void ConvertToPostfix_ComplexPrecedence_FollowsNotAndOrOrder()
 	{
 		// Arrange
-		// Infix: Java OR C# AND NOT Python 
+		// Infix: Java OR C# AND Ltu NOT Python 
 		// Precedence: NOT(3) > AND(2) > OR(1)
-		// Postfix: Java C# Python NOT AND OR
+		// Postfix: Java C# Ltu Python NOT AND OR
 		var tokens = new List<ExtractedQueryToken>
 		{
 			CreateToken("Java", QueryTokenType.Term),
 			CreateToken("OR", QueryTokenType.LogicalOperator),
 			CreateToken("C#", QueryTokenType.Term),
 			CreateToken("AND", QueryTokenType.LogicalOperator),
+			CreateToken("Ltu", QueryTokenType.Term),
 			CreateToken("NOT", QueryTokenType.LogicalOperator),
 			CreateToken("Python", QueryTokenType.Term)
 		};
 
-		var expected = new List<string> { "Java", "C#", "Python", "NOT", "AND", "OR" };
+		var expected = new List<string> { "Java", "C#", "Ltu", "Python", "NOT", "AND", "OR" };
 		
 		// Act
 		var result = _sut
@@ -261,9 +263,9 @@ public class SearchQueryShuntingYardParserTests
 		// 2. "AND" (first) -> Stack
 		// 3. "Luleå" -> Output
 		// 4. "AND" (second) "AND" (first) on stack. 
-		//    same precedence (2 >= 2), first is poped to Output.
+		//    same precedence (2 >= 2), first is popped to Output.
 		// 5. "Stockholm" -> Output
-		// 6. last "AND" poped to Output.
+		// 6. last "AND" popped to Output.
 
 		// Expect Postfix: Java Luleå AND Stockholm AND
 
@@ -284,6 +286,89 @@ public class SearchQueryShuntingYardParserTests
 
 		Assert.Equal(expected, result);
 	}
+
+	[Fact]
+	public void ConvertToPostfix_OperatorsInSequence_ShouldThrowFormatException()
+	{
+		// Arrange
+		// Query: Java AND NOT Ltu
+		var tokens = new List<ExtractedQueryToken>
+		{
+			CreateToken("Java", QueryTokenType.Term),
+			CreateToken("AND", QueryTokenType.LogicalOperator),
+			CreateToken("NOT", QueryTokenType.LogicalOperator),
+			CreateToken("Ltu", QueryTokenType.Term),
+		};
+
+		Assert.Throws<FormatException>(()=> _sut.ConvertToPostfix(tokens));
+	}
+	
+	[Fact]
+	public void ConvertToPostfix_OperatorsInSequenceWithParentheses_ShouldThrowFormatException()
+	{
+		// Arrange
+		// Query: Java AND (NOT Ltu)
+		var tokens = new List<ExtractedQueryToken>
+		{
+			CreateToken("Java", QueryTokenType.Term),
+			CreateToken("AND", QueryTokenType.LogicalOperator),
+			CreateToken("(", QueryTokenType.GroupingOperator),
+			CreateToken("NOT", QueryTokenType.LogicalOperator),
+			CreateToken("Ltu", QueryTokenType.Term),
+			CreateToken(")", QueryTokenType.GroupingOperator),
+		};
+
+		Assert.Throws<FormatException>(()=> _sut.ConvertToPostfix(tokens));
+	}
+	
+	[Fact]
+	public void ConvertToPostfix_OperatorsFirst_ShouldThrowFormatException()
+	{
+		// Arrange
+		// Query: NOT Ltu
+		var tokens = new List<ExtractedQueryToken>
+		{
+			CreateToken("NOT", QueryTokenType.LogicalOperator),
+			CreateToken("Ltu", QueryTokenType.Term),
+		};
+
+		Assert.Throws<FormatException>(()=> _sut.ConvertToPostfix(tokens));
+	}
+	
+	[Fact]
+	public void ConvertToPostfix_OperatorsFirstInParentheses_ShouldThrowFormatException()
+	{
+		// Arrange
+		// Query: (NOT Ltu)
+		var tokens = new List<ExtractedQueryToken>
+		{
+			CreateToken("(", QueryTokenType.GroupingOperator),
+			CreateToken("NOT", QueryTokenType.LogicalOperator),
+			CreateToken("Ltu", QueryTokenType.Term),
+			CreateToken(")", QueryTokenType.GroupingOperator)
+		};
+
+		Assert.Throws<FormatException>(()=> _sut.ConvertToPostfix(tokens));
+	}
+	
+	[Fact]
+	public void ConvertToPostfix_OperatorsFirstInMultipleParentheses_ShouldThrowFormatException()
+	{
+		// Arrange
+		// Query: (NOT Ltu)
+		var tokens = new List<ExtractedQueryToken>
+		{
+			CreateToken("(", QueryTokenType.GroupingOperator),
+			CreateToken("(", QueryTokenType.GroupingOperator),
+			CreateToken("NOT", QueryTokenType.LogicalOperator),
+			CreateToken("Ltu", QueryTokenType.Term),
+			CreateToken(")", QueryTokenType.GroupingOperator),
+			CreateToken(")", QueryTokenType.GroupingOperator)
+		};
+
+		Assert.Throws<FormatException>(()=> _sut.ConvertToPostfix(tokens));
+	}
+
 
 	private ExtractedQueryToken CreateToken(string text, QueryTokenType type)
 	{


### PR DESCRIPTION
Found bug in QueryStingTokenizer that hindered progress on issue, I had to solved it here for convenience sake. An explanation of what was fixed can be found in the commit history.

As for the added feature regarding guarding against Logical operators before any term or phrase nodes. se bellow.


Add operator validation to shunting-yard parser
Refactor ConvertToPostfix to add validation and clearer handling of logical and grouping operators.
Introduces checks that prevent queries from starting with a logical operator and disallow consecutive logical operators, including when inside parentheses.
Have also extracted helper methods for mismatched parentheses, logical-operator sequencing, and grouping detection, and refactors IsANotOperator into a switch expression.

Tests updated to include an extra term ("Ltu") in precedence scenarios as the previous scenarios did not make sense from a requirement point of view.
Several new unit tests that assert FormatException for invalid operator placements (operators in sequence, operators first, and operators-first inside parentheses) were also added.

Error messages were improved to be more descriptive when format issues are detected.