### PR TITLE
Preserve spacing in HTML text extraction

### DIFF
--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/HelperClasses/HtmlTextExtractor.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/HelperClasses/HtmlTextExtractor.cs
@@ -1,0 +1,60 @@
+using System.Text;
+using HtmlAgilityPack;
+
+/// <summary>
+/// Provides utility methods for extracting human-readable text from HTML nodes 
+/// while preserving logical spacing between block-level elements.
+/// </summary>
+public static class HtmlTextExtractor
+{
+    private static readonly HashSet<string> BlockElements = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "p", "div", "li", "br", "tr", "h1", "h2", "h3", "h4", "h5", "h6", "section", "article", "aside"
+    };
+
+    /// <summary>
+    /// Traverses the HTML tree and extracts text, ensuring that block-level elements 
+    /// (like div, p, li) are separated by spaces to prevent word concatenation.
+    /// </summary>
+    /// <param name="node">The root node to extract text from.</param>
+    /// <param name="sb">The StringBuilder to append text to.</param>
+    public static void ExtractTextWithSpaces(HtmlNode node, StringBuilder sb)
+    {
+        foreach (var child in node.ChildNodes)
+        {
+            if (child.NodeType == HtmlNodeType.Text)
+            {
+                // Append text directly from text nodes
+                sb.Append(child.InnerText);
+            }
+            else
+            {
+                // If when entering a new block element there already is content in 
+                // the string builder add a space before adding the next element
+                // Example scenario: <li>Support<div>FAQ</div></li>
+                bool isBlock = IsBlockElement(child.Name);
+
+                if (isBlock && sb.Length > 0 && !char.IsWhiteSpace(sb[sb.Length - 1]))
+                {
+                    sb.Append(" ");
+                }
+
+                // Recursively visit child nodes
+                ExtractTextWithSpaces(child, sb);
+
+                // If the element is a block-level tag, inject a space to ensure 
+                // logical separation (e.g., prevent "HomeAbout" from <li>Home</li><li>About</li>)
+                if (isBlock && sb.Length > 0 && !char.IsWhiteSpace(sb[sb.Length - 1]))
+                {
+                    sb.Append(" ");
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Determines if an HTML element is a block-level element that visually 
+    /// separates content in a browser.
+    /// </summary>
+    private static bool IsBlockElement(string name) => BlockElements.Contains(name);
+}

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/LTU.SearchEngine.Backend.Core.csproj
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/LTU.SearchEngine.Backend.Core.csproj
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageReference Include="Lucene.Net" Version="4.8.0-beta00017" />
     <PackageReference Include="Lucene.Net.Analysis.Common" Version="4.8.0-beta00017" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.1" />

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/HapHtmlParser.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/HapHtmlParser.cs
@@ -347,53 +347,22 @@ public class HapHtmlParser : IHtmlParser
         }
     }
 
-    private void ExtractTextWithSpaces(HtmlNode node, StringBuilder sb)
+    private string GetCleanText(HtmlNode node)
     {
-        foreach (var child in node.ChildNodes)
-        {
-            if (child.NodeType.Equals(HtmlNodeType.Text))
-            {
-                sb.Append(child.InnerText);
-            }
-            else
-            {
-                ExtractTextWithSpaces(child, sb);
-                if (IsBlockElement(child.Name)) sb.Append(" ");
-            }
-        }
+        var sb = new StringBuilder();
+        HtmlTextExtractor.ExtractTextWithSpaces(node, sb);
+        return sb.ToString();
     }
-
-    private bool IsBlockElement(string name)
-    {
-        string[] blockElements = { 
-            "p", "div", "li", "br", 
-            "tr", "h1", "h2", "h3", 
-            "h4", "h5", "h6", 
-            "section", "article", "aside" 
-        };
-
-        return blockElements.Contains(name.ToLower());
-    }
+    
 
     private void HandleBodyText(HtmlDocument doc, List<IndexedTerm> terms)
     {
         // At this stage, scripts, titles, and headers have been removed.
-        // InnerText now contains only the remaining "Body" content (paragraphs, lists, divs).
-        
-        // var bodyText = doc.DocumentNode.InnerText;
         string bodyText = GetCleanText(doc.DocumentNode);
         AddTerms(terms, bodyText, TermSource.Body);
     }
 
-    private string GetCleanText(HtmlNode node)
-    {
-        var sb = new StringBuilder();
-        ExtractTextWithSpaces(node, sb);
-        return sb.ToString();
-        
-    }
-    
-
+  
     // Add space to prevent word concatenation after removal
     private void ReplaceChildWithSpaceNode(HtmlDocument doc, HtmlNode childNode)
     {

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/HapHtmlParser.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/HapHtmlParser.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Text;
+using System.Text.RegularExpressions;
 using HtmlAgilityPack;
 using LTU.SearchEngine.Backend.Core;
 using LTU.SearchEngine.Backend.Core.Exceptions;
@@ -320,7 +321,8 @@ public class HapHtmlParser : IHtmlParser
         {
             foreach (var node in footerNodes)
             {
-                AddTerms(terms, node.InnerText, TermSource.Body);
+                string footerText = GetCleanText(node);
+                AddTerms(terms, footerText, TermSource.Body);
                 ReplaceChildWithSpaceNode(doc, node);
             }
         } 
@@ -345,13 +347,49 @@ public class HapHtmlParser : IHtmlParser
         }
     }
 
+    private void ExtractTextWithSpaces(HtmlNode node, StringBuilder sb)
+    {
+        foreach (var child in node.ChildNodes)
+        {
+            if (child.NodeType.Equals(HtmlNodeType.Text))
+            {
+                sb.Append(child.InnerText);
+            }
+            else
+            {
+                ExtractTextWithSpaces(child, sb);
+                if (IsBlockElement(child.Name)) sb.Append(" ");
+            }
+        }
+    }
+
+    private bool IsBlockElement(string name)
+    {
+        string[] blockElements = { 
+            "p", "div", "li", "br", 
+            "tr", "h1", "h2", "h3", 
+            "h4", "h5", "h6", 
+            "section", "article", "aside" 
+        };
+
+        return blockElements.Contains(name.ToLower());
+    }
 
     private void HandleBodyText(HtmlDocument doc, List<IndexedTerm> terms)
     {
         // At this stage, scripts, titles, and headers have been removed.
         // InnerText now contains only the remaining "Body" content (paragraphs, lists, divs).
-        var bodyText = doc.DocumentNode.InnerText;
+        
+        // var bodyText = doc.DocumentNode.InnerText;
+        string bodyText = GetCleanText(doc.DocumentNode);
         AddTerms(terms, bodyText, TermSource.Body);
+    }
+
+    private string GetCleanText(HtmlNode node)
+    {
+        var sb = new StringBuilder();
+        ExtractTextWithSpaces(node, sb);
+        return sb.ToString();
         
     }
     

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Crawling.Tests/HtmlTextExtractorTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Crawling.Tests/HtmlTextExtractorTests.cs
@@ -1,0 +1,79 @@
+using System.Text;
+using HtmlAgilityPack;
+
+namespace LTU.SearchEngine.Test.Crawling;
+
+public class HtmlTextExtractorTests
+{
+    [Theory]
+    [InlineData("<li>Hem</li><li>Om oss</li>", "Hem Om oss ")]
+    [InlineData("<div>Del 1</div><div>Del 2</div>", "Del 1 Del 2 ")]
+    [InlineData("<p>Hello</p><br>World", "Hello World")]
+    [InlineData("<h1>Rubrik</h1><p>Text</p>", "Rubrik Text ")]
+    public void ExtractTextWithSpaces_BlockElements_ShouldHaveSpaces(string html, string expected)
+    {
+        // Arrange
+        var doc = new HtmlDocument();
+        doc.LoadHtml(html);
+        var sb = new StringBuilder();
+
+        // Act
+        HtmlTextExtractor.ExtractTextWithSpaces(doc.DocumentNode, sb);
+        var result = sb.ToString();
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void ExtractTextWithSpaces_InlineElements_ShouldNotHaveExtraSpaces()
+    {
+        // Arrange
+        var html = "<span>There</span><span>are</span><span>no</span><span>blocks</span>";
+        var doc = new HtmlDocument();
+        doc.LoadHtml(html);
+        var sb = new StringBuilder();
+
+        // Act
+        HtmlTextExtractor.ExtractTextWithSpaces(doc.DocumentNode, sb);
+
+        // Assert
+        Assert.Equal("Therearenoblocks", sb.ToString());
+    }
+
+    [Fact]
+    public void ExtractTextWithSpaces_DeeplyNestedList_ShouldPreserveSeparation()
+    {
+        // Arrange
+        var html = "<footer><ul><li>Kontakt</li><li>Support<div>FAQ</div></li></ul></footer>";
+        var doc = new HtmlDocument();
+        doc.LoadHtml(html);
+        var sb = new StringBuilder();
+
+        // Act
+        HtmlTextExtractor.ExtractTextWithSpaces(doc.DocumentNode, sb);
+        var result = sb.ToString();
+
+        // Assert
+        // We check if key words exist with space between them
+        Assert.Contains("Kontakt ", result);
+        Assert.Contains("Support ", result);
+        Assert.Contains("FAQ ", result);
+    }
+
+
+    [Fact]
+    public void ExtractTextWithSpaces_EmptyNode_ShouldReturnEmpty()
+    {
+        // Arrange
+        var doc = new HtmlDocument();
+        doc.LoadHtml("");
+        var sb = new StringBuilder();
+
+        // Act
+        HtmlTextExtractor.ExtractTextWithSpaces(doc.DocumentNode, sb);
+
+        // Assert
+        Assert.Empty(sb.ToString());
+    }
+}


### PR DESCRIPTION
The problem stemmed from how InnerText removed the remaining tags. It simply removed them without inserting a whitespace inbetween. I solved this by replaceing the direct InnerText usage with a recursive text extractor that preserves spaces between block elements to avoid word concatenation.

Added:
- GetCleanText,
- New helper class: HtmlTextExtractor
  - ExtractTextWithSpaces and
  - IsBlockElement helpers,

updated:
- HandleBodyText and
- footer processing to use the new extractor.

This improves term extraction accuracy when indexing HTML content.