### PR TITLE
Enhance query tokenization with RequirementLevel and required operators

### DIFF
--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/Helpers/QueryStringTokenizer.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/Helpers/QueryStringTokenizer.cs
@@ -214,7 +214,7 @@ public class QueryStringTokenizer : IStringTokenizer<ExtractedQueryToken, Ignore
 		private bool ShouldBreakTerm(char character, int index)
         {
 			if (IsGroupingOperator(character)) return true;
-			if ("!+-&|".Contains(character) && IsAtStartOfWordOrAfterColon(index)) return true;
+			if ("!-&|".Contains(character) && IsAtStartOfWordOrAfterColon(index)) return true;
 
 			return false;
         }
@@ -236,6 +236,18 @@ public class QueryStringTokenizer : IStringTokenizer<ExtractedQueryToken, Ignore
 			if (_index + 1 < _input.Length)
 			{
 				char next = _input[_index + 1];
+
+				// Sequential + have implicit AND relation 
+				if (next.Equals('+'))
+				{
+					_tokens.Add(new ExtractedQueryToken(
+						QueryTokenType.LogicalOperator, 
+						"AND", 
+						RequirementLevel.Required, 
+						_globalLanguage)
+					);
+					return;	
+				}
 
 				// Do not insert OR before operators
 				if ("!+-&|".Contains(next) ||

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/Helpers/QueryStringTokenizer.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/Helpers/QueryStringTokenizer.cs
@@ -144,7 +144,7 @@ public class QueryStringTokenizer : IStringTokenizer<ExtractedQueryToken, Ignore
 		}
 
                 
-		private void Flush( QueryTokenType queryTokenType, string languageCode)
+		private void Flush(QueryTokenType queryTokenType, string languageCode)
 		{
 			if (_stringBuilder.Length == 0) return;
 
@@ -299,7 +299,7 @@ public class QueryStringTokenizer : IStringTokenizer<ExtractedQueryToken, Ignore
 		}
 
 
-		private LoopAction TryHandleIsCapitalLetterOperator()
+     	private LoopAction TryHandleIsCapitalLetterOperator()
 		{
 			if (IsCapitalLetterOperator(_input, _index))
 			{
@@ -339,13 +339,13 @@ public class QueryStringTokenizer : IStringTokenizer<ExtractedQueryToken, Ignore
 
 		private bool IsLogicalOperator(char character)
 		{
-			if ((_index.Equals(0) || char.IsWhiteSpace(_input[_index - 1])) &&
-				Regex.IsMatch(character.ToString(), @"[\+\-\!\&\|]")
-				)
-			{
-				return true;			
-			}
-
+			bool isAtStart = _index.Equals(0);
+			bool isAfterSeparator = !isAtStart && 
+				(char.IsWhiteSpace(_input[_index - 1]) || " :([{".Contains(_input[_index - 1]));
+			
+			if (isAtStart || isAfterSeparator) 
+				return "+-!&|".Contains(character);
+			
 			return false;
 		}
 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/Helpers/QueryStringTokenizer.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/Helpers/QueryStringTokenizer.cs
@@ -92,7 +92,7 @@ public class QueryStringTokenizer : IStringTokenizer<ExtractedQueryToken, Ignore
 
                 if ((isWhitespace || ShouldBreakTerm(_character, _index)) && !_isBuildingAPhrase)
                 {
-                    Flush(QueryTokenType.Term, ResolveLanguage(_singleTermPhraseLanguage, _globalLanguage));
+                    FlushTermOrPhrase(QueryTokenType.Term, ResolveLanguage(_singleTermPhraseLanguage, _globalLanguage));
                     _singleTermPhraseLanguage = null!;
                 }
 
@@ -134,7 +134,7 @@ public class QueryStringTokenizer : IStringTokenizer<ExtractedQueryToken, Ignore
             }
 
             // Handles the last term if there is one
-            Flush(QueryTokenType.Term, ResolveLanguage(_singleTermPhraseLanguage, _globalLanguage));
+            FlushTermOrPhrase(QueryTokenType.Term, ResolveLanguage(_singleTermPhraseLanguage, _globalLanguage));
 			
 			_querySyntaxHelper.ValidateGrouping(_tokens);
 
@@ -143,56 +143,72 @@ public class QueryStringTokenizer : IStringTokenizer<ExtractedQueryToken, Ignore
 			); 
 		}
 
-                
-		private void Flush(QueryTokenType queryTokenType, string languageCode)
+
+		private void FlushOperator(QueryTokenType type)
 		{
 			if (_stringBuilder.Length == 0) return;
 
-			RequirementLevel requirementLevel = _isRequired ? 
-				RequirementLevel.Required: 
-				RequirementLevel.Optional;
-
-			var originalText = _stringBuilder.ToString().Trim();
-			string finalToken;
+			var tokenValue = _stringBuilder.ToString().Trim();
 		
-			// Handles term and phrase normalization and token creation
-			if (queryTokenType == QueryTokenType.Term || queryTokenType == QueryTokenType.Phrase)
-			{
-				var words = originalText.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+			RequirementLevel requirementLevel = GetRequirementLevel();
 
-				var normalizedWords = new List<string>();
+			_tokens.Add(new ExtractedQueryToken(type, tokenValue, requirementLevel));
 
-				foreach (var word in words)
-				{
-					var normalizedWord = _textNormalizer.Normalize(word, languageCode);
-
-					foreach (var token in normalizedWord)
-					{
-						if (!string.IsNullOrWhiteSpace(token)) 
-							normalizedWords.Add(token);
-						else 
-							_ignoredTokens.Add(new IgnoredTermsDTO{Token = word, Language = languageCode });	
-					}
-				}
-
-				finalToken = string.Join(' ', normalizedWords);	
-			}
-			else
-			{
-				finalToken = originalText;
-			}
-
-			if (finalToken is not null)
-			{
-				_tokens.Add(new ExtractedQueryToken(queryTokenType, finalToken, requirementLevel, languageCode));
-			}
-			
 			_stringBuilder.Clear();
-			_isRequired = false;
+			_isRequired = false; // Reset state
 		}
 
+                
+		private void FlushTermOrPhrase(QueryTokenType queryTokenType, string languageCode)
+        {
+            if (_stringBuilder.Length == 0) return;
 
-		private LoopAction HandleEscapeCharacter()
+            RequirementLevel requirementLevel = GetRequirementLevel();
+
+            var originalText = _stringBuilder.ToString().Trim();
+            string finalToken;
+
+            // Handles term and phrase normalization and token creation
+            if (queryTokenType == QueryTokenType.Term || queryTokenType == QueryTokenType.Phrase)
+            {
+                var words = originalText.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+                var normalizedWords = new List<string>();
+
+                foreach (var word in words)
+                {
+                    var normalizedWord = _textNormalizer.Normalize(word, languageCode);
+
+                    foreach (var token in normalizedWord)
+                    {
+                        if (!string.IsNullOrWhiteSpace(token))
+                            normalizedWords.Add(token);
+                        else
+                            _ignoredTokens.Add(new IgnoredTermsDTO { Token = word, Language = languageCode });
+                    }
+                }
+
+                finalToken = string.Join(' ', normalizedWords);
+            }
+            else
+            {
+                finalToken = originalText;
+            }
+
+            if (finalToken is not null)
+            {
+                _tokens.Add(new ExtractedQueryToken(queryTokenType, finalToken, requirementLevel, languageCode));
+            }
+
+            _stringBuilder.Clear();
+            _isRequired = false;
+        }
+
+        private RequirementLevel GetRequirementLevel() =>
+        	_isRequired ? RequirementLevel.Required : RequirementLevel.Optional;
+        
+
+        private LoopAction HandleEscapeCharacter()
         {
             if (!_isNextCharacterEscaped && _character.Equals('\\') && _index + 1 < _input.Length)
             {
@@ -214,7 +230,7 @@ public class QueryStringTokenizer : IStringTokenizer<ExtractedQueryToken, Ignore
 		private bool ShouldBreakTerm(char character, int index)
         {
 			if (IsGroupingOperator(character)) return true;
-			if ("!-&|".Contains(character) && IsAtStartOfWordOrAfterColon(index)) return true;
+			if ("!+-&|".Contains(character) && IsAtStartOfWordOrAfterColon(index)) return true; // ToDo: Make sure that + is required here!
 
 			return false;
         }
@@ -243,8 +259,7 @@ public class QueryStringTokenizer : IStringTokenizer<ExtractedQueryToken, Ignore
 					_tokens.Add(new ExtractedQueryToken(
 						QueryTokenType.LogicalOperator, 
 						"AND", 
-						RequirementLevel.Required, 
-						_globalLanguage)
+						RequirementLevel.Required)
 					);
 					return;	
 				}
@@ -259,8 +274,7 @@ public class QueryStringTokenizer : IStringTokenizer<ExtractedQueryToken, Ignore
 				_tokens.Add(new ExtractedQueryToken(
 					QueryTokenType.LogicalOperator, 
 					"OR", 
-					RequirementLevel.Optional, 
-					_globalLanguage)
+					RequirementLevel.Optional)
 				);
 			}
         }
@@ -295,7 +309,7 @@ public class QueryStringTokenizer : IStringTokenizer<ExtractedQueryToken, Ignore
 			if (IsGroupingOperator(_character))
 			{
 				_stringBuilder.Append(_character);
-				Flush(QueryTokenType.GroupingOperator, ResolveLanguage(_singleTermPhraseLanguage, _globalLanguage));
+				FlushOperator(QueryTokenType.GroupingOperator);
 				return LoopAction.Continue;
 			}
 
@@ -319,7 +333,7 @@ public class QueryStringTokenizer : IStringTokenizer<ExtractedQueryToken, Ignore
 				if (IsDoubleLogicalOperator(_character)) _stringBuilder.Append(_input, _index++, 2);
 				else _stringBuilder.Append(_character);
 
-				Flush(QueryTokenType.LogicalOperator, ResolveLanguage(_singleTermPhraseLanguage, _globalLanguage));
+				FlushOperator(QueryTokenType.LogicalOperator);
 				return LoopAction.Continue;
 			}
 
@@ -335,7 +349,8 @@ public class QueryStringTokenizer : IStringTokenizer<ExtractedQueryToken, Ignore
 				int length = (span.StartsWith("AND") || span.StartsWith("NOT")) ? 3 : 2;
 
 				_stringBuilder.Append(_input, _index, length);
-				Flush(QueryTokenType.LogicalOperator, ResolveLanguage(_singleTermPhraseLanguage, _globalLanguage));
+				
+				FlushOperator(QueryTokenType.LogicalOperator);
 
 				_index += (length - 1);
 				return LoopAction.Continue;
@@ -353,7 +368,7 @@ public class QueryStringTokenizer : IStringTokenizer<ExtractedQueryToken, Ignore
 				if (IsEdgeOfPhrase(checkEndPhrase: true))
 				{
 					_isBuildingAPhrase = !_isBuildingAPhrase;
-					Flush(QueryTokenType.Phrase, ResolveLanguage(_singleTermPhraseLanguage, _globalLanguage));
+					FlushTermOrPhrase(QueryTokenType.Phrase, ResolveLanguage(_singleTermPhraseLanguage, _globalLanguage));
 					return LoopAction.Continue;
 				}
 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/Helpers/QueryStringTokenizer.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/Helpers/QueryStringTokenizer.cs
@@ -3,7 +3,6 @@ using LTU.SearchEngine.Backend.Core.Enums;
 using LTU.SearchEngine.Backend.Core.Model.DTOs;
 using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
 using System.Text;
-using System.Text.RegularExpressions;
 
 namespace LTU.SearchEngine.Application.QueryParsing.Helpers;
 
@@ -45,9 +44,10 @@ public class QueryStringTokenizer : IStringTokenizer<ExtractedQueryToken, Ignore
 		private StringBuilder _stringBuilder = new();
 		private bool _isBuildingAPhrase = false;
 		private string _singleTermPhraseLanguage = null!;
-		private int _index;
 		private char _character; 
 		private bool _isNextCharacterEscaped = false;
+		private bool _isRequired = false; 
+		private int _index;
 
 		public QueryStringTokenizationSession(
 			string input, string languageCode, 
@@ -148,6 +148,10 @@ public class QueryStringTokenizer : IStringTokenizer<ExtractedQueryToken, Ignore
 		{
 			if (_stringBuilder.Length == 0) return;
 
+			RequirementLevel requirementLevel = _isRequired ? 
+				RequirementLevel.Required: 
+				RequirementLevel.Optional;
+
 			var originalText = _stringBuilder.ToString().Trim();
 			string finalToken;
 		
@@ -180,10 +184,11 @@ public class QueryStringTokenizer : IStringTokenizer<ExtractedQueryToken, Ignore
 
 			if (finalToken is not null)
 			{
-				_tokens.Add(new ExtractedQueryToken(queryTokenType, finalToken, languageCode));
+				_tokens.Add(new ExtractedQueryToken(queryTokenType, finalToken, requirementLevel, languageCode));
 			}
 			
 			_stringBuilder.Clear();
+			_isRequired = false;
 		}
 
 
@@ -239,7 +244,12 @@ public class QueryStringTokenizer : IStringTokenizer<ExtractedQueryToken, Ignore
 					IsLanguagePreFix(_input, _index +1)
 				) return; 
 
-				_tokens.Add(new ExtractedQueryToken(QueryTokenType.LogicalOperator, "OR", _globalLanguage));
+				_tokens.Add(new ExtractedQueryToken(
+					QueryTokenType.LogicalOperator, 
+					"OR", 
+					RequirementLevel.Optional, 
+					_globalLanguage)
+				);
 			}
         }
 
@@ -288,6 +298,12 @@ public class QueryStringTokenizer : IStringTokenizer<ExtractedQueryToken, Ignore
 		{
 			if (IsLogicalOperator(_character))
 			{
+				if (_character.Equals('+'))
+				{
+					_isRequired = true;
+					return LoopAction.Continue;
+				}
+				
 				if (IsDoubleLogicalOperator(_character)) _stringBuilder.Append(_input, _index++, 2);
 				else _stringBuilder.Append(_character);
 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Enums/RequirementLevel.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Enums/RequirementLevel.cs
@@ -1,0 +1,8 @@
+namespace LTU.SearchEngine.Backend.Core.Enums;
+
+public enum RequirementLevel
+{
+    Optional, 
+    Required, 
+    Prohibited // if NOT is to be handled differently in the future
+}

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/ExtractedQueryToken.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/ExtractedQueryToken.cs
@@ -13,7 +13,7 @@ public class ExtractedQueryToken
 		QueryTokenType tokenType, 
 		string token, 
 		RequirementLevel requirementLevel = RequirementLevel.Optional,
-		string language = "sv")
+		string language = "Unknown")
 	{
 		if (tokenType.Equals(QueryTokenType.LogicalOperator) && token.Length > 3)
 		{

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/ExtractedQueryToken.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/ExtractedQueryToken.cs
@@ -7,8 +7,13 @@ public class ExtractedQueryToken
 	public QueryTokenType TokenType { get; }
 	public string Token { get; }
 	public string Language { get; }
+	public RequirementLevel RequirementLevel { get; }
 
-	public ExtractedQueryToken(QueryTokenType tokenType, string token, string language = "sv")
+	public ExtractedQueryToken(
+		QueryTokenType tokenType, 
+		string token, 
+		RequirementLevel requirementLevel = RequirementLevel.Optional,
+		string language = "sv")
 	{
 		if (tokenType.Equals(QueryTokenType.LogicalOperator) && token.Length > 3)
 		{
@@ -29,5 +34,6 @@ public class ExtractedQueryToken
 		Token = token;
 		TokenType = tokenType;
 		Language = language;
+		RequirementLevel = requirementLevel;
 	}
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/QueryNodes/IIsRequirable.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/QueryNodes/IIsRequirable.cs
@@ -1,0 +1,22 @@
+namespace LTU.SearchEngine.Backend.Core.Model.ValueObjects.QueryNodes;
+
+/// <summary>
+/// Defines a contract for query nodes that can be explicitly marked as mandatory 
+/// requirements within a search clause.
+/// </summary>
+/// <remarks>
+/// This interface corresponds to the "+" prefix or "MUST" operator in query syntax, 
+/// specifying that the document must contain the match defined by this node to be 
+/// considered a valid result.
+/// </remarks>
+public interface IIsRequirable
+{
+    /// <summary>
+    /// Indicates whether the current node is a mandatory requirement for its parent clause.
+    /// </summary>
+    /// <returns>
+    /// <see langword="true"/> if the node associated with the prefix requirement operator (e.g., '+') 
+    /// indicating it must be present; <see langword="false"/> if the node is optional (should-match).
+    /// </returns>
+    bool IsRequirable();
+}

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/QueryNodes/IIsRequirable.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/QueryNodes/IIsRequirable.cs
@@ -18,5 +18,5 @@ public interface IIsRequirable
     /// <see langword="true"/> if the node associated with the prefix requirement operator (e.g., '+') 
     /// indicating it must be present; <see langword="false"/> if the node is optional (should-match).
     /// </returns>
-    bool IsRequirable();
+    bool IsRequired();
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/QueryNodes/LogicOperationNode.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/QueryNodes/LogicOperationNode.cs
@@ -12,8 +12,9 @@ namespace LTU.SearchEngine.Backend.Core.Model.ValueObjects.QueryNodes;
 /// This node is a structural component of the AST, used to represent logical operations <br />
 /// such as AND and OR by linking a left and a right <see cref="QueryNode{T}"/>.
 /// </remarks>
-public class LogicOperationNode<T> : QueryNode<T>
+public class LogicOperationNode<T> : QueryNode<T>, IIsRequirable
 {
+	private bool _isRequired; 
 	public QueryNode<T> LeftNode { get; }
 	public QueryNode<T> RightNode { get; }
 	public LogicalOperators LogicalOperator { get; }
@@ -26,7 +27,8 @@ public class LogicOperationNode<T> : QueryNode<T>
 	public LogicOperationNode(
 		QueryNode<T> leftNode,
 		QueryNode<T> rightNode,
-		LogicalOperators logicalOperator
+		LogicalOperators logicalOperator,
+		bool isRequired = false
 		)
 	{
 		LeftNode = leftNode ??
@@ -37,11 +39,15 @@ public class LogicOperationNode<T> : QueryNode<T>
 		ValidateLogicalOperator(logicalOperator);
 
 		LogicalOperator = logicalOperator;
+		_isRequired = isRequired;
 	}
 
 	/// <inheritdoc>/>
 	public override Task<T> AcceptAsync(IQueryVisitor<T> visitor)
 		=> visitor.VisitAsync(this);
+
+	/// <inheritdoc/>
+	public bool IsRequirable() => _isRequired;
 
 	/// <summary>
 	/// Used for debugging and visualization purposes, returns the logical expression <br/>
@@ -64,5 +70,4 @@ public class LogicOperationNode<T> : QueryNode<T>
 			);
 		}
 	}
-
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/QueryNodes/LogicOperationNode.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/QueryNodes/LogicOperationNode.cs
@@ -47,7 +47,7 @@ public class LogicOperationNode<T> : QueryNode<T>, IIsRequirable
 		=> visitor.VisitAsync(this);
 
 	/// <inheritdoc/>
-	public bool IsRequirable() => _isRequired;
+	public bool IsRequired() => _isRequired;
 
 	/// <summary>
 	/// Used for debugging and visualization purposes, returns the logical expression <br/>

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/QueryNodes/PhraseNode.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/QueryNodes/PhraseNode.cs
@@ -13,14 +13,16 @@ namespace LTU.SearchEngine.Backend.Core.Model.ValueObjects.QueryNodes;
 /// </remarks>
 public class PhraseNode<T> : QueryNode<T>, IIsVoidable
 {
+	private bool _isRequired; 
 	public List<ExtractedQueryToken> Phrase { get; }
 
 	/// <summary>Initializes a new instance of the <see cref="PhraseNode{T}"/> class.</summary>
 	/// <param name="phrase">A list of <see cref="ExtractedQueryToken"/> forming the phrase. Cannot be null.</param>
 	/// <exception cref="ArgumentNullException">Thrown if the provided phrase list is null.</exception>
-	public PhraseNode(List<ExtractedQueryToken> phrase)
+	public PhraseNode(List<ExtractedQueryToken> phrase, bool isRequired = false)
 	{
 		Phrase = phrase ?? throw new ArgumentNullException(nameof(phrase), "must have a value.");
+		_isRequired = isRequired;
 	}
 
 	/// <inheritdoc/>
@@ -30,6 +32,9 @@ public class PhraseNode<T> : QueryNode<T>, IIsVoidable
 	/// <inheritdoc/>
 	public bool IsVoid() 
 		=>  Phrase == null || Phrase.Count == 0 || Phrase.All( t => string.IsNullOrWhiteSpace(t.Token));
+
+	/// <inheritdoc/>
+	public bool IsRequirable() => _isRequired;
 
 	/// <summary>
 	/// Used for debugging and visualization purposes, returns the phrase as a <br/>

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/QueryNodes/PhraseNode.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/QueryNodes/PhraseNode.cs
@@ -11,7 +11,7 @@ namespace LTU.SearchEngine.Backend.Core.Model.ValueObjects.QueryNodes;
 /// A PhraseNode is used to represent quoted strings from the user input, ensuring that the <br />
 /// included tokens are treated as a single, ordered unit during the search process.
 /// </remarks>
-public class PhraseNode<T> : QueryNode<T>, IIsVoidable
+public class PhraseNode<T> : QueryNode<T>, IIsVoidable, IIsRequirable
 {
 	private bool _isRequired; 
 	public List<ExtractedQueryToken> Phrase { get; }
@@ -34,7 +34,7 @@ public class PhraseNode<T> : QueryNode<T>, IIsVoidable
 		=>  Phrase == null || Phrase.Count == 0 || Phrase.All( t => string.IsNullOrWhiteSpace(t.Token));
 
 	/// <inheritdoc/>
-	public bool IsRequirable() => _isRequired;
+	public bool IsRequired() => _isRequired;
 
 	/// <summary>
 	/// Used for debugging and visualization purposes, returns the phrase as a <br/>

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/QueryNodes/TermNode.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/QueryNodes/TermNode.cs
@@ -36,7 +36,7 @@ public class TermNode<T> : QueryNode<T>, IIsVoidable, IIsRequirable
 	public bool IsVoid() => string.IsNullOrWhiteSpace(Term);
     
 	/// <inheritdoc/>
-	public bool IsRequirable() => _isRequired;
+	public bool IsRequired() => _isRequired;
 
 	/// <summary>
 	/// Used for debugging and visualization purposes, returns the term string contained in this node.

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/QueryNodes/TermNode.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/ValueObjects/QueryNodes/TermNode.cs
@@ -11,18 +11,20 @@ namespace LTU.SearchEngine.Backend.Core.Model.ValueObjects.QueryNodes;
 /// A TermNode is an atomic element in the Abstract Syntax Tree (AST), representing <br />
 /// an unquoted keyword provided by the user.
 /// </remarks>
-public class TermNode<T> : QueryNode<T>, IIsVoidable
+public class TermNode<T> : QueryNode<T>, IIsVoidable, IIsRequirable
 {
+	private bool _isRequired; 
 	public string Term { get; }
 
 	/// <summary>Initializes a new instance of the <see cref="TermNode{T}"/> class.</summary>
 	/// <param name="term">The search term string. Cannot be null.</param>
 	/// <exception cref="ArgumentNullException">Thrown if the provided term is null.</exception>
-	public TermNode(string term)
+	public TermNode(string term, bool isRequired = false)
 	{
 		if (term is null) throw new ArgumentNullException(nameof(term), "must have a value.");
 
 		Term = term;
+		_isRequired = isRequired;
 	}
 
 
@@ -32,6 +34,9 @@ public class TermNode<T> : QueryNode<T>, IIsVoidable
     
 	/// <inheritdoc/>
 	public bool IsVoid() => string.IsNullOrWhiteSpace(Term);
+    
+	/// <inheritdoc/>
+	public bool IsRequirable() => _isRequired;
 
 	/// <summary>
 	/// Used for debugging and visualization purposes, returns the term string contained in this node.

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/QueryEvaluatorVisitor.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/QueryEvaluatorVisitor.cs
@@ -58,14 +58,30 @@ public class QueryEvaluatorVisitor : IQueryVisitor<HashSet<int>>
 
 	/// <inheritdoc/>
 	/// <remarks>
-	/// This implementation evaluates the <see cref="IIsVoidable.IsVoid"/> state of the child nodes before processing.
-	/// <list type="bullet">
-	/// <item>If both nodes are void, an empty result is returned.</item>
-	/// <item>If only one node is void, the operation is bypassed and the non-void node is evaluated directly.</item>
-	/// <item>Otherwise, a set operation (Intersect, Union, or Except) is performed on the results of both branches.</item>
-	/// <item>Special handling for NOT operations ensures that if the left node is void, the entire operation is treated as void to prevent incorrect result sets.</item>
-	/// </list>
-	/// </remarks> 
+	/// Evaluates logical operations (AND, OR, NOT) by performing set operations on document ID collections.
+	/// <para>
+	/// 	<b>Void Handling:</b>
+	/// 	<list type="bullet">
+	/// 		<item>If both child nodes are void, returns an empty set.</item>
+	/// 		<item>If one node is void, the operation is bypassed in favor of the non-void node (e.g., "A OR [void]" becomes "A").</item>
+	/// 		<item>Special case for <see cref="LogicalOperators.NOT"/>: If the left node (the base set) is void, the entire operation is treated as void.</item>
+	/// 	</list>
+	///	</para>
+	///	<para>
+	/// 	<b>Requirement Filtering (Mandatory Terms):</b>
+	/// 	<list type="bullet">
+	///			<item>
+	/// 			For <see cref="LogicalOperators.OR"/>, if a child node is marked as required (e.g., "A OR +B"), 
+	/// 			the resulting union is intersected with that child's result set. This effectively ensures the required 
+	/// 			term is present while still allowing the other branch to contribute matches.
+	/// 		</item>
+	/// 		<item>
+	/// 			Requirement levels are implicitly satisfied by <see cref="LogicalOperators.AND"/> 
+	/// 			and do not require additional filtering.
+	/// 		</item>
+	/// 	</list>
+	/// </para>
+	/// </remarks>
 	public async Task<HashSet<int>> VisitAsync(LogicOperationNode<HashSet<int>> node)
     {
         bool leftNodeIsVoid = IsNodeVoid(node.LeftNode);

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/QueryEvaluatorVisitor.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/QueryEvaluatorVisitor.cs
@@ -79,13 +79,22 @@ public class QueryEvaluatorVisitor : IQueryVisitor<HashSet<int>>
         var left = await node.LeftNode.AcceptAsync(this);
         var right = await node.RightNode.AcceptAsync(this);
 
-        return node.LogicalOperator switch
+		var result = node.LogicalOperator switch
         {
             LogicalOperators.AND => left.Intersect(right).ToHashSet(),
             LogicalOperators.OR => left.Union(right).ToHashSet(),
             LogicalOperators.NOT => left.Except(right).ToHashSet(),
             _ => throw new InvalidOperationException($"Unsupported logical operator: {node.LogicalOperator}")
         };
+
+		// Result is "filtered" through the required node
+		if (node.LogicalOperator.Equals(LogicalOperators.OR))
+		{
+			if (IsRequiredNode(node.LeftNode)) result.IntersectWith(left); 
+			if (IsRequiredNode(node.RightNode)) result.IntersectWith(right); 
+		}
+
+		return result;
     }
 
 	private bool IsWholeOperationVoid(bool leftNodeIsVoid, bool rightNodeIsVoid, LogicOperationNode<HashSet<int>> node)
@@ -104,9 +113,15 @@ public class QueryEvaluatorVisitor : IQueryVisitor<HashSet<int>>
     {
         if (node is IIsVoidable voidableNode && voidableNode.IsVoid()) 
 			return true;
-        
         return false;
     }
+
+	private static bool IsRequiredNode(QueryNode<HashSet<int>> node)
+	{
+		if (node is IIsRequirable requirableNode && requirableNode.IsRequired())
+			return true;
+		return false;
+	}
 
     /// <inheritdoc/>
     public Task<HashSet<int>> VisitAsync(RequiredNode<HashSet<int>> node)

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/SearchQueryBuilder/AbstractSyntaxTreeBuilder.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/SearchQueryBuilder/AbstractSyntaxTreeBuilder.cs
@@ -35,18 +35,22 @@ public class AbstractSyntaxTreeBuilder<TResult> : ITreeBuilder<TResult, Extracte
 
 		foreach (ExtractedQueryToken token in postfix)
 		{
+			bool isRequired = token.RequirementLevel.Equals(RequirementLevel.Required) ? 
+				true : 
+				false;
+
 			switch (token.TokenType)
 			{
 				case QueryTokenType.Term:
-					Stack.Push(new TermNode<TResult>(token.Token));
+					Stack.Push(new TermNode<TResult>(token.Token, isRequired));
 					break;
 				case QueryTokenType.Phrase:
 					Stack.Push(
-						new PhraseNode<TResult>(ConvertPhraseToTermList(token.Token))
+						new PhraseNode<TResult>(ConvertPhraseToTermList(token.Token), isRequired)
 					);
 					break;
 				case QueryTokenType.LogicalOperator:
-					HandleLogicalOperator(Stack, token);
+					HandleLogicalOperator(Stack, token, isRequired);
 					break;
 				default:
 					break;
@@ -61,7 +65,9 @@ public class AbstractSyntaxTreeBuilder<TResult> : ITreeBuilder<TResult, Extracte
 
 
 	private void HandleLogicalOperator(
-		Stack<QueryNode<TResult>> aSTStack, ExtractedQueryToken token)
+		Stack<QueryNode<TResult>> aSTStack, 
+		ExtractedQueryToken token,
+		bool isRequired = false)
 	{
 		// makes sure there are enough tokens to build a logical operation
 		if (aSTStack.Count < 2)
@@ -75,7 +81,8 @@ public class AbstractSyntaxTreeBuilder<TResult> : ITreeBuilder<TResult, Extracte
 		aSTStack.Push(new LogicOperationNode<TResult>(
 			leftNode: left,
 			rightNode: right,
-			logicalOperator: op
+			logicalOperator: op,
+			isRequired: isRequired
 		));
 	}
 
@@ -86,7 +93,6 @@ public class AbstractSyntaxTreeBuilder<TResult> : ITreeBuilder<TResult, Extracte
 			"AND" or "&&" => LogicalOperators.AND,
 			"OR" or "||" => LogicalOperators.OR,
 			"NOT" or "-" or "!" => LogicalOperators.NOT,
-			// "+" => LogicalOperators.REQUIRED, When Required gets implemented, this should be un-commented.
 			_ => throw new NotSupportedException()
 		};
 	}

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/SearchQueryBuilder/SearchQueryShuntingYardParser.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/SearchQueryBuilder/SearchQueryShuntingYardParser.cs
@@ -4,19 +4,29 @@ using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
 namespace LTU.SearchEngine.Backend.Core.SearchQueryBuilder;
 
 /// <summary>
-/// Implements the Shunting-yard algorithm to parse search queries. <br/>
-/// It converts an infix notation query (e.g., "A AND B") into postfix notation (Reverse Polish Notation), <br/>
-/// handling logical operator precedence (NOT > AND > OR) and grouping via parentheses.
+/// Implements an enhanced Shunting-yard algorithm to parse search queries into Postfix notation (RPN). <br/>
+/// Beyond standard operator precedence (NOT > AND > OR), this implementation handles:
+/// <list type="bullet">
+///     <item><b>Requirement Persistence:</b> Individual terms maintain their <see cref="RequirementLevel"/> (e.g., +term).</item>
+///     <item><b>Requirement Inheritance:</b> Propagates requirements from grouping operators to their root logical operators (e.g., +(A OR B) marks OR as Required).</item>
+///     <item><b>Validation:</b> Prevents invalid semantic combinations like consecutive operators or applying NOT to a required term.</item>
+/// </list>
 /// </summary>
 public class SearchQueryShuntingYardParser : IShuntingYardParser<ExtractedQueryToken>
 {
 	/// <inheritdoc/>
+    /// <summary>
+    /// Converts an infix sequence of tokens into a postfix queue while preserving and propagating requirement metadata.
+    /// </summary>
+    /// <param name="tokens">The stream of tokens extracted from the raw search string.</param>
+    /// <returns>A queue of tokens in Reverse Polish Notation, ready for AST construction.</returns>
+    /// <exception cref="FormatException">Thrown when encountering mismatched parentheses, consecutive operators, or illegal requirement applications (e.g., NOT +term).</exception>
+    /// <exception cref="ArgumentNullException">Thrown if the token collection is null.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if the token collection is empty.</exception> 
 	public Queue<ExtractedQueryToken> ConvertToPostfix(IEnumerable<ExtractedQueryToken> tokens)
 	{
-		// ToDo: Figure out a solution to handle required tokens.
 		VerifyTokens(tokens);
 
-		// Queue<ExtractedQueryToken> outputQueue = new();
 		List<ExtractedQueryToken> postFixResults = new();
 		Stack<ExtractedQueryToken> operatorStack = new();
 
@@ -39,7 +49,6 @@ public class SearchQueryShuntingYardParser : IShuntingYardParser<ExtractedQueryT
 
             if (IsTermOrPhrase(token))
             {
-                // outputQueue.Enqueue(token);
                 postFixResults.Add(token);
                 firstTermPhraseSet = true;
             }
@@ -52,7 +61,6 @@ public class SearchQueryShuntingYardParser : IShuntingYardParser<ExtractedQueryT
                 // Move operators to output until the matching start parenthesis is found.
                 while (ShouldPopOperator(operatorStack))
                 {
-                    // outputQueue.Enqueue(operatorStack.Pop());
                     postFixResults.Add(operatorStack.Pop());
                 }
 
@@ -63,16 +71,12 @@ public class SearchQueryShuntingYardParser : IShuntingYardParser<ExtractedQueryT
                 
                 if (openingBracket.RequirementLevel.Equals(RequirementLevel.Required))
                     MarkLastOperatorAsRequired(postFixResults);
-            
-                // if (operatorStack.Count > 0) operatorStack.Pop();
-
             }
             else if (currTokenIsLogicalOperator)
             {
                 int currentOperatorValue = GetPrecedenceValue(token.Token);
 
                 while (NextPopDoesNotHavePrecedence(operatorStack, currentOperatorValue))
-                    // outputQueue.Enqueue(operatorStack.Pop());
                     postFixResults.Add(operatorStack.Pop());
 
                 operatorStack.Push(token);
@@ -88,7 +92,6 @@ public class SearchQueryShuntingYardParser : IShuntingYardParser<ExtractedQueryT
 
             HandleMismatchingStartParentheses(remainingToken);
 
-            // outputQueue.Enqueue(remainingToken);
             postFixResults.Add(remainingToken);
         }
 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/SearchQueryBuilder/SearchQueryShuntingYardParser.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/SearchQueryBuilder/SearchQueryShuntingYardParser.cs
@@ -16,22 +16,31 @@ public class SearchQueryShuntingYardParser : IShuntingYardParser<ExtractedQueryT
 		// ToDo: Figure out a solution to handle required tokens.
 		VerifyTokens(tokens);
 
-		Queue<ExtractedQueryToken> outputQueue = new();
+		// Queue<ExtractedQueryToken> outputQueue = new();
+		List<ExtractedQueryToken> postFixResults = new();
 		Stack<ExtractedQueryToken> operatorStack = new();
 
 		ExtractedQueryToken? lastNonGroupingToken = null;
 		bool firstTermPhraseSet = false;
 		
-		foreach (ExtractedQueryToken token in tokens)
+        var tokenList = tokens.ToList();
+
+		for (int i = 0; i < tokenList.Count; i++)
         {
+            var token = tokenList[i];
+
             bool currTokenIsLogicalOperator = IsLogicalOperator(token);
 
             HandleLogicalOperatorBeforeFirstTermOrPhrase(firstTermPhraseSet, token, currTokenIsLogicalOperator);
             HandleLogicalOperatorsInSequence(lastNonGroupingToken, token);
 
+            if (CanVerifyRequirementLookahead(tokenList, i, currTokenIsLogicalOperator))
+                HandleRequiredRequirement(token, tokenList[i + 1]);
+
             if (IsTermOrPhrase(token))
             {
-                outputQueue.Enqueue(token);
+                // outputQueue.Enqueue(token);
+                postFixResults.Add(token);
                 firstTermPhraseSet = true;
             }
             else if (IsStartParentheses(token))
@@ -43,20 +52,28 @@ public class SearchQueryShuntingYardParser : IShuntingYardParser<ExtractedQueryT
                 // Move operators to output until the matching start parenthesis is found.
                 while (ShouldPopOperator(operatorStack))
                 {
-                    outputQueue.Enqueue(operatorStack.Pop());
+                    // outputQueue.Enqueue(operatorStack.Pop());
+                    postFixResults.Add(operatorStack.Pop());
                 }
 
                 HandleMismatchingClosingParentheses(operatorStack);
 
                 // Discard the start parenthesis from the stack.
-                if (operatorStack.Count > 0) operatorStack.Pop();
+                var openingBracket = operatorStack.Pop();
+                
+                if (openingBracket.RequirementLevel.Equals(RequirementLevel.Required))
+                    MarkLastOperatorAsRequired(postFixResults);
+            
+                // if (operatorStack.Count > 0) operatorStack.Pop();
+
             }
-            else if (IsLogicalOperator(token))
+            else if (currTokenIsLogicalOperator)
             {
                 int currentOperatorValue = GetPrecedenceValue(token.Token);
 
                 while (NextPopDoesNotHavePrecedence(operatorStack, currentOperatorValue))
-                    outputQueue.Enqueue(operatorStack.Pop());
+                    // outputQueue.Enqueue(operatorStack.Pop());
+                    postFixResults.Add(operatorStack.Pop());
 
                 operatorStack.Push(token);
             }
@@ -71,11 +88,49 @@ public class SearchQueryShuntingYardParser : IShuntingYardParser<ExtractedQueryT
 
             HandleMismatchingStartParentheses(remainingToken);
 
-            outputQueue.Enqueue(remainingToken);
+            // outputQueue.Enqueue(remainingToken);
+            postFixResults.Add(remainingToken);
         }
 
-        return outputQueue;
+        return new Queue<ExtractedQueryToken>(postFixResults);
 	}
+
+    private void MarkLastOperatorAsRequired(List<ExtractedQueryToken> outputQueue)
+    {
+        if (outputQueue.Count > 0)
+        {
+            var lastToken = outputQueue[^1];
+            var requiredOperatorTokenVersion = new ExtractedQueryToken(
+                tokenType: lastToken.TokenType,
+                token: lastToken.Token,
+                language: lastToken.Language,
+                requirementLevel: RequirementLevel.Required
+            ); 
+
+            outputQueue[^1] = requiredOperatorTokenVersion;
+        }
+
+    }
+
+    private static bool CanVerifyRequirementLookahead(
+        List<ExtractedQueryToken> tokenList, 
+        int index, 
+        bool isLogicalOperator)
+    {
+        return isLogicalOperator && (index + 1 < tokenList.Count);
+    }
+    
+
+    private void HandleRequiredRequirement(ExtractedQueryToken operatorToken, ExtractedQueryToken nextToken)
+    {
+        if (IsANotOperator(operatorToken) && nextToken.RequirementLevel.Equals(RequirementLevel.Required))
+        {
+            throw new FormatException(
+                $"Invalid query format: The NOT operator cannot be applied to a required term or group. " +
+                $"Found '{operatorToken.Token}' followed by a '+' requirement on '{nextToken.Token}'."
+            );
+        }
+    }
 
     private void HandleMismatchingStartParentheses(ExtractedQueryToken remainingToken)
     {

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/AbstractSyntaxTreeBuilderTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/AbstractSyntaxTreeBuilderTests.cs
@@ -131,6 +131,120 @@ public class AbstractSyntaxTreeBuilderTests
 		Assert.Equal("world", phraseNode.Phrase[1].Token);
 	}
 
+
+	[Fact]
+	public void BuildTree_RequiredTerm_CreatesNodeWithIsRequiredTrue()
+	{
+		// Arrange
+		var postfix = new Queue<ExtractedQueryToken>(new[]
+		{
+			new ExtractedQueryToken(QueryTokenType.Term, "cat", RequirementLevel.Required)
+		});
+
+		_parserMock
+			.Setup(p => p.ConvertToPostfix(It.IsAny<IEnumerable<ExtractedQueryToken>>()))
+			.Returns(postfix);
+
+		var sut = CreateBuilder();
+
+		// Act
+		var result = sut.BuildTree(new List<ExtractedQueryToken>());
+
+		// Assert
+		var termNode = Assert.IsType<TermNode<HashSet<int>>>(result);
+		Assert.True(termNode.IsRequired()); 
+	}
+
+
+	[Fact]
+	public void BuildTree_RequiredPhrase_CreatesNodeWithIsRequiredTrue()
+	{
+		// Arrange
+		var postfix = new Queue<ExtractedQueryToken>(new[]
+		{
+			new ExtractedQueryToken(QueryTokenType.Phrase, "luleå ltu", RequirementLevel.Required)
+		});
+
+		_parserMock
+			.Setup(p => p.ConvertToPostfix(It.IsAny<IEnumerable<ExtractedQueryToken>>()))
+			.Returns(postfix);
+
+		var sut = CreateBuilder();
+
+		// Act
+		var result = sut.BuildTree(new List<ExtractedQueryToken>());
+
+		// Assert
+		var phraseNode = Assert.IsType<PhraseNode<HashSet<int>>>(result);
+		Assert.True(phraseNode.IsRequired());
+	}
+
+
+	[Fact]
+	public void BuildTree_RequiredLogicalOperator_CreatesLogicNodeWithIsRequiredTrue()
+	{
+		// Arrange: Postfix for "cat dog AND" where AND is tagged as Required
+		var postfix = new Queue<ExtractedQueryToken>(new[]
+		{
+			new ExtractedQueryToken(QueryTokenType.Term, "cat"),
+			new ExtractedQueryToken(QueryTokenType.Term, "dog"),
+			new ExtractedQueryToken(QueryTokenType.LogicalOperator, "AND", RequirementLevel.Required)
+		});
+
+		_parserMock
+			.Setup(p => p.ConvertToPostfix(It.IsAny<IEnumerable<ExtractedQueryToken>>()))
+			.Returns(postfix);
+
+		var sut = CreateBuilder();
+
+		// Act
+		var result = sut.BuildTree(new List<ExtractedQueryToken>());
+
+		// Assert
+		var logicNode = Assert.IsType<LogicOperationNode<HashSet<int>>>(result);
+		Assert.True(logicNode.IsRequired());
+		
+		// Child nodes should still be optional unless they were specifically tagged
+		var left = Assert.IsType<TermNode<HashSet<int>>>(logicNode.LeftNode);
+		Assert.False(left!.IsRequired());
+		
+		var right = Assert.IsType<TermNode<HashSet<int>>>(logicNode.RightNode);
+		Assert.False(right!.IsRequired());
+	}
+
+
+	[Fact]
+	public void BuildTree_MixedRequirements_AssignsPropertiesCorrectly()
+	{
+		// Arrange: +cat dog OR (Optional OR, but 'cat' is required)
+		var postfix = new Queue<ExtractedQueryToken>(new[]
+		{
+			new ExtractedQueryToken(QueryTokenType.Term, "cat", RequirementLevel.Required),
+			new ExtractedQueryToken(QueryTokenType.Term, "dog", RequirementLevel.Optional),
+			new ExtractedQueryToken(QueryTokenType.LogicalOperator, "OR", RequirementLevel.Optional)
+		});
+
+		_parserMock
+			.Setup(p => p.ConvertToPostfix(It.IsAny<IEnumerable<ExtractedQueryToken>>()))
+			.Returns(postfix);
+
+		var sut = CreateBuilder();
+
+		// Act
+		var result = sut.BuildTree(new List<ExtractedQueryToken>());
+
+		// Assert
+		var logicNode = Assert.IsType<LogicOperationNode<HashSet<int>>>(result);
+		Assert.False(logicNode.IsRequired()); // The OR itself is optional
+		
+		var left = Assert.IsType<TermNode<HashSet<int>>>(logicNode.LeftNode);
+		Assert.True(left.IsRequired()); // cat is required
+		
+		var right = Assert.IsType<TermNode<HashSet<int>>>(logicNode.RightNode);
+		Assert.False(right.IsRequired()); // dog is optional
+	}
+
+
 	[Fact]
 	public void BuildTree_InvalidStructure_Throws()
 	{

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/ExtractedQueryTokenTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/ExtractedQueryTokenTests.cs
@@ -81,13 +81,13 @@ public class ExtractedQueryTokenTests
     }
 
     [Fact]
-    public void Constructor_DefaultLanguage_IsSwedish()
+    public void Constructor_DefaultLanguage_IsUnknown()
     {
         // Act
         var result = new ExtractedQueryToken(QueryTokenType.Term, "test");
 
         // Assert
-        Assert.Equal("sv", result.Language);
+        Assert.Equal("Unknown", result.Language);
     }
 
     [Theory]

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/ExtractedQueryTokenTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/ExtractedQueryTokenTests.cs
@@ -74,7 +74,7 @@ public class ExtractedQueryTokenTests
         var language = "en";
 
         // Act
-        var result = new ExtractedQueryToken(type, token, language);
+        var result = new ExtractedQueryToken(type, token, RequirementLevel.Optional, language);
 
         // Assert
         Assert.Equal(language, result.Language);

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/QueryEvaluatorVisitorTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/QueryEvaluatorVisitorTests.cs
@@ -192,8 +192,9 @@ public class QueryEvaluatorVisitorTests
 		var leftNode = new TermNode<HashSet<int>>(string.Empty); // Assumed to implement IIsVoidable and return true
 		var rightNode = new TermNode<HashSet<int>>("dog");
 		
-		_repositoryMock.Setup(r => r.GetDocumentIdsForTermAsync("dog"))
-					.ReturnsAsync(new HashSet<int> { 1 });
+		_repositoryMock
+			.Setup(r => r.GetDocumentIdsForTermAsync("dog"))
+			.ReturnsAsync(new HashSet<int> { 1 });
 
 		var node = new LogicOperationNode<HashSet<int>>(leftNode, rightNode, LogicalOperators.NOT);
 
@@ -213,8 +214,9 @@ public class QueryEvaluatorVisitorTests
 		var leftNode = new TermNode<HashSet<int>>("cat");
 		var rightNode = new TermNode<HashSet<int>>(string.Empty); // Void node
 
-		_repositoryMock.Setup(r => r.GetDocumentIdsForTermAsync("cat"))
-					.ReturnsAsync(expectedIds);
+		_repositoryMock
+			.Setup(r => r.GetDocumentIdsForTermAsync("cat"))
+			.ReturnsAsync(expectedIds);
 
 		var node = new LogicOperationNode<HashSet<int>>(leftNode, rightNode, LogicalOperators.OR);
 
@@ -246,12 +248,152 @@ public class QueryEvaluatorVisitorTests
 	public async Task VisitAsync_TermNode_WhenRepositoryThrows_ShouldThrowQueryEvaluationException()
 	{
 		// Arrange
-		_repositoryMock.Setup(r => r.GetDocumentIdsForTermAsync(It.IsAny<string>()))
-					.ThrowsAsync(new Exception("Database down"));
+		_repositoryMock
+			.Setup(r => r.GetDocumentIdsForTermAsync(It.IsAny<string>()))
+			.ThrowsAsync(new Exception("Database down"));
+		
 		var node = new TermNode<HashSet<int>>("fail");
 
 		// Act & Assert
 		var ex = await Assert.ThrowsAsync<QueryEvaluationException>(() => _sut.VisitAsync(node));
 		Assert.Contains("Failed evaluating term 'fail'", ex.Message);
+	}
+
+	[Fact]
+	public async Task VisitAsync_OR_WithRequiredRightChild_IntersectsResults()
+	{
+		// Arrange: "cat" OR +"dog"
+		// cat has {1, 2}, dog has {2, 3}. 
+		// Normal OR would be {1, 2, 3}. 
+		// Because dog is required, it should be {1, 2, 3} INTERSECT {2, 3} = {2, 3}.
+		var catSet = new HashSet<int> { 1, 2 };
+		var dogSet = new HashSet<int> { 2, 3 };
+		var expectedIds = new HashSet<int> { 2, 3 };
+
+		_repositoryMock.Setup(r => r.GetDocumentIdsForTermAsync("cat")).ReturnsAsync(catSet);
+		_repositoryMock.Setup(r => r.GetDocumentIdsForTermAsync("dog")).ReturnsAsync(dogSet);
+
+		var leftNode = new TermNode<HashSet<int>>("cat", isRequired: false);
+		var rightNode = new TermNode<HashSet<int>>("dog", isRequired: true); // Required!
+
+		var node = new LogicOperationNode<HashSet<int>>(leftNode, rightNode, LogicalOperators.OR);
+
+		// Act
+		var result = await _sut.VisitAsync(node);
+
+		// Assert
+		Assert.Equal(expectedIds, result);
+		Assert.DoesNotContain(1, result); 
+	}
+
+	[Fact]
+	public async Task VisitAsync_OR_WithRequiredLeftChild_IntersectsResults()
+	{
+		// Arrange: +"cat" OR "dog"
+		var catSet = new HashSet<int> { 1, 2 };
+		var dogSet = new HashSet<int> { 2, 3 };
+		var expectedIds = new HashSet<int> { 1, 2 }; // Must have cat
+
+		_repositoryMock.Setup(r => r.GetDocumentIdsForTermAsync("cat")).ReturnsAsync(catSet);
+		_repositoryMock.Setup(r => r.GetDocumentIdsForTermAsync("dog")).ReturnsAsync(dogSet);
+
+		var leftNode = new TermNode<HashSet<int>>("cat", isRequired: true);
+		var rightNode = new TermNode<HashSet<int>>("dog", isRequired: false);
+
+		var node = new LogicOperationNode<HashSet<int>>(leftNode, rightNode, LogicalOperators.OR);
+
+		// Act
+		var result = await _sut.VisitAsync(node);
+
+		// Assert
+		Assert.Equal(expectedIds, result);
+	}
+
+	[Fact]
+	public async Task VisitAsync_OR_BothChildrenRequired_ResultsInIntersection()
+	{
+		// Arrange: +"cat" OR +"dog"
+		var catSet = new HashSet<int> { 1, 2 };
+		var dogSet = new HashSet<int> { 2, 3 };
+		var expectedIds = new HashSet<int> { 2 }; // Only common element
+
+		_repositoryMock.Setup(r => r.GetDocumentIdsForTermAsync("cat")).ReturnsAsync(catSet);
+		_repositoryMock.Setup(r => r.GetDocumentIdsForTermAsync("dog")).ReturnsAsync(dogSet);
+
+		var leftNode = new TermNode<HashSet<int>>("cat", isRequired: true);
+		var rightNode = new TermNode<HashSet<int>>("dog", isRequired: true);
+
+		var node = new LogicOperationNode<HashSet<int>>(leftNode, rightNode, LogicalOperators.OR);
+
+		// Act
+		var result = await _sut.VisitAsync(node);
+
+		// Assert
+		Assert.Equal(expectedIds, result);
+	}
+
+	[Fact]
+	public async Task VisitAsync_AND_WithRequiredChild_BehavesLikeStandardAND()
+	{
+		// Arrange: cat AND +dog
+		var catSet = new HashSet<int> { 1, 2 };
+		var dogSet = new HashSet<int> { 2, 3 };
+		
+		_repositoryMock.Setup(r => r.GetDocumentIdsForTermAsync("cat")).ReturnsAsync(catSet);
+		_repositoryMock.Setup(r => r.GetDocumentIdsForTermAsync("dog")).ReturnsAsync(dogSet);
+
+		var node = new LogicOperationNode<HashSet<int>>(
+			new TermNode<HashSet<int>>("cat"),
+			new TermNode<HashSet<int>>("dog", isRequired: true),
+			LogicalOperators.AND
+		);
+
+		// Act
+		var result = await _sut.VisitAsync(node);
+
+		// Assert
+		Assert.Single(result);
+		Assert.Contains(2, result);
+	}
+
+	[Fact]
+	public async Task VisitAsync_OR_WithRequiredNOTChild_FiltersCorrectly()
+	{
+		// Arrange: +(Java NOT Python) OR C#
+		// Java: 	{1, 2, 3}, 
+		// Python: 	{3}, 
+		// C#: 		{4}
+		// (Java NOT Python) = {1, 2}
+		// ({1, 2} OR {4}) = {1, 2, 4}
+		// Filter by Required NOT: {1, 2, 4} INTERSECT {1, 2} = {1, 2}
+		
+		var javaSet = new HashSet<int> { 1, 2, 3 };
+		var pythonSet = new HashSet<int> { 3 };
+		var cSharpSet = new HashSet<int> { 4 };
+
+		_repositoryMock.Setup(r => r.GetDocumentIdsForTermAsync("Java")).ReturnsAsync(javaSet);
+		_repositoryMock.Setup(r => r.GetDocumentIdsForTermAsync("Python")).ReturnsAsync(pythonSet);
+		_repositoryMock.Setup(r => r.GetDocumentIdsForTermAsync("C#")).ReturnsAsync(cSharpSet);
+
+		var notNode = new LogicOperationNode<HashSet<int>>(
+			new TermNode<HashSet<int>>("Java"),
+			new TermNode<HashSet<int>>("Python"),
+			LogicalOperators.NOT,
+			isRequired: true // The whole NOT group is required
+		);
+
+		var rootOrNode = new LogicOperationNode<HashSet<int>>(
+			notNode,
+			new TermNode<HashSet<int>>("C#"),
+			LogicalOperators.OR
+		);
+
+		// Act
+		var result = await _sut.VisitAsync(rootOrNode);
+
+		// Assert
+		Assert.Contains(1, result);
+		Assert.Contains(2, result);
+		Assert.DoesNotContain(4, result); // C# was there, but the mandatory NOT group excluded it
 	}
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/QueryTokenizerTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/QueryTokenizerTests.cs
@@ -130,7 +130,7 @@ public class QueryTokenizerTests
 		var start = new ExtractedQueryToken(QueryTokenType.Term, "start", RequirementLevel.Optional, "en");
 		var unclosed = new ExtractedQueryToken(QueryTokenType.Term, "\"unclosed", RequirementLevel.Optional, "en");
 		var phrase = new ExtractedQueryToken(QueryTokenType.Term, "phrase", RequirementLevel.Optional, "en");
-		var or = new ExtractedQueryToken(QueryTokenType.LogicalOperator, "OR", RequirementLevel.Optional, "en");
+		var or = new ExtractedQueryToken(QueryTokenType.LogicalOperator, "OR", RequirementLevel.Optional);
 		// Act
 		var result = _sut.Tokenize(input, "en");
 		var resultList = result.Tokens.ToList();
@@ -345,9 +345,7 @@ public class QueryTokenizerTests
 		var input = $"start {operatorInput} phrase";
 
 		var start = new ExtractedQueryToken(QueryTokenType.Term, "start", RequirementLevel.Optional, "en");
-		var expectedOperator = new ExtractedQueryToken(
-			QueryTokenType.LogicalOperator, operatorInput, RequirementLevel.Optional, "en"
-		);
+		var expectedOperator = new ExtractedQueryToken(QueryTokenType.LogicalOperator, operatorInput, RequirementLevel.Optional);
 		var phrase = new ExtractedQueryToken(QueryTokenType.Term, "phrase", RequirementLevel.Optional, "en");
 
 		// Act
@@ -372,7 +370,7 @@ public class QueryTokenizerTests
 
 		var first = new ExtractedQueryToken(QueryTokenType.Term, "first", RequirementLevel.Optional, "en");
 		var expectedOperator = new ExtractedQueryToken(
-			QueryTokenType.LogicalOperator, operatorInput, RequirementLevel.Optional, "en"
+			QueryTokenType.LogicalOperator, operatorInput, RequirementLevel.Optional, "Unknown"
 		);
 		var second = new ExtractedQueryToken(QueryTokenType.Term, "second", RequirementLevel.Optional, "en");
 
@@ -399,13 +397,13 @@ public class QueryTokenizerTests
 		var input = $"{operator1}\"start phrase\"{operator2}";
 
 		var expectedOperator1 = new ExtractedQueryToken(
-			QueryTokenType.GroupingOperator, operator1, RequirementLevel.Optional, "en"
+			QueryTokenType.GroupingOperator, operator1, RequirementLevel.Optional
 		);
 		var expectedPhrase = new ExtractedQueryToken(
 			QueryTokenType.Phrase, "start phrase", RequirementLevel.Optional, "en"
 		);
 		var expectedOperator2 = new ExtractedQueryToken(
-			QueryTokenType.GroupingOperator, operator2, RequirementLevel.Optional, "en"
+			QueryTokenType.GroupingOperator, operator2, RequirementLevel.Optional
 		);
 
 		// Act
@@ -504,9 +502,8 @@ public class QueryTokenizerTests
 	[Theory]
 	[InlineData("term1", 1)]
 	[InlineData("\"term1 term2\"", 1)]
-	[InlineData("term1 \"term2 term3\"", 3)] // implicit OR +1
-	[InlineData("term1 en:AND term3", 2)]
-	[InlineData("term1 AND term3", 3)]
+	[InlineData("term1 \"term2 term3\"", 2)] 
+	[InlineData("term1 AND term3", 2)] 
 	public void Tokenize_IsLanguagePreFix_FindsNoLanguage_UsesDefault(string input, int instances)
 	{
 		// Act 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/QueryTokenizerTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/QueryTokenizerTests.cs
@@ -272,6 +272,46 @@ public class QueryTokenizerTests
     }
 
 
+	[Fact]
+	public void Tokenize_RequiredGrouping_StartGroupingOperatorTaggedAsRequired()
+    {
+		// Arrange
+		string input = "+(term1 AND term2)";
+		
+        // Act
+        var result = _sut.Tokenize(input, "en");
+        var token = result.Tokens.First();
+
+        // Assert
+        Assert.Equal("(", token.Token);
+        Assert.Equal(RequirementLevel.Required, token.RequirementLevel);
+    }
+
+
+	[Fact]
+	public void Tokenize_NestedRequiredGrouping_InnerAndOuterParenthesesTaggedAsRequired()
+	{
+		// Arrange
+		// Logic: +( term1 AND +( term1 OR term2 ) )
+		string input = "+(term1 AND +(term1 OR term2))";
+		
+		// Act
+		var result = _sut.Tokenize(input, "en");
+		var tokens = result.Tokens.ToList();
+
+		// Assert
+		// 1. Check Outer Parenthesis: +(
+		var outerParen = tokens[0];
+		Assert.Equal("(", outerParen.Token);
+		Assert.Equal(RequirementLevel.Required, outerParen.RequirementLevel);
+
+		// 2. Check Inner Parenthesis: Sequence should be: 0:+(  1:term1, 2:AND, 3:+(
+		var innerParen = tokens[3];
+		Assert.Equal("(", innerParen.Token);
+		Assert.Equal(RequirementLevel.Required, innerParen.RequirementLevel);
+	}
+
+
     [Fact]
     public void Tokenize_TermFollowedByExplicitOperator_DoesNotInsertImplicitOr()
     {

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/QueryTokenizerTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/QueryTokenizerTests.cs
@@ -312,6 +312,19 @@ public class QueryTokenizerTests
 	}
 
 
+	[Fact]
+	public void Tokenize_DeeplyNestedRequired_AllOpeningBracketsAreRequired()
+	{
+		string input = "+(+(+(term)))"; // Triple nested required
+		var result = _sut.Tokenize(input, "en");
+
+		var openBrackets = result.Tokens.Where(t => t.Token == "(").ToList();
+
+		Assert.Equal(3, openBrackets.Count);
+		Assert.All(openBrackets, t => Assert.Equal(RequirementLevel.Required, t.RequirementLevel));
+	}
+
+
     [Fact]
     public void Tokenize_TermFollowedByExplicitOperator_DoesNotInsertImplicitOr()
     {

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/QueryTokenizerTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/QueryTokenizerTests.cs
@@ -62,9 +62,9 @@ public class QueryTokenizerTests
 		// Arrange
 		var input = "apple orange banana";
 		
-		var apple = new ExtractedQueryToken(QueryTokenType.Term, "apple", "en");
-		var orange = new ExtractedQueryToken(QueryTokenType.Term, "orange", "en");
-		var banana = new ExtractedQueryToken(QueryTokenType.Term, "banana", "en");
+		var apple = new ExtractedQueryToken(QueryTokenType.Term, "apple", RequirementLevel.Optional, "en");
+		var orange = new ExtractedQueryToken(QueryTokenType.Term, "orange", RequirementLevel.Optional, "en");
+		var banana = new ExtractedQueryToken(QueryTokenType.Term, "banana", RequirementLevel.Optional, "en");
 
 		var expected = new List<ExtractedQueryToken> { apple, orange, banana };
 
@@ -81,9 +81,9 @@ public class QueryTokenizerTests
 		// Arrange
 		var input = "cat \"hello dolly\" dog";
 
-		var cat = new ExtractedQueryToken(QueryTokenType.Term, "cat", "en");
-		var helloDolly = new ExtractedQueryToken(QueryTokenType.Phrase, "hello dolly", "en");
-		var dog = new ExtractedQueryToken(QueryTokenType.Term, "dog", "en");
+		var cat = new ExtractedQueryToken(QueryTokenType.Term, "cat", RequirementLevel.Optional, "en");
+		var helloDolly = new ExtractedQueryToken(QueryTokenType.Phrase, "hello dolly", RequirementLevel.Optional, "en");
+		var dog = new ExtractedQueryToken(QueryTokenType.Term, "dog", RequirementLevel.Optional, "en");
 
 		// Act 
 		var result = _sut.Tokenize(input, "en");
@@ -101,8 +101,8 @@ public class QueryTokenizerTests
 	{
 		// Arrange
 		var input = "  word1    word2  ";
-		var word1 = new ExtractedQueryToken(QueryTokenType.Term, "word1", "en");
-		var word2 = new ExtractedQueryToken(QueryTokenType.Term, "word2", "en");
+		var word1 = new ExtractedQueryToken(QueryTokenType.Term, "word1", RequirementLevel.Optional, "en");
+		var word2 = new ExtractedQueryToken(QueryTokenType.Term, "word2", RequirementLevel.Optional, "en");
 
 		// Act
 		var result = _sut.Tokenize(input, "en");
@@ -127,10 +127,10 @@ public class QueryTokenizerTests
 		// Arrange
 		var input = "start \"unclosed phrase";
 
-		var start = new ExtractedQueryToken(QueryTokenType.Term, "start", "en");
-		var unclosed = new ExtractedQueryToken(QueryTokenType.Term, "\"unclosed", "en");
-		var phrase = new ExtractedQueryToken(QueryTokenType.Term, "phrase", "en");
-		var or = new ExtractedQueryToken(QueryTokenType.LogicalOperator, "OR", "en");
+		var start = new ExtractedQueryToken(QueryTokenType.Term, "start", RequirementLevel.Optional, "en");
+		var unclosed = new ExtractedQueryToken(QueryTokenType.Term, "\"unclosed", RequirementLevel.Optional, "en");
+		var phrase = new ExtractedQueryToken(QueryTokenType.Term, "phrase", RequirementLevel.Optional, "en");
+		var or = new ExtractedQueryToken(QueryTokenType.LogicalOperator, "OR", RequirementLevel.Optional, "en");
 		// Act
 		var result = _sut.Tokenize(input, "en");
 		var resultList = result.Tokens.ToList();
@@ -188,6 +188,89 @@ public class QueryTokenizerTests
         Assert.Equal("OR", resultList[3].Token);
         Assert.Equal("orange", resultList[4].Token);
     }
+
+
+	[Theory]
+    [InlineData("+apple", "apple")]
+    [InlineData("+orange", "orange")]
+    public void Tokenize_PlusPrefixOnTerm_SetsRequirementLevelToRequired(string input, string expectedTerm)
+    {
+        // Act
+        var result = _sut.Tokenize(input, "en");
+        var token = result.Tokens.First();
+
+        // Assert
+        Assert.Equal(expectedTerm, token.Token);
+        Assert.Equal(RequirementLevel.Required, token.RequirementLevel);
+        Assert.Equal(QueryTokenType.Term, token.TokenType);
+    }
+
+
+	[Fact]
+    public void Tokenize_PlusPrefixOnPhrase_SetsRequirementLevelToRequired()
+    {
+        // Arrange
+        var input = "+\"mandatory phrase\"";
+
+        // Act
+        var result = _sut.Tokenize(input, "en");
+        var token = result.Tokens.First();
+
+        // Assert
+        Assert.Equal("mandatory phrase", token.Token);
+        Assert.Equal(RequirementLevel.Required, token.RequirementLevel);
+        Assert.Equal(QueryTokenType.Phrase, token.TokenType);
+    }
+
+
+	[Theory]
+	[InlineData("+apple +banana")]
+	[InlineData("+\"apple pie\" +\"banana split\"")]
+    public void Tokenize_MultipleRequiredTerms_InsertsImplicitAND(string input)
+    {
+        // Act
+        var result = _sut.Tokenize(input, "en");
+        var resultList = result.Tokens.ToList();
+
+        // Assert (required, AND, required)
+        Assert.Equal(3, resultList.Count);
+        Assert.Equal(RequirementLevel.Required, resultList[0].RequirementLevel);
+        Assert.Equal(RequirementLevel.Required, resultList[2].RequirementLevel);
+        Assert.Equal("AND", resultList[1].Token);
+    }
+
+
+	[Theory]
+	[InlineData("\\+apple", "+apple")]
+	[InlineData("\\+\"apple banana\"", "+apple banana")]
+	public void Tokenize_EscapedPlusAtStart_ShouldBeOptional(string input, string expected)
+    {
+        // Act
+        var result = _sut.Tokenize(input, "en");
+        var token = result.Tokens.First();
+
+        // Assert
+        Assert.Equal(expected, token.Token);
+        Assert.Equal(RequirementLevel.Optional, token.RequirementLevel);
+    }
+	
+	
+	[Theory]
+	[InlineData("\"apple \\+ banana\"", "apple + banana")]
+	[InlineData("\"\\+apple  banana\"", "+apple banana")]
+	[InlineData("\"apple \\+banana\"", "apple +banana")]
+	[InlineData("\"apple banana\\+\"", "apple banana+")]
+	public void Tokenize_EscapedPlusInPhrase_ShouldNotInsertRequired(string input, string expected)
+    {
+        // Act
+        var result = _sut.Tokenize(input, "en");
+        var token = result.Tokens.First();
+
+        // Assert
+        Assert.Equal(expected, token.Token);
+        Assert.Equal(RequirementLevel.Optional, token.RequirementLevel);
+    }
+
 
     [Fact]
     public void Tokenize_TermFollowedByExplicitOperator_DoesNotInsertImplicitOr()
@@ -250,7 +333,7 @@ public class QueryTokenizerTests
     [Theory]
 	[InlineData("!")]
 	[InlineData("-")]
-	[InlineData("+")]
+	// [InlineData("+")]
 	[InlineData("&&")]
 	[InlineData("||")]
 	[InlineData("AND")]
@@ -261,9 +344,11 @@ public class QueryTokenizerTests
 		// Arrange
 		var input = $"start {operatorInput} phrase";
 
-		var start = new ExtractedQueryToken(QueryTokenType.Term, "start", "en");
-		var expectedOperator = new ExtractedQueryToken(QueryTokenType.LogicalOperator, operatorInput, "en");
-		var phrase = new ExtractedQueryToken(QueryTokenType.Term, "phrase", "en");
+		var start = new ExtractedQueryToken(QueryTokenType.Term, "start", RequirementLevel.Optional, "en");
+		var expectedOperator = new ExtractedQueryToken(
+			QueryTokenType.LogicalOperator, operatorInput, RequirementLevel.Optional, "en"
+		);
+		var phrase = new ExtractedQueryToken(QueryTokenType.Term, "phrase", RequirementLevel.Optional, "en");
 
 		// Act
 		var result = _sut.Tokenize(input, "en");
@@ -285,9 +370,11 @@ public class QueryTokenizerTests
 		// Arrange
 		var input = $"first {operatorInput}second";
 
-		var first = new ExtractedQueryToken(QueryTokenType.Term, "first", "en");
-		var expectedOperator = new ExtractedQueryToken(QueryTokenType.LogicalOperator, operatorInput, "en");
-		var second = new ExtractedQueryToken(QueryTokenType.Term, "second", "en");
+		var first = new ExtractedQueryToken(QueryTokenType.Term, "first", RequirementLevel.Optional, "en");
+		var expectedOperator = new ExtractedQueryToken(
+			QueryTokenType.LogicalOperator, operatorInput, RequirementLevel.Optional, "en"
+		);
+		var second = new ExtractedQueryToken(QueryTokenType.Term, "second", RequirementLevel.Optional, "en");
 
 		// Act
 		var result = _sut.Tokenize(input, "en");
@@ -311,9 +398,15 @@ public class QueryTokenizerTests
 		// Arrange
 		var input = $"{operator1}\"start phrase\"{operator2}";
 
-		var expectedOperator1 = new ExtractedQueryToken(QueryTokenType.GroupingOperator, operator1, "en");
-		var expectedPhrase = new ExtractedQueryToken(QueryTokenType.Phrase, "start phrase", "en");
-		var expectedOperator2 = new ExtractedQueryToken(QueryTokenType.GroupingOperator, operator2, "en");
+		var expectedOperator1 = new ExtractedQueryToken(
+			QueryTokenType.GroupingOperator, operator1, RequirementLevel.Optional, "en"
+		);
+		var expectedPhrase = new ExtractedQueryToken(
+			QueryTokenType.Phrase, "start phrase", RequirementLevel.Optional, "en"
+		);
+		var expectedOperator2 = new ExtractedQueryToken(
+			QueryTokenType.GroupingOperator, operator2, RequirementLevel.Optional, "en"
+		);
 
 		// Act
 		var result = _sut.Tokenize(input, "en");
@@ -348,13 +441,13 @@ public class QueryTokenizerTests
     }
 
     [Theory]
+    // [InlineData("+")]
     [InlineData("AND")]
     [InlineData("OR")]
     [InlineData("NOT")]
     [InlineData("!")]
     [InlineData("||")]
     [InlineData("&&")]
-    [InlineData("+")]
     [InlineData("-")]
     public void Tokenize_Should_Not_Normalize_LogicalOperators(string input)
     {

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/SearchQueryShuntingYardParserTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/SearchQueryShuntingYardParserTests.cs
@@ -101,31 +101,24 @@ public class SearchQueryShuntingYardParserTests
 		Assert.Equivalent(QueryTokenType.LogicalOperator, result[2].TokenType);
 	}
 
-	// ToDo: implement this test when required operators are implemented in the parser.
-	//[Fact]
-	//public void ConvertToPostfix_HandlesRequiredOperatorsCorrectly()
-	//{
-	//	// Arrange
-	//	// Infix: +Java OR Luleå -> Postfix: +Java Luleå OR
-	//	var tokens = new List<ExtractedQueryToken>
-	//	{
-	//		CreateToken("Java", QueryTokenType.Term),
-	//		CreateToken(op, QueryTokenType.LogicalOperator),
-	//		CreateToken("Luleå", QueryTokenType.Term)
-	//	};
+	[Fact]
+	public void ConvertToPostfix_RequiredTerm_MaintainsRequirementLevel()
+	{
+		// Arrange: +Java AND Luleå
+		var tokens = new List<ExtractedQueryToken>
+		{
+			CreateToken("Java", QueryTokenType.Term, RequirementLevel.Required),
+			CreateToken("AND", QueryTokenType.LogicalOperator),
+			CreateToken("Luleå", QueryTokenType.Term)
+		};
 
-	//	// Act
-	//	var result = _sut
-	//		.ConvertToPostfix(tokens)
-	//		.ToList();
+		// Act
+		var result = _sut.ConvertToPostfix(tokens).ToList();
 
-	//	// Assert
-	//	Assert.Equal(3, result.Count);
-	//	Assert.Equal("Java", result[0].Token);
-	//	Assert.Equal("Luleå", result[1].Token);
-	//	Assert.Equal(op, result[2].Token);
-	//	Assert.Equivalent(QueryTokenType.LogicalOperator, result[2].TokenType);
-	//}
+		// Assert
+		Assert.Equal(RequirementLevel.Required, result[0].RequirementLevel); // Java
+		Assert.Equal(RequirementLevel.Optional, result[1].RequirementLevel); // Luleå
+	}
 
 	[Fact]
 	public void ConvertToPostfix_PrecedenceNotOverAnd_ReturnsNotFirst()
@@ -287,8 +280,73 @@ public class SearchQueryShuntingYardParserTests
 		Assert.Equal(expected, result);
 	}
 
+
 	[Fact]
-	public void ConvertToPostfix_OperatorsInSequence_ShouldThrowFormatException()
+	public void ConvertToPostfix_RequiredGrouping_AppliesRequirementToRootOperator()
+	{
+		// Arrange: term1 AND +(term2 OR term3)
+		// Infix: term1, AND, +(, term2, OR, term3, )
+		var tokens = new List<ExtractedQueryToken>
+		{
+			CreateToken("term1", QueryTokenType.Term),
+			CreateToken("AND", QueryTokenType.LogicalOperator),
+			CreateToken("(", QueryTokenType.GroupingOperator, RequirementLevel.Required),
+			CreateToken("term2", QueryTokenType.Term),
+			CreateToken("OR", QueryTokenType.LogicalOperator),
+			CreateToken("term3", QueryTokenType.Term),
+			CreateToken(")", QueryTokenType.GroupingOperator)
+		};
+
+		// Act
+		var result = _sut.ConvertToPostfix(tokens).ToList();
+
+		// Assert
+		// Expected Postfix: term1, term2, term3, OR (Required), AND
+		var orOperator = result.First(t => t.Token == "OR");
+		var andOperator = result.First(t => t.Token == "AND");
+
+		Assert.Equal(RequirementLevel.Required, orOperator.RequirementLevel);
+		Assert.Equal(RequirementLevel.Optional, andOperator.RequirementLevel);
+	}
+
+
+	[Fact]
+	public void ConvertToPostfix_NestedRequiredGrouping_MarksBothRootOperatorsAsRequired()
+	{
+		// Arrange: +(term1 AND +(term2 OR term3))
+		var tokens = new List<ExtractedQueryToken>
+		{
+			CreateToken("(", QueryTokenType.GroupingOperator, RequirementLevel.Required),
+			CreateToken("term1", QueryTokenType.Term),
+			CreateToken("AND", QueryTokenType.LogicalOperator),
+			CreateToken("(", QueryTokenType.GroupingOperator, RequirementLevel.Required),
+			CreateToken("term2", QueryTokenType.Term),
+			CreateToken("OR", QueryTokenType.LogicalOperator),
+			CreateToken("term3", QueryTokenType.Term),
+			CreateToken(")", QueryTokenType.GroupingOperator),
+			CreateToken(")", QueryTokenType.GroupingOperator)
+		};
+
+		// Act
+		var result = _sut.ConvertToPostfix(tokens).ToList();
+
+		// Assert
+		// Postfix: term1, term2, term3, OR (Req), AND (Req)
+		var orToken = result.Find(t => t.Token == "OR");
+		var andToken = result.Find(t => t.Token == "AND");
+
+		Assert.NotNull(orToken);
+		Assert.NotNull(andToken);
+		Assert.Equal(RequirementLevel.Required, orToken.RequirementLevel);
+		Assert.Equal(RequirementLevel.Required, andToken.RequirementLevel);
+	}
+
+
+	[Theory]
+	[InlineData("!")]
+	[InlineData("-")]
+	[InlineData("NOT")]
+	public void ConvertToPostfix_OperatorsInSequence_ShouldThrowFormatException(string not)
 	{
 		// Arrange
 		// Query: Java AND NOT Ltu
@@ -296,15 +354,18 @@ public class SearchQueryShuntingYardParserTests
 		{
 			CreateToken("Java", QueryTokenType.Term),
 			CreateToken("AND", QueryTokenType.LogicalOperator),
-			CreateToken("NOT", QueryTokenType.LogicalOperator),
+			CreateToken(not, QueryTokenType.LogicalOperator),
 			CreateToken("Ltu", QueryTokenType.Term),
 		};
 
 		Assert.Throws<FormatException>(()=> _sut.ConvertToPostfix(tokens));
 	}
 	
-	[Fact]
-	public void ConvertToPostfix_OperatorsInSequenceWithParentheses_ShouldThrowFormatException()
+	[Theory]
+	[InlineData("!")]
+	[InlineData("-")]
+	[InlineData("NOT")]
+	public void ConvertToPostfix_OperatorsInSequenceWithParentheses_ShouldThrowFormatException(string not)
 	{
 		// Arrange
 		// Query: Java AND (NOT Ltu)
@@ -313,7 +374,7 @@ public class SearchQueryShuntingYardParserTests
 			CreateToken("Java", QueryTokenType.Term),
 			CreateToken("AND", QueryTokenType.LogicalOperator),
 			CreateToken("(", QueryTokenType.GroupingOperator),
-			CreateToken("NOT", QueryTokenType.LogicalOperator),
+			CreateToken(not, QueryTokenType.LogicalOperator),
 			CreateToken("Ltu", QueryTokenType.Term),
 			CreateToken(")", QueryTokenType.GroupingOperator),
 		};
@@ -321,29 +382,35 @@ public class SearchQueryShuntingYardParserTests
 		Assert.Throws<FormatException>(()=> _sut.ConvertToPostfix(tokens));
 	}
 	
-	[Fact]
-	public void ConvertToPostfix_OperatorsFirst_ShouldThrowFormatException()
+	[Theory]
+	[InlineData("!")]
+	[InlineData("-")]
+	[InlineData("NOT")]
+	public void ConvertToPostfix_OperatorsFirst_ShouldThrowFormatException(string not)
 	{
 		// Arrange
 		// Query: NOT Ltu
 		var tokens = new List<ExtractedQueryToken>
 		{
-			CreateToken("NOT", QueryTokenType.LogicalOperator),
+			CreateToken(not, QueryTokenType.LogicalOperator),
 			CreateToken("Ltu", QueryTokenType.Term),
 		};
 
 		Assert.Throws<FormatException>(()=> _sut.ConvertToPostfix(tokens));
 	}
 	
-	[Fact]
-	public void ConvertToPostfix_OperatorsFirstInParentheses_ShouldThrowFormatException()
+	[Theory]
+	[InlineData("!")]
+	[InlineData("-")]
+	[InlineData("NOT")]
+	public void ConvertToPostfix_OperatorsFirstInParentheses_ShouldThrowFormatException(string not)
 	{
 		// Arrange
 		// Query: (NOT Ltu)
 		var tokens = new List<ExtractedQueryToken>
 		{
 			CreateToken("(", QueryTokenType.GroupingOperator),
-			CreateToken("NOT", QueryTokenType.LogicalOperator),
+			CreateToken(not, QueryTokenType.LogicalOperator),
 			CreateToken("Ltu", QueryTokenType.Term),
 			CreateToken(")", QueryTokenType.GroupingOperator)
 		};
@@ -351,8 +418,11 @@ public class SearchQueryShuntingYardParserTests
 		Assert.Throws<FormatException>(()=> _sut.ConvertToPostfix(tokens));
 	}
 	
-	[Fact]
-	public void ConvertToPostfix_OperatorsFirstInMultipleParentheses_ShouldThrowFormatException()
+	[Theory]
+	[InlineData("!")]
+	[InlineData("-")]
+	[InlineData("NOT")]
+	public void ConvertToPostfix_OperatorsFirstInMultipleParentheses_ShouldThrowFormatException(string not)
 	{
 		// Arrange
 		// Query: ((NOT Ltu))
@@ -360,7 +430,7 @@ public class SearchQueryShuntingYardParserTests
 		{
 			CreateToken("(", QueryTokenType.GroupingOperator),
 			CreateToken("(", QueryTokenType.GroupingOperator),
-			CreateToken("NOT", QueryTokenType.LogicalOperator),
+			CreateToken(not, QueryTokenType.LogicalOperator),
 			CreateToken("Ltu", QueryTokenType.Term),
 			CreateToken(")", QueryTokenType.GroupingOperator),
 			CreateToken(")", QueryTokenType.GroupingOperator)
@@ -370,11 +440,75 @@ public class SearchQueryShuntingYardParserTests
 	}
 
 
-	private ExtractedQueryToken CreateToken(string text, QueryTokenType type)
+	[Theory]
+	[InlineData("!")]
+	[InlineData("-")]
+	[InlineData("NOT")]
+	public void ConvertToPostfix_NotAndRequiredInSequenceSameExpression_ShouldThrowFormatException(string not)
+	{
+		// Arrange
+		// Query: term NOT +Ltu
+		var tokens = new List<ExtractedQueryToken>
+		{
+			CreateToken("term", QueryTokenType.Term),
+			CreateToken(not, QueryTokenType.LogicalOperator),
+			CreateToken("Ltu", QueryTokenType.Term, RequirementLevel.Required)
+		};
+
+		Assert.Throws<FormatException>(()=> _sut.ConvertToPostfix(tokens));
+	}
+
+	[Theory]
+	[InlineData("!")]
+	[InlineData("-")]
+	[InlineData("NOT")]
+	public void ConvertToPostfix_NotAndRequiredInSequenceSameExpressionWithPhrase_ShouldThrowFormatException(string not)
+	{
+		// Arrange
+		// Query: term NOT +"Ltu term"
+		var tokens = new List<ExtractedQueryToken>
+		{
+			CreateToken("term", QueryTokenType.Term),
+			CreateToken(not, QueryTokenType.LogicalOperator),
+			CreateToken("Ltu term", QueryTokenType.Phrase, RequirementLevel.Required)
+		};
+
+		Assert.Throws<FormatException>(()=> _sut.ConvertToPostfix(tokens));
+	}
+	
+	[Theory]
+	[InlineData("!")]
+	[InlineData("-")]
+	[InlineData("NOT")]
+	public void ConvertToPostfix_NotAndRequiredInSameExpressionWithParentheses_ShouldThrowFormatException(string not)
+	{
+		// Arrange
+		// Query: term NOT +(Ltu OR Term)
+		var tokens = new List<ExtractedQueryToken>
+		{
+			CreateToken("term", QueryTokenType.Term),
+			CreateToken(not, QueryTokenType.LogicalOperator),
+			CreateToken("(", QueryTokenType.GroupingOperator, RequirementLevel.Required),
+			CreateToken("Ltu", QueryTokenType.Term),
+			CreateToken("OR", QueryTokenType.LogicalOperator),
+			CreateToken("term", QueryTokenType.Term),
+			CreateToken(")", QueryTokenType.GroupingOperator)
+		};
+
+		Assert.Throws<FormatException>(()=> _sut.ConvertToPostfix(tokens));
+	}
+
+
+	private ExtractedQueryToken CreateToken(
+		string text, 
+		QueryTokenType type, 
+		RequirementLevel requirementLevel = RequirementLevel.Optional
+		)
 	{
 		return new ExtractedQueryToken( 
 			tokenType: type,
-			token : text 
+			token : text, 
+			requirementLevel: requirementLevel
 		);
 	}
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/SqlIndexRepositoryTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/SqlIndexRepositoryTests.cs
@@ -239,9 +239,9 @@ public class SqlIndexRepositoryTests : IDisposable
         // Create the PhraseNode to search for "quick brown fox"
         var tokens = new List<ExtractedQueryToken>
         {
-            new ExtractedQueryToken(QueryTokenType.Phrase, "quick", "en"),
-            new ExtractedQueryToken(QueryTokenType.Phrase, "brown", "en"),
-            new ExtractedQueryToken(QueryTokenType.Phrase, "fox", "en")
+            new ExtractedQueryToken(QueryTokenType.Phrase, "quick", RequirementLevel.Optional, "en"),
+            new ExtractedQueryToken(QueryTokenType.Phrase, "brown", RequirementLevel.Optional, "en"),
+            new ExtractedQueryToken(QueryTokenType.Phrase, "fox", RequirementLevel.Optional, "en")
         };
         
         var phraseNode = new PhraseNode<HashSet<int>>(tokens);


### PR DESCRIPTION
Implemented the requested fetcher.

Introduced the state isRequired through enum and interface implemented by the `Term`/`Phrase`/`LogicOperatorNode `classes.
All related classes in the queryparsing and evaluater sequence were updated to account for this change `QueryStringTokenizer `-> `SearchQueryShuntingYardParser `-> `AbstractSyntaxTreeBuilder `->`QueryEvaluatorVisitor`.

-`QueryStringTokenizer `: handles recognition of the required state and if it liked to Term, Phrase or a Logical statement
-`SearchQueryShuntingYardParser `: handles logical correctness, and assigning the required state to logical operators (moved from the paretheses to last logical operator found in current enclosed parentheses)  
-`AbstractSyntaxTreeBuilder `: converts requirement state to nodes.
-`QueryEvaluatorVisitor`: handles the special cases related to the required state.
