### PR TITLE
Refactor tokenizer and add query parsing tests

### DIFF
--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/Helpers/QueryStringTokenizer.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/Helpers/QueryStringTokenizer.cs
@@ -177,15 +177,8 @@ public class QueryStringTokenizer : IStringTokenizer<ExtractedQueryToken, Ignore
 
                 foreach (var word in words)
                 {
-                    var normalizedWord = _textNormalizer.Normalize(word, languageCode);
-
-                    foreach (var token in normalizedWord)
-                    {
-                        if (!string.IsNullOrWhiteSpace(token))
-                            normalizedWords.Add(token);
-                        else
-                            _ignoredTokens.Add(new IgnoredTermsDTO { Token = word, Language = languageCode });
-                    }
+                    var normalizedResult = _textNormalizer.Normalize(word, languageCode).ToList();
+					DistributeTokensByValidity(languageCode, normalizedWords, word, normalizedResult);
                 }
 
                 finalToken = string.Join(' ', normalizedWords);
@@ -202,6 +195,26 @@ public class QueryStringTokenizer : IStringTokenizer<ExtractedQueryToken, Ignore
 
             _stringBuilder.Clear();
             _isRequired = false;
+        }
+
+        private void DistributeTokensByValidity(
+			string languageCode, 
+			List<string> normalizedWords, 
+			string word, 
+			IEnumerable<string> normalizedResult)
+        {
+			if (!normalizedResult.Any())
+			{
+				_ignoredTokens.Add(new IgnoredTermsDTO { Token = word.ToLowerInvariant(), Language = languageCode });
+			}	
+
+			foreach (var token in normalizedResult)
+            {
+                if (!string.IsNullOrWhiteSpace(token))
+                    normalizedWords.Add(token);
+                else
+                    _ignoredTokens.Add(new IgnoredTermsDTO { Token = word.ToLowerInvariant(), Language = languageCode });
+            }
         }
 
         private RequirementLevel GetRequirementLevel() =>

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/IntegrationTesting/SearchQueryIntegrationTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/IntegrationTesting/SearchQueryIntegrationTests.cs
@@ -1,4 +1,5 @@
 using System.Net.Http.Json;
+using LTU.SearchEngine.Application.QueryParsing;
 using LTU.SearchEngine.Backend.Api;
 using LTU.SearchEngine.Backend.Core.Entities;
 using LTU.SearchEngine.Backend.Core.Model.DTOs;
@@ -9,7 +10,6 @@ using LTU.SearchEngine.Infrastructure.Data;
 using LTU.SearchEngine.Infrastructure.Indexing;
 using LTU.SearchEngine.Test.HelperClasses;
 using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -237,7 +237,63 @@ public class SearchQueryIntegrationTests : IClassFixture<WebApplicationFactory<P
         Assert.DoesNotContain(testResult.searchResults, r => r.Url.Contains("/b"));
     }
    
-   
+
+    [Theory]
+    [InlineData("+")]
+    [InlineData("!")]
+    [InlineData("%")]
+    [InlineData("#")]
+    [InlineData("&")]
+    [InlineData("|")]
+    [InlineData("@")]
+    [InlineData("(")]
+    [InlineData(")")]
+    [InlineData("{")]
+    [InlineData("}")]
+    [InlineData("[")]
+    [InlineData("]")]
+    [InlineData("\"")]
+    [Trait("TestCase", "TC-FRQ-3002")]
+    public async Task Search_ShouldHandleEscapedCharacters_Correctly(string character)
+    {
+        // Arrange
+        var httpClient = _webHostBuilder.CreateFakeInternetClient();
+        using var testFactory = CreateTestFactory<Indexer>(httpClient: httpClient);
+        using var scope = testFactory.Services.CreateScope();
+        
+        var dbFactory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<SearchDbContext>>();
+        using var db = dbFactory.CreateDbContext();
+        await db.Database.EnsureCreatedAsync();
+
+        // Seed Documents A
+        var docA = new Page { Url = "http://localhost/a", Title = "Doc A", LastCrawled = DateTime.UtcNow };
+        
+        // term will look like this ex: te!rm
+        var term = new Term { Word = $"te{character}rm", LanguageCode = "en" };
+        
+        db.Pages.AddRange(docA);
+        db.Terms.AddRange(term);
+        await db.SaveChangesAsync();
+
+        // Map terms to pages
+        db.PageWordFrequencies.AddRange(
+            new PageWordFrequency { Page = docA, Term = term, HeaderFrequency = 1 }
+        );
+
+        await db.SaveChangesAsync();
+
+        var apiClient = testFactory.CreateClient();
+
+        // Act - query will look like this ex: te\!rm
+        var url = SearchUrlGenerator.QueryUrlBuilder(query: $"te\\{character}rm", language: "en");
+        var helloResult = await apiClient.GetFromJsonAsync<SearchResponseDTO>(url);
+        
+        // Assert
+        Assert.Contains(helloResult!.searchResults, r => r.Url.Contains("/a"));
+    }
+    
+
+
     [Theory]
     [InlineData("\"hello from page\"")]
     [InlineData("\"hello from\"")]
@@ -312,60 +368,115 @@ public class SearchQueryIntegrationTests : IClassFixture<WebApplicationFactory<P
         Assert.DoesNotContain(helloResult.searchResults, r => r.Url.Contains("/c"));
     }
 
-    [Theory]
-    [InlineData("+")]
-    [InlineData("!")]
-    [InlineData("%")]
-    [InlineData("#")]
-    [InlineData("&")]
-    [InlineData("|")]
-    [InlineData("@")]
-    [InlineData("(")]
-    [InlineData(")")]
-    [InlineData("{")]
-    [InlineData("}")]
-    [InlineData("[")]
-    [InlineData("]")]
-    [InlineData("\"")]
-    [Trait("TestCase", "TC-FRQ-3002")]
-    public async Task Search_ShouldHandleEscapedCharacters_Correctly(string character)
+    private async Task<HttpClient> SetupSearchBooleanOperatorAreCaseSensitiveDatabase(WebApplicationFactory<Program> testFactory)
     {
-        // Arrange
-        var httpClient = _webHostBuilder.CreateFakeInternetClient();
-        using var testFactory = CreateTestFactory<Indexer>(httpClient: httpClient);
         using var scope = testFactory.Services.CreateScope();
         
         var dbFactory = scope.ServiceProvider.GetRequiredService<IDbContextFactory<SearchDbContext>>();
         using var db = dbFactory.CreateDbContext();
         await db.Database.EnsureCreatedAsync();
 
-        // Seed Documents A
-        var docA = new Page { Url = "http://localhost/a", Title = "Doc A", LastCrawled = DateTime.UtcNow };
+        // Seed Documents A, B, and C
+        var docA = new Page { Url = "http://localhost/a", Title = "Doc A", LastCrawled = DateTime.UtcNow }; // term1 term2
         
-        // term will look like this ex: te!rm
-        var term = new Term { Word = $"te{character}rm", LanguageCode = "en" };
+        var term1 = new Term { Word = "term1", LanguageCode = "en" };
+        var term2 = new Term { Word = "term2", LanguageCode = "en" };
         
         db.Pages.AddRange(docA);
-        db.Terms.AddRange(term);
+        db.Terms.AddRange(term1, term2);
         await db.SaveChangesAsync();
 
         // Map terms to pages
         db.PageWordFrequencies.AddRange(
-            new PageWordFrequency { Page = docA, Term = term, HeaderFrequency = 1 }
+            new PageWordFrequency { Page = docA, Term = term1, HeaderFrequency = 1 }, 
+            new PageWordFrequency { Page = docA, Term = term2, HeaderFrequency = 1 } 
         );
 
         await db.SaveChangesAsync();
 
-        var apiClient = testFactory.CreateClient();
+        return testFactory.CreateClient();
+    }
 
-        // Act - query will look like this ex: te\!rm
-        var url = SearchUrlGenerator.QueryUrlBuilder(query: $"te\\{character}rm", language: "en");
-        var helloResult = await apiClient.GetFromJsonAsync<SearchResponseDTO>(url);
+
+    [Theory]
+    [InlineData("and", "and", "AND")]
+    [InlineData("And", "and", "AND")]
+    [InlineData("ANd", "and", "AND")]
+    [InlineData("aND", "and", "AND")]
+    [InlineData("anD", "and", "AND")]
+    [InlineData("or", "or", "OR")]
+    [InlineData("Or", "or", "OR")]
+    [InlineData("oR", "or", "OR")]
+    [Trait("TestCase", "TC-FRQ-3004")]
+    public async Task Search_BooleanOperatorAreCaseSensitiveAndOr_Correctly(
+        string input, 
+        string expectedIgnored, 
+        string correctOperator
+        )
+    {
+        // Arrange
+        var httpClient = _webHostBuilder.CreateFakeInternetClient();
+        using var testFactory = CreateTestFactory<QueryParser>(httpClient: httpClient);
+        var apiClient = await SetupSearchBooleanOperatorAreCaseSensitiveDatabase(testFactory);
+
+        // Act - Step 1 - Not capital letters 
+        string query = $"term1 {input} term2";
+        var url = SearchUrlGenerator.QueryUrlBuilder(query, language: "en");
+        var result = await apiClient .GetFromJsonAsync<SearchResponseDTO>(url);
         
         // Assert
-        Assert.Contains(helloResult!.searchResults, r => r.Url.Contains("/a"));
+        Assert.Contains(result!.searchResults, r => r.Url.Contains("/a"));
+        Assert.Contains(result.ignoredTokens!, r => r.Token.Contains(expectedIgnored));
+        
+        // Act - Step 2 - Capital letters 
+        query = $"term1 {correctOperator} term2";
+        url = SearchUrlGenerator.QueryUrlBuilder(query, language: "en");
+        result = await apiClient.GetFromJsonAsync<SearchResponseDTO>(url);
+        
+        // Assert
+        Assert.Contains(result!.searchResults, r => r.Url.Contains("/a"));
+        Assert.DoesNotContain(result.ignoredTokens!, r => r.Token.Contains(expectedIgnored));    
     }
-    
+
+
+    [Theory]
+    [InlineData("not", "not", "NOT")]
+    [InlineData("Not", "not", "NOT")]
+    [InlineData("NOt", "not", "NOT")]
+    [InlineData("nOT", "not", "NOT")]
+    [InlineData("noT", "not", "NOT")]
+    [Trait("TestCase", "TC-FRQ-3004")]
+    public async Task Search_BooleanOperatorAreCaseSensitiveNot_Correctly(
+        string input, 
+        string expectedIgnored, 
+        string correctOperator
+        )
+    {
+        // Arrange
+        var httpClient = _webHostBuilder.CreateFakeInternetClient();
+        using var testFactory = CreateTestFactory<QueryParser>(httpClient: httpClient);
+        var apiClient = await SetupSearchBooleanOperatorAreCaseSensitiveDatabase(testFactory);
+
+        // Act - Step 1 - Not capital letters 
+        string query = $"term1 {input} term2";
+        var url = SearchUrlGenerator.QueryUrlBuilder(query, language: "en");
+        var result = await apiClient .GetFromJsonAsync<SearchResponseDTO>(url);
+        
+        // Assert
+        Assert.Contains(result!.searchResults, r => r.Url.Contains("/a"));
+        Assert.Contains(result.ignoredTokens!, r => r.Token.Contains(expectedIgnored));
+        
+        // Act - Step 2 - Capital letters 
+        query = $"term1 {correctOperator} term2";
+        url = SearchUrlGenerator.QueryUrlBuilder(query, language: "en");
+        result = await apiClient.GetFromJsonAsync<SearchResponseDTO>(url);
+        
+        // Assert
+        Assert.DoesNotContain(result!.searchResults, r => r.Url.Contains("/a"));
+        Assert.DoesNotContain(result.ignoredTokens!, r => r.Token.Contains(expectedIgnored));
+    }
+
+
     public void Dispose()
     {
         if (File.Exists(_tempSettingsPath)) File.Delete(_tempSettingsPath);


### PR DESCRIPTION
Added integration tests covering boolean operator case-sensitivity (AND/OR/NOT). Introduce a DB setup helper (SetupSearchBooleanOperatorAreCaseSensitiveDatabase) to seed pages/terms, and wire tests to use the helper. Also adjust using directives and clean up related test code. Tests include trait identifier (TC-FRQ-3004).

An undocumented bug was found during test implementation. If a single word is is not exploded into multiple tokens then it is never added to the ignored list. I solved it as follows. Extract token distribution logic from QueryStringTokenizer into DistributeTokensByValidity to centralize normalization handling and ensure ignored tokens are lowercased. Update tokenizer to collect normalized results into a list and delegate validity checks to the new helper.