### PR TITLE
96 implement result pagination update the searchcontrollergetsearchresponse endpoint to support paginated results

### DIFF
--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Api/ExtensionsUseExceptionHandler/ProblemDetailsExceptionHandler.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Api/ExtensionsUseExceptionHandler/ProblemDetailsExceptionHandler.cs
@@ -1,4 +1,5 @@
 ﻿using LTU.SearchEngine.Api.ExtensionsUseExceptionHandler.CustomExceptions;
+using LTU.SearchEngine.Backend.Core.Exceptions;
 using LTU.SearchEngine.Backend.Core.Exceptions.SearchQueryExceptions;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
@@ -58,16 +59,16 @@ public static class ProblemDetailsExceptionHandler
 								instance: context.Request.Path
 							);
 							break;
-						//case PaginationArgumentOutOfRangeException argumentOutOfRangeException: // Paging parameters out of range
-						//	statusCode = StatusCodes.Status400BadRequest;
-						//	problemDetails = problemDetailsFactory.CreateProblemDetails(
-						//		context,
-						//		statusCode,
-						//		title: argumentOutOfRangeException.Title,
-						//		detail: argumentOutOfRangeException.Message,
-						//		instance: context.Request.Path
-						//	);
-						//	break;
+						case PaginationOutOfRangeException argumentOutOfRangeException: // Paging parameters out of range
+							statusCode = StatusCodes.Status400BadRequest;
+							problemDetails = problemDetailsFactory.CreateProblemDetails(
+								context,
+								statusCode,
+								title: argumentOutOfRangeException.Title,
+								detail: argumentOutOfRangeException.Message,
+								instance: context.Request.Path
+							);
+							break;
 						default:
 							statusCode = StatusCodes.Status500InternalServerError;  // General server error
 							problemDetails = problemDetailsFactory.CreateProblemDetails(

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Api/LTU.SearchEngine.Api.csproj
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Api/LTU.SearchEngine.Api.csproj
@@ -24,6 +24,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.5" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.1.5" />

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Api/SearchController.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Api/SearchController.cs
@@ -20,20 +20,27 @@ namespace LTU.SearchEngine.Api
             _serviceManager = serviceManager;
         }
 
-        /// <summary>
-        /// Executes a advanced search query.
-        /// </summary>
-        /// <remarks>
-        /// Supports boolean logic:
-        /// - AND: `cats AND dogs`  <br/>
-        /// - OR: `cats OR dogs`    <br/>
-        /// - NOT: `cats NOT dogs`  <br/>
-        /// - Grouping: `(cats AND dogs) OR birds` <br/>
-        /// </remarks>
-        /// <param name="query">The search string (Max 500 chars).</param>
-        /// <param name="page">The page number (1-based index). Defaults to 1.</param>
-        /// <param name="language">ISO language code (e.g., 'sv', 'en'). Defaults to 'sv'.</param>
-        [HttpGet]
+		/// <summary>
+		/// Executes an advanced search query with support for boolean logic and pagination.
+		/// </summary>
+		/// <remarks>
+		/// Query Syntax Support:                                                                   <br />
+		/// - Boolean Operators: `AND`, `OR`, `NOT` (e.g., `cats AND dogs`).                        <br />
+		/// - Grouping: Use parentheses to control precedence (e.g., `(cats OR dogs) AND birds`).   <br />
+		/// - Phrases: Use quotes for exact matches (e.g., `"hello world"`).                        <br />
+		/// - Prefixes: Use `+` for mandatory terms or `-` for exclusion.                           <br />
+		///                                                                                         <br />
+		/// Language Overrides:                                                                     <br />
+		/// You can override the global language for specific terms using a prefix (e.g., `sv:katt en:dog`).
+		/// </remarks>
+		/// <param name="searchParameters">
+		/// Parameters for the search query, including the query string (max 500 chars) 
+		/// and the default ISO language code (e.g., 'sv', 'en').
+		/// </param>
+		/// <param name="paginationParameters">
+		/// Parameters for controlling pagination, such as PageNumber and PageSize.
+		/// </param>
+		[HttpGet]
         [SwaggerOperation(
             Summary = "Search the indexed web pages", 
             Description = "Returns a paginated list of documents matching the boolean query.")
@@ -44,18 +51,8 @@ namespace LTU.SearchEngine.Api
         public async Task<ActionResult<SearchResponseDTO>> GetSearchResponses(
             [FromQuery] SearchQueryRequestParameters searchParameters,
             [FromQuery] PaginationRequestParameters paginationParameters
-            // [FromQuery] string query,
-            // [FromQuery] int pageNumber = 1,
-            // [FromQuery] string language = "sv"
             )
         {
-            // if (string.IsNullOrWhiteSpace(query)) return BadRequest("Search query cannot be empty."); 
-            // if (query.Length > 500) return BadRequest("Query length is limited to 500 characters!");
-            // if (pageNumber < 1) return BadRequest("Page number must be 1 or greater.");
-            // if (pageNumber > 100) return BadRequest("Deep pagination is restricted. Please refine your query!");
-
-            // var responseDto = await _serviceManager.QueryService
-            //     .GetSearchResultsAsync(requestParameters.Query.Trim(), requestParameters.Language);
             var responseDto = await _serviceManager.QueryService
                 .GetSearchResultsAsync(searchParameters, paginationParameters);
 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Api/SearchController.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Api/SearchController.cs
@@ -1,5 +1,6 @@
 ﻿using LTU.SearchEngine.Application;
 using LTU.SearchEngine.Backend.Core.Model.DTOs;
+using LTU.SearchEngine.Backend.Core.RequestParameters;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.RateLimiting;
 using Swashbuckle.AspNetCore.Annotations;
@@ -41,16 +42,22 @@ namespace LTU.SearchEngine.Api
         [SwaggerResponse(400, "Invalid query syntax or query too long")]
         [SwaggerResponse(429, "Rate limit exceeded. Please wait before searching again.")]
         public async Task<ActionResult<SearchResponseDTO>> GetSearchResponses(
-            [FromQuery] string query,
-            [FromQuery] int pageNumber = 1,
-            [FromQuery] string language = "sv")
+            [FromQuery] SearchQueryRequestParameters searchParameters,
+            [FromQuery] PaginationRequestParameters paginationParameters
+            // [FromQuery] string query,
+            // [FromQuery] int pageNumber = 1,
+            // [FromQuery] string language = "sv"
+            )
         {
-            if (string.IsNullOrWhiteSpace(query)) return BadRequest("Search query cannot be empty."); 
-            if (query.Length > 500) return BadRequest("Query length is limited to 500 characters!");
-            if (pageNumber < 1) return BadRequest("Page number must be 1 or greater.");
-            if (pageNumber > 100) return BadRequest("Deep pagination is restricted. Please refine your query!");
+            // if (string.IsNullOrWhiteSpace(query)) return BadRequest("Search query cannot be empty."); 
+            // if (query.Length > 500) return BadRequest("Query length is limited to 500 characters!");
+            // if (pageNumber < 1) return BadRequest("Page number must be 1 or greater.");
+            // if (pageNumber > 100) return BadRequest("Deep pagination is restricted. Please refine your query!");
 
-            var responseDto = await _serviceManager.QueryService.GetSearchResultsAsync(query.Trim(), language);
+            // var responseDto = await _serviceManager.QueryService
+            //     .GetSearchResultsAsync(requestParameters.Query.Trim(), requestParameters.Language);
+            var responseDto = await _serviceManager.QueryService
+                .GetSearchResultsAsync(searchParameters, paginationParameters);
 
             return Ok(responseDto);
         }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/Helpers/IStringTokenizer.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/Helpers/IStringTokenizer.cs
@@ -5,31 +5,37 @@ namespace LTU.SearchEngine.Application.QueryParsing.Helpers;
 
 
 /// <summary>
-/// Defines a contract for decomposing a raw input string into a structured collection 
+/// Defines a contract for decomposing a raw search request into a structured collection 
 /// of categorized tokens and identified ignored terms.
 /// </summary>
+/// <remarks>
+/// The tokenizer is responsible for identifying logical operators (AND, OR, NOT), 
+/// quoted phrases, grouping symbols (parentheses), and handling language-specific 
+/// normalization rules such as stop-word removal.
+/// </remarks>
 /// <typeparam name="TToken">
 /// The type representing a finalized, categorized token (e.g., <see cref="ExtractedQueryToken"/>).
 /// </typeparam>
 /// <typeparam name="TIgnoredToken">
-/// The type representing metadata for tokens that were discarded during processing 
-/// (e.g., IgnoredTermsDTO).
+/// The type representing metadata for tokens that were discarded during processing, 
+/// such as identified stop-words (e.g., <see cref="IgnoredTermsDTO"/>).
 /// </typeparam>
 public interface IStringTokenizer<TToken, TIgnoredToken>
 {
 	/// <summary>
-    /// Transforms a raw input string into a structured <see cref="QueryStringTokenizingResult{TToken, TIgnoredToken}"/>.
-    /// </summary>
-    /// <param name="input">The raw string to be tokenized.</param>
-    /// <param name="languageCode">
-    /// The language context (defaulting to "sv") used to determine language-specific 
-    /// tokenization rules, such as stop-words or character boundaries.
-    /// </param>
-    /// <returns>
-    /// A result object containing a sequence of valid tokens of type <typeparamref name="TToken"/> 
-    /// and a collection of ignored elements of type <typeparamref name="TIgnoredToken"/>.
-    /// </returns>
-    /// <exception cref="ArgumentNullException">Thrown if the input string is null.</exception>
-	// QueryStringTokenizingResult<TToken, TIgnoredToken> Tokenize(string input, string languageCode = "sv");
+	/// Transforms search request parameters into a structured <see cref="QueryStringTokenizingResult{TToken, TIgnoredToken}"/>.
+	/// </summary>
+	/// <param name="searchParameters">
+	/// An object containing the raw input string and the global language context 
+	/// required to apply correct tokenization and normalization rules.
+	/// </param>
+	/// <returns>
+	/// A result object containing a sequence of valid tokens of type <typeparamref name="TToken"/> 
+	/// and a collection of elements of type <typeparamref name="TIgnoredToken"/> that were filtered out.
+	/// </returns>
+	/// <exception cref="ArgumentNullException">Thrown if <paramref name="searchParameters"/> is null.</exception>
+	/// <exception cref="Backend.Core.Exceptions.InvalidQueryStringException">
+	/// Thrown if the input string contains invalid syntax that cannot be recovered.
+	/// </exception>
 	QueryStringTokenizingResult<TToken, TIgnoredToken> Tokenize(SearchQueryRequestParameters searchParameters);
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/Helpers/IStringTokenizer.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/Helpers/IStringTokenizer.cs
@@ -1,4 +1,5 @@
 ﻿using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
+using LTU.SearchEngine.Backend.Core.RequestParameters;
 
 namespace LTU.SearchEngine.Application.QueryParsing.Helpers;
 
@@ -29,5 +30,6 @@ public interface IStringTokenizer<TToken, TIgnoredToken>
     /// and a collection of ignored elements of type <typeparamref name="TIgnoredToken"/>.
     /// </returns>
     /// <exception cref="ArgumentNullException">Thrown if the input string is null.</exception>
-	QueryStringTokenizingResult<TToken, TIgnoredToken> Tokenize(string input, string languageCode = "sv");
+	// QueryStringTokenizingResult<TToken, TIgnoredToken> Tokenize(string input, string languageCode = "sv");
+	QueryStringTokenizingResult<TToken, TIgnoredToken> Tokenize(SearchQueryRequestParameters searchParameters);
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/Helpers/QueryStringTokenizer.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/Helpers/QueryStringTokenizer.cs
@@ -26,10 +26,8 @@ public class QueryStringTokenizer : IStringTokenizer<ExtractedQueryToken, Ignore
 
 
 	/// <inheritdoc/>
-	// public QueryStringTokenizingResult<ExtractedQueryToken, IgnoredTermsDTO> Tokenize(string input, string languageCode)
 	public QueryStringTokenizingResult<ExtractedQueryToken, IgnoredTermsDTO> Tokenize(SearchQueryRequestParameters searchParameters)
 	{
-		// var session = new QueryStringTokenizationSession(input, languageCode, _syntaxHelper, _normalizer);
 		var session = new QueryStringTokenizationSession(
 			searchParameters.Query, 
 			searchParameters.Language, 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/Helpers/QueryStringTokenizer.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/Helpers/QueryStringTokenizer.cs
@@ -2,6 +2,7 @@
 using LTU.SearchEngine.Backend.Core.Enums;
 using LTU.SearchEngine.Backend.Core.Model.DTOs;
 using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
+using LTU.SearchEngine.Backend.Core.RequestParameters;
 using System.Text;
 
 namespace LTU.SearchEngine.Application.QueryParsing.Helpers;
@@ -25,9 +26,16 @@ public class QueryStringTokenizer : IStringTokenizer<ExtractedQueryToken, Ignore
 
 
 	/// <inheritdoc/>
-	public QueryStringTokenizingResult<ExtractedQueryToken, IgnoredTermsDTO> Tokenize(string input, string languageCode)
+	// public QueryStringTokenizingResult<ExtractedQueryToken, IgnoredTermsDTO> Tokenize(string input, string languageCode)
+	public QueryStringTokenizingResult<ExtractedQueryToken, IgnoredTermsDTO> Tokenize(SearchQueryRequestParameters searchParameters)
 	{
-		var session = new QueryStringTokenizationSession(input, languageCode, _syntaxHelper, _normalizer);
+		// var session = new QueryStringTokenizationSession(input, languageCode, _syntaxHelper, _normalizer);
+		var session = new QueryStringTokenizationSession(
+			searchParameters.Query, 
+			searchParameters.Language, 
+			_syntaxHelper, 
+			_normalizer
+		);
 		return session.Execute();
 	}
 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/IQueryParser.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/IQueryParser.cs
@@ -1,5 +1,6 @@
 ﻿using LTU.SearchEngine.Backend.Core.Model.DTOs;
 using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
+using LTU.SearchEngine.Backend.Core.RequestParameters;
 
 namespace LTU.SearchEngine.Application.QueryParsing;
 
@@ -34,5 +35,6 @@ public interface IQueryParser
     /// <exception cref="Backend.Core.Exceptions.InvalidQueryStringException">
     /// Thrown when the query contains syntax errors that prevent a valid tree from being constructed (e.g., mismatched grouping operators).
     /// </exception>
-	QueryParsingResult<HashSet<int>, IgnoredTermsDTO> Parse(string rawQuery, string languageCode = "sv");
+	// QueryParsingResult<HashSet<int>, IgnoredTermsDTO> Parse(string rawQuery, string languageCode = "sv");
+	QueryParsingResult<HashSet<int>, IgnoredTermsDTO> Parse(SearchQueryRequestParameters searchParameters);
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/IQueryParser.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/IQueryParser.cs
@@ -5,36 +5,40 @@ using LTU.SearchEngine.Backend.Core.RequestParameters;
 namespace LTU.SearchEngine.Application.QueryParsing;
 
 /// <summary>
-/// Defines a service for transforming a raw search string into an executable query tree.
+/// Defines a service for transforming raw search parameters into an executable query tree.
 /// </summary>
 /// <remarks>
 /// This component orchestrates the transition from unstructured text to a structured 
-/// logical representation by coordinating string tokenization and tree construction.
+/// logical representation. It coordinates the workflow between string tokenization 
+/// and tree construction to produce a result ready for database execution.
 /// </remarks>
 public interface IQueryParser
 {
 	/// <summary>
-    /// Parses a raw query string into a structured query result, including the logical root node and any ignored terms.
-    /// </summary>
-    /// <param name="rawQuery">The raw, unparsed string input provided by the user.</param>
-    /// <param name="languageCode">The ISO language code (e.g., "sv", "en") used to drive normalization and language-specific parsing rules.</param>
-    /// <returns>
-    /// A <see cref="QueryParsingResult{TResult, TIgnoredToken}"/> containing:
-    /// <list type="bullet">
-    /// 	<item>
-    /// 		<description><see cref="QueryParsingResult{TResult, TIgnoredToken}.RootNode"/>: 
-    /// 		The root of the constructed query tree used for document matching.</description>
-    /// 	</item>
-    /// 	<item>
-    /// 		<description><see cref="QueryParsingResult{TResult, TIgnoredToken}.IgnoredTokens"/>: 
-    /// 		A collection of terms that were identified but excluded (e.g., stop-words) during the tokenization process.</description>
-    /// 	</item>
-    /// </list>
-    /// </returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="rawQuery"/> is null.</exception>
-    /// <exception cref="Backend.Core.Exceptions.InvalidQueryStringException">
-    /// Thrown when the query contains syntax errors that prevent a valid tree from being constructed (e.g., mismatched grouping operators).
-    /// </exception>
-	// QueryParsingResult<HashSet<int>, IgnoredTermsDTO> Parse(string rawQuery, string languageCode = "sv");
+	/// Parses search request parameters into a structured query result, including 
+	/// the logical root node and any ignored terms.
+	/// </summary>
+	/// <param name="searchParameters">
+	/// An object containing the raw query string and global language context 
+	/// provided by the user.
+	/// </param>
+	/// <returns>
+	/// A <see cref="QueryParsingResult{HashSet, IgnoredTermsDTO}"/> containing:
+	/// <list type="bullet">
+	///     <item>
+	///         <term>RootNode</term>
+	///         <description>The root of the constructed query tree used for document matching and filtering.</description>
+	///     </item>
+	///     <item>
+	///         <term>IgnoredTokens</term>
+	///         <description>A collection of terms (e.g., stop-words) that were identified but excluded from the final tree.</description>
+	///     </item>
+	/// </list>
+	/// </returns>
+	/// <exception cref="ArgumentNullException">Thrown when <paramref name="searchParameters"/> is null.</exception>
+	/// <exception cref="LTU.SearchEngine.Backend.Core.Exceptions.InvalidQueryStringException">
+	/// Thrown when the query contains syntax errors that prevent a valid tree from being constructed, 
+	/// such as mismatched parentheses or invalid operator placement.
+	/// </exception>
 	QueryParsingResult<HashSet<int>, IgnoredTermsDTO> Parse(SearchQueryRequestParameters searchParameters);
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/IQueryService.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/IQueryService.cs
@@ -1,24 +1,39 @@
 ﻿using LTU.SearchEngine.Backend.Core.Model.DTOs;
-using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
 using LTU.SearchEngine.Backend.Core.RequestParameters;
 
-namespace LTU.SearchEngine.Application.QueryParsing
+namespace LTU.SearchEngine.Application.QueryParsing;
+
+/// <summary>
+/// Defines the primary search gateway for the application, responsible for orchestrating 
+/// query parsing, logical evaluation, and paginated document retrieval.
+/// </summary>
+/// <remarks>
+/// This service acts as the entry point for the API layer, aggregating the results 
+/// from the Query Parser and the Document Repository into a unified response DTO.
+/// </remarks>
+public interface IQueryService
 {
-    /// <summary>
-    /// Defines the core search functionality for the application, handling query parsing and document retrieval.
-    /// </summary>
-    public interface IQueryService
-    {
-        /// <summary>
-        /// Performs an asynchronous search based on the provided query string.
-        /// </summary>
-        /// <param name="query">The search expression to evaluate (e.g., "cats AND dogs").</param>
-        /// <param name="languageCode">The main language of the given query.</param> 
-        /// <returns>A task representing the asynchronous operation, containing a collection of <see cref="SearchResultItem"/>.</returns>
-        // Task<SearchResponseDTO> GetSearchResultsAsync(string query, string languageCode = "sv");
-        Task<SearchResponseDTO> GetSearchResultsAsync(
-            SearchQueryRequestParameters searchParameters,
-            PaginationRequestParameters paginationParameters
-        );
-    }
+	/// <summary>
+	/// Executes a comprehensive search operation asynchronously based on complex query logic and pagination settings.
+	/// </summary>
+	/// <param name="searchParameters">
+	/// Encapsulates the user's search expression and the global language context 
+	/// (e.g., query string, default ISO language code).
+	/// </param>
+	/// <param name="paginationParameters">
+	/// Encapsulates settings for controlling the result set window, 
+	/// including page numbers and page sizes.
+	/// </param> 
+	/// <returns>
+	/// A task representing the asynchronous operation, containing a <see cref="SearchResponseDTO"/> 
+	/// which includes matching documents, pagination metadata, and information about ignored terms.
+	/// </returns>
+	/// <exception cref="ArgumentNullException">Thrown if either parameter object is null.</exception>
+	/// <exception cref="LTU.SearchEngine.Backend.Core.Exceptions.InvalidQueryStringException">
+	/// Thrown if the search expression within <paramref name="searchParameters"/> fails logical validation.
+	/// </exception>
+	Task<SearchResponseDTO> GetSearchResultsAsync(
+        SearchQueryRequestParameters searchParameters,
+        PaginationRequestParameters paginationParameters
+    );
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/IQueryService.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/IQueryService.cs
@@ -1,8 +1,6 @@
 ﻿using LTU.SearchEngine.Backend.Core.Model.DTOs;
 using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
-using System;
-using System.Collections.Generic;
-using System.Text;
+using LTU.SearchEngine.Backend.Core.RequestParameters;
 
 namespace LTU.SearchEngine.Application.QueryParsing
 {
@@ -17,6 +15,10 @@ namespace LTU.SearchEngine.Application.QueryParsing
         /// <param name="query">The search expression to evaluate (e.g., "cats AND dogs").</param>
         /// <param name="languageCode">The main language of the given query.</param> 
         /// <returns>A task representing the asynchronous operation, containing a collection of <see cref="SearchResultItem"/>.</returns>
-        Task<SearchResponseDTO> GetSearchResultsAsync(string query, string languageCode = "sv");
+        // Task<SearchResponseDTO> GetSearchResultsAsync(string query, string languageCode = "sv");
+        Task<SearchResponseDTO> GetSearchResultsAsync(
+            SearchQueryRequestParameters searchParameters,
+            PaginationRequestParameters paginationParameters
+        );
     }
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/QueryParser.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/QueryParser.cs
@@ -2,6 +2,7 @@
 using LTU.SearchEngine.Backend.Core.Model.DTOs;
 using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
 using LTU.SearchEngine.Backend.Core.Model.ValueObjects.QueryNodes;
+using LTU.SearchEngine.Backend.Core.RequestParameters;
 using LTU.SearchEngine.Backend.Core.SearchQueryBuilder;
 
 namespace LTU.SearchEngine.Application.QueryParsing;
@@ -41,9 +42,11 @@ public class QueryParser : IQueryParser
 	}
 
 	/// <inheritdoc/>
-	public QueryParsingResult<HashSet<int>, IgnoredTermsDTO> Parse(string rawQuery, string languageCode = "sv")
+	// public QueryParsingResult<HashSet<int>, IgnoredTermsDTO> Parse(string rawQuery, string languageCode = "sv")
+	public QueryParsingResult<HashSet<int>, IgnoredTermsDTO> Parse(SearchQueryRequestParameters searchParameters)
 	{
-		var tokenizerResult = _stringTokenizer.Tokenize(rawQuery, languageCode);
+		// var tokenizerResult = _stringTokenizer.Tokenize(rawQuery, languageCode);
+		var tokenizerResult = _stringTokenizer.Tokenize(searchParameters);
 
 		QueryNode<HashSet<int>> rootNode = _treeBuilder.BuildTree(tokenizerResult.Tokens);
 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/QueryParser.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/QueryParser.cs
@@ -9,13 +9,25 @@ namespace LTU.SearchEngine.Application.QueryParsing;
 
 /// <summary>
 /// Provides a concrete implementation of <see cref="IQueryParser"/> that orchestrates 
-/// the conversion of raw text into a structured query tree.
+/// the conversion of raw search parameters into a structured, executable query tree.
 /// </summary>
 /// <remarks>
-/// This implementation follows a two-step pipeline:
+/// This implementation executes a two-stage processing pipeline:
 /// <list type="number">
-/// 	<item><description>Tokenization and normalization via an <see cref="IStringTokenizer{TToken, TIgnoredToken}"/>.</description></item>
-/// 	<item><description>Tree construction via an <see cref="ITreeBuilder{TResult, TToken}"/>.</description></item>
+///     <item>
+///         <term>Tokenization</term>
+///         <description>
+///             The raw input string is decomposed into categorized tokens (terms, phrases, operators) 
+///             and normalized according to the specified language context.
+///         </description>
+///     </item>
+///     <item>
+///         <term>Tree Construction</term>
+///         <description>
+///             The resulting token stream is parsed into a hierarchical tree of <see cref="QueryNode{T}"/> 
+///             objects, representing the final boolean logic.
+///         </description>
+///     </item>
 /// </list>
 /// </remarks>
 public class QueryParser : IQueryParser
@@ -24,11 +36,11 @@ public class QueryParser : IQueryParser
 	private readonly IStringTokenizer<ExtractedQueryToken, IgnoredTermsDTO> _stringTokenizer;
 
 	/// <summary>
-    /// Initializes a new instance of the <see cref="QueryParser"/> class.
-    /// </summary>
-    /// <param name="treeBuilder">The builder responsible for transforming tokens into a logical tree structure.</param>
-    /// <param name="stringTokenizer">The tokenizer responsible for segmenting and normalizing the raw input string.</param>
-    /// <exception cref="ArgumentNullException">Thrown if <paramref name="treeBuilder"/> or <paramref name="stringTokenizer"/> is null.</exception>
+	/// Initializes a new instance of the <see cref="QueryParser"/> class with required dependencies.
+	/// </summary>
+	/// <param name="treeBuilder">The builder responsible for transforming normalized tokens into a logical tree structure.</param>
+	/// <param name="stringTokenizer">The tokenizer responsible for segmenting and cleaning the raw input string.</param>
+	/// <exception cref="ArgumentNullException">Thrown if <paramref name="treeBuilder"/> or <paramref name="stringTokenizer"/> is null.</exception>
 	public QueryParser(
 		ITreeBuilder<HashSet<int>, ExtractedQueryToken> treeBuilder,
 		IStringTokenizer<ExtractedQueryToken, IgnoredTermsDTO> stringTokenizer
@@ -42,10 +54,8 @@ public class QueryParser : IQueryParser
 	}
 
 	/// <inheritdoc/>
-	// public QueryParsingResult<HashSet<int>, IgnoredTermsDTO> Parse(string rawQuery, string languageCode = "sv")
 	public QueryParsingResult<HashSet<int>, IgnoredTermsDTO> Parse(SearchQueryRequestParameters searchParameters)
 	{
-		// var tokenizerResult = _stringTokenizer.Tokenize(rawQuery, languageCode);
 		var tokenizerResult = _stringTokenizer.Tokenize(searchParameters);
 
 		QueryNode<HashSet<int>> rootNode = _treeBuilder.BuildTree(tokenizerResult.Tokens);

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/QueryService.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/QueryService.cs
@@ -2,6 +2,7 @@
 using System.Globalization;
 using LTU.SearchEngine.Backend.Core.Model.DTOs;
 using LTU.SearchEngine.Backend.Core.Model.ValueObjects.QueryNodes;
+using LTU.SearchEngine.Backend.Core.RequestParameters;
 using LTU.SearchEngine.Backend.Core.SearchQueryBuilder;
 using LTU.SearchEngine.Infrastructure.Repositories;
 
@@ -25,12 +26,17 @@ public class QueryService : IQueryService
 	}
 
 	/// <inheritdoc/>
-	public async Task<SearchResponseDTO> GetSearchResultsAsync(string rawQuery, string languageCode = "sv")
+	// public async Task<SearchResponseDTO> GetSearchResultsAsync(string rawQuery, string languageCode = "sv")
+	public async Task<SearchResponseDTO> GetSearchResultsAsync(
+		SearchQueryRequestParameters searchParameters,
+        PaginationRequestParameters paginationParameters
+		)
 	{
 		
 		var stopWatch = Stopwatch.StartNew();
 
-		var (queryNode, ignoredTokens) = _queryParser.Parse(rawQuery, languageCode);
+		// var (queryNode, ignoredTokens) = _queryParser.Parse(rawQuery, languageCode);
+		var (queryNode, ignoredTokens) = _queryParser.Parse(searchParameters);
 		
 		HashSet<int> resultIds;
 		
@@ -40,8 +46,10 @@ public class QueryService : IQueryService
 			resultIds = await _queryEvaluatorVisitor.ExecuteAsync(queryNode);
 		
 		
+		// var documentResults = await _indexRepository
+		// 	.GetDocumentsByIdAsync(resultIds.ToList());
 		var documentResults = await _indexRepository
-			.GetDocumentsByIdAsync(resultIds.ToList());
+			.GetDocumentsByIdAsync(resultIds.ToList(), paginationParameters);
 
 		stopWatch.Stop();
 		var elapsedTime = stopWatch.Elapsed.TotalMilliseconds;
@@ -50,16 +58,32 @@ public class QueryService : IQueryService
 			$"Search completed in {elapsedTime:F2} ms!"
 		);
 
+
+
+		// return new SearchResponseDTO(
+		// 	searchResults: documentResults.Select(doc => new DocumentDTO(
+		// 		Id : doc.Id,
+		// 		Url : doc.Url,
+		// 		Title : doc.Title,
+		// 		Language : doc.Language)
+		// 	),
+		// 	currentPage: 1,
+		// 	pageSize: 1,
+		// 	totalResults: documentResults.Count(),
+		// 	message: timingMessage,
+		// 	ignoredTokens: ignoredTokens
+		// );
 		return new SearchResponseDTO(
-			searchResults: documentResults.Select(doc => new DocumentDTO(
+			searchResults: documentResults.Items.Select(doc => new DocumentDTO(
 				Id : doc.Id,
 				Url : doc.Url,
 				Title : doc.Title,
 				Language : doc.Language)
 			),
-			currentPage: 1,
-			pageSize: 1,
-			totalResults: documentResults.Count(),
+			// currentPage: 1,
+			// pageSize: 1,
+			// totalResults: documentResults.Count(),
+			metaData: documentResults.MetaData,
 			message: timingMessage,
 			ignoredTokens: ignoredTokens
 		);

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/QueryService.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/QueryService.cs
@@ -8,12 +8,31 @@ using LTU.SearchEngine.Infrastructure.Repositories;
 
 namespace LTU.SearchEngine.Application.QueryParsing;
 
+/// <summary>
+/// Provides a concrete implementation of <see cref="IQueryService"/> that orchestrates the 
+/// end-to-end search process, from query parsing to database retrieval.
+/// </summary>
+/// <remarks>
+/// The service follows a strict execution pipeline:
+/// <list type="number">
+///     <item><description><b>Parsing:</b> Converts the raw request into a logical query tree.</description></item>
+///     <item><description><b>Evaluation:</b> Uses a Visitor pattern to resolve the tree into a set of document IDs.</description></item>
+///     <item><description><b>Retrieval:</b> Fetches the actual document content and metadata using paginated repository calls.</description></item>
+/// </list>
+/// Performance is tracked via <see cref="Stopwatch"/> and included in the final response.
+/// </remarks>
 public class QueryService : IQueryService
 {
 	private readonly IIndexRepository _indexRepository;
 	private readonly IQueryParser _queryParser;
 	private readonly IQueryVisitor<HashSet<int>> _queryEvaluatorVisitor;
 
+	/// <summary>
+	/// Initializes a new instance of the <see cref="QueryService"/> class with required infrastructure and domain services.
+	/// </summary>
+	/// <param name="indexRepository">The repository used for fetching physical document data.</param>
+	/// <param name="queryParser">The parser used to transform raw input into a logical tree.</param>
+	/// <param name="queryEvaluatorVisitor">The visitor implementation used to evaluate boolean logic across the index.</param>
 	public QueryService(
 		IIndexRepository indexRepository,
 		IQueryParser queryParser,
@@ -25,17 +44,15 @@ public class QueryService : IQueryService
 		_queryEvaluatorVisitor = queryEvaluatorVisitor;
 	}
 
+	
 	/// <inheritdoc/>
-	// public async Task<SearchResponseDTO> GetSearchResultsAsync(string rawQuery, string languageCode = "sv")
 	public async Task<SearchResponseDTO> GetSearchResultsAsync(
 		SearchQueryRequestParameters searchParameters,
         PaginationRequestParameters paginationParameters
 		)
 	{
-		
 		var stopWatch = Stopwatch.StartNew();
 
-		// var (queryNode, ignoredTokens) = _queryParser.Parse(rawQuery, languageCode);
 		var (queryNode, ignoredTokens) = _queryParser.Parse(searchParameters);
 		
 		HashSet<int> resultIds;
@@ -46,8 +63,6 @@ public class QueryService : IQueryService
 			resultIds = await _queryEvaluatorVisitor.ExecuteAsync(queryNode);
 		
 		
-		// var documentResults = await _indexRepository
-		// 	.GetDocumentsByIdAsync(resultIds.ToList());
 		var documentResults = await _indexRepository
 			.GetDocumentsByIdAsync(resultIds.ToList(), paginationParameters);
 
@@ -59,20 +74,6 @@ public class QueryService : IQueryService
 		);
 
 
-
-		// return new SearchResponseDTO(
-		// 	searchResults: documentResults.Select(doc => new DocumentDTO(
-		// 		Id : doc.Id,
-		// 		Url : doc.Url,
-		// 		Title : doc.Title,
-		// 		Language : doc.Language)
-		// 	),
-		// 	currentPage: 1,
-		// 	pageSize: 1,
-		// 	totalResults: documentResults.Count(),
-		// 	message: timingMessage,
-		// 	ignoredTokens: ignoredTokens
-		// );
 		return new SearchResponseDTO(
 			searchResults: documentResults.Items.Select(doc => new DocumentDTO(
 				Id : doc.Id,
@@ -80,9 +81,6 @@ public class QueryService : IQueryService
 				Title : doc.Title,
 				Language : doc.Language)
 			),
-			// currentPage: 1,
-			// pageSize: 1,
-			// totalResults: documentResults.Count(),
 			metaData: documentResults.MetaData,
 			message: timingMessage,
 			ignoredTokens: ignoredTokens

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/QueryService.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Application/QueryParsing/QueryService.cs
@@ -75,15 +75,15 @@ public class QueryService : IQueryService
 
 
 		return new SearchResponseDTO(
-			searchResults: documentResults.Items.Select(doc => new DocumentDTO(
+			SearchResults: documentResults.Items.Select(doc => new DocumentDTO(
 				Id : doc.Id,
 				Url : doc.Url,
 				Title : doc.Title,
 				Language : doc.Language)
 			),
-			metaData: documentResults.MetaData,
-			message: timingMessage,
-			ignoredTokens: ignoredTokens
+			MetaData: documentResults.MetaData,
+			Message: timingMessage,
+			IgnoredTokens: ignoredTokens
 		);
 	}
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Exceptions/PaginationOutOfRangeException.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Exceptions/PaginationOutOfRangeException.cs
@@ -1,0 +1,12 @@
+namespace LTU.SearchEngine.Backend.Core.Exceptions;
+
+public class PaginationOutOfRangeException : Exception
+{
+    public string Title { get; }
+    
+    public PaginationOutOfRangeException(string message, string title = "Pagination out of range.") 
+        : base (message)
+    {
+        Title = title;
+    }
+}

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/InfrastructureContracts/IIndexRepository.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/InfrastructureContracts/IIndexRepository.cs
@@ -25,7 +25,7 @@ public interface IIndexRepository
 	Task<HashSet<int>> GetDocumentIdsForTermAsync(string term);
 	Task<HashSet<int>> GetDocumentIdsForPhraseAsync(PhraseNode<HashSet<int>> phrase); 
 	// Task<List<Page>> GetDocumentsByIdAsync(List<int> pageIds);
-	Task<IPaginatedResult<Page>> GetDocumentsByIdAsync(
+	Task<PaginatedResult<Page>> GetDocumentsByIdAsync(
         List<int> pageIds, 
         PaginationRequestParameters paginationParameters
     );

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/InfrastructureContracts/IIndexRepository.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/InfrastructureContracts/IIndexRepository.cs
@@ -6,29 +6,64 @@ using LTU.SearchEngine.Backend.Core.RequestParameters;
 namespace LTU.SearchEngine.Infrastructure.Repositories;
 
 /// <summary>
-/// Defines the contract for storing and retrieving indexed documents and terms.
+/// Defines the contract for the search engine's persistence layer, managing both 
+/// the inverted index and document metadata.
 /// </summary>
 /// <remarks>
 /// <para>
-/// Implementations of this interface are responsible for persisting index data,
-/// including forward indexes and inverted indexes.
+/// Implementations of this interface handle the "heavy lifting" of the search engine:
+/// mapping terms to document IDs (Inverted Index) and retrieving the actual web page 
+/// content for the final search results.
 /// </para>
 /// <para>
-/// The repository abstraction hides storage details from the indexing flow and
-/// allows different persistence strategies to be introduced without changing
-/// the indexing logic.
+/// This abstraction allows the application to remain agnostic of the underlying storage 
+/// (e.g., SQL, NoSQL, or In-Memory) while providing optimized methods for document lookup.
 /// </para>
 /// </remarks>
 public interface IIndexRepository
 {
-    Task AddDocumentAsync(IndexDocument document);
+	/// <summary>
+	/// Persists a newly indexed document and its associated term frequencies to the storage.
+	/// </summary>
+	/// <param name="document">The indexed representation of a web page.</param>
+	Task AddDocumentAsync(IndexDocument document);
+
+	/// <summary>
+	/// Retrieves a set of unique document IDs that contain the specified search term.
+	/// </summary>
+	/// <param name="term">The normalized search term to look up.</param>
+	/// <returns>A unique collection of document IDs associated with the term.</returns>
 	Task<HashSet<int>> GetDocumentIdsForTermAsync(string term);
-	Task<HashSet<int>> GetDocumentIdsForPhraseAsync(PhraseNode<HashSet<int>> phrase); 
-	// Task<List<Page>> GetDocumentsByIdAsync(List<int> pageIds);
+
+	/// <summary>
+	/// Retrieves a set of document IDs that contain a specific sequence of terms 
+	/// (phrase) in the exact specified order.
+	/// </summary>
+	/// <param name="phrase">The node containing the ordered list of terms to match.</param>
+	/// <returns>A unique collection of document IDs containing the exact phrase.</returns>
+	Task<HashSet<int>> GetDocumentIdsForPhraseAsync(PhraseNode<HashSet<int>> phrase);
+
+	/// <summary>
+	/// Hydrates a list of document IDs into full <see cref="Page"/> entities with 
+	/// support for pagination and metadata.
+	/// </summary>
+	/// <param name="pageIds">The list of document IDs to fetch.</param>
+	/// <param name="paginationParameters">Settings for controlling page indexing and result limits.</param>
+	/// <returns>A paginated result containing the requested document entities and metadata.</returns>
 	Task<PaginatedResult<Page>> GetDocumentsByIdAsync(
-        List<int> pageIds, 
-        PaginationRequestParameters paginationParameters
-    );
+        List<int> pageIds, PaginationRequestParameters paginationParameters);
+
+	/// <summary>
+	/// Performs a duplicate check by looking for an existing document with the same content hash.
+	/// </summary>
+	/// <param name="hash">The SHA-256 hash of the page content.</param>
+	/// <returns>The ID of the existing document if found; otherwise, null.</returns>
 	Task<int?> GetExistingDocumentByHashAsync(string hash);
+
+	/// <summary>
+	/// Updates the timestamp for when a document was last visited by the crawler.
+	/// </summary>
+	/// <param name="id">The unique identifier of the document.</param>
+	/// <param name="newCrawl">The timestamp of the current crawl.</param>
 	Task UpdateLastCrawledAsync(int id, DateTime newCrawl);
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/InfrastructureContracts/IIndexRepository.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/InfrastructureContracts/IIndexRepository.cs
@@ -1,5 +1,6 @@
 ﻿using LTU.SearchEngine.Backend.Core.Entities;
 using LTU.SearchEngine.Backend.Core.Model.ValueObjects.QueryNodes;
+using LTU.SearchEngine.Backend.Core.RequestParameters;
 
 
 namespace LTU.SearchEngine.Infrastructure.Repositories;
@@ -23,7 +24,11 @@ public interface IIndexRepository
     Task AddDocumentAsync(IndexDocument document);
 	Task<HashSet<int>> GetDocumentIdsForTermAsync(string term);
 	Task<HashSet<int>> GetDocumentIdsForPhraseAsync(PhraseNode<HashSet<int>> phrase); 
-	Task<List<Page>> GetDocumentsByIdAsync(List<int> pageIds);
+	// Task<List<Page>> GetDocumentsByIdAsync(List<int> pageIds);
+	Task<IPaginatedResult<Page>> GetDocumentsByIdAsync(
+        List<int> pageIds, 
+        PaginationRequestParameters paginationParameters
+    );
 	Task<int?> GetExistingDocumentByHashAsync(string hash);
 	Task UpdateLastCrawledAsync(int id, DateTime newCrawl);
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/DTOs/SearchResponseDTO.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/DTOs/SearchResponseDTO.cs
@@ -1,4 +1,5 @@
 ﻿using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
+using LTU.SearchEngine.Backend.Core.RequestParameters;
 
 namespace LTU.SearchEngine.Backend.Core.Model.DTOs;
 
@@ -14,9 +15,10 @@ namespace LTU.SearchEngine.Backend.Core.Model.DTOs;
 /// <param name="ignoredTokens">An optional collection of <see cref="IgnoredTermsDTO"/> representing any tokens that were ignored during query parsing.</param>
 public record SearchResponseDTO(
 	IEnumerable<DocumentDTO> searchResults,
-	int currentPage,
-	int pageSize,
-	int totalResults,
+	// int currentPage,
+	// int pageSize,
+	// int totalResults,
+	IPaginationMetaData metaData,
 	string? message,
 	IEnumerable<IgnoredTermsDTO>? ignoredTokens = null
 );

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/DTOs/SearchResponseDTO.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/DTOs/SearchResponseDTO.cs
@@ -1,24 +1,25 @@
-﻿using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
-using LTU.SearchEngine.Backend.Core.RequestParameters;
+﻿using LTU.SearchEngine.Backend.Core.RequestParameters;
 
 namespace LTU.SearchEngine.Backend.Core.Model.DTOs;
 
 /// <summary>
-/// Represents a paginated search response containing a collection of results and execution metadata. <br/>
-/// This DTO is used to deliver search data and pagination state to the client.
+/// Represents the final paginated search response delivered to the client.
 /// </summary>
-/// <param name="searchResults">A collection of <see cref="SearchResultItem"/> matching the query for the current page.</param>
-/// <param name="currentPage">The one-based index of the current result page.</param>
-/// <param name="pageSize">The maximum number of items requested per page.</param>
-/// <param name="totalResults">The total number of documents matching the search criteria across all pages.</param>
-/// <param name="message">An optional status or warning message (e.g., "No results found" or "Query expanded").</param>
-/// <param name="ignoredTokens">An optional collection of <see cref="IgnoredTermsDTO"/> representing any tokens that were ignored during query parsing.</param>
+/// <remarks>
+/// This DTO aggregates the actual matching documents with critical execution metadata, 
+/// such as pagination state (total pages, current offset), performance messages, 
+/// and information regarding query preprocessing (e.g., stop-words removed).
+/// </remarks>
+/// <param name="SearchResults">A collection of <see cref="DocumentDTO"/> containing the hydrated data of matching web pages.</param>
+/// <param name="MetaData">The pagination state, including total item counts and page boundaries.</param>
+/// <param name="Message">A status or telemetry message, typically containing the search execution time.</param>
+/// <param name="IgnoredTokens">
+/// An optional collection of <see cref="IgnoredTermsDTO"/> detailing terms that were 
+/// stripped from the query during parsing (e.g., stop-words or invalid characters).
+/// </param>
 public record SearchResponseDTO(
-	IEnumerable<DocumentDTO> searchResults,
-	// int currentPage,
-	// int pageSize,
-	// int totalResults,
-	PaginationMetaData metaData,
-	string? message,
-	IEnumerable<IgnoredTermsDTO>? ignoredTokens = null
+	IEnumerable<DocumentDTO> SearchResults,
+	PaginationMetaData MetaData,
+	string? Message,
+	IEnumerable<IgnoredTermsDTO>? IgnoredTokens = null
 );

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/DTOs/SearchResponseDTO.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/Model/DTOs/SearchResponseDTO.cs
@@ -18,7 +18,7 @@ public record SearchResponseDTO(
 	// int currentPage,
 	// int pageSize,
 	// int totalResults,
-	IPaginationMetaData metaData,
+	PaginationMetaData metaData,
 	string? message,
 	IEnumerable<IgnoredTermsDTO>? ignoredTokens = null
 );

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/RequestParameters/IPagenatedResult.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/RequestParameters/IPagenatedResult.cs
@@ -1,0 +1,7 @@
+namespace LTU.SearchEngine.Backend.Core.RequestParameters;
+
+public interface IPaginatedResult<T>
+{
+    IEnumerable<T> Items { get; }
+    IPaginationMetaData MetaData { get; }
+}

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/RequestParameters/IPagenatedResult.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/RequestParameters/IPagenatedResult.cs
@@ -1,7 +1,0 @@
-namespace LTU.SearchEngine.Backend.Core.RequestParameters;
-
-public interface IPaginatedResult<T>
-{
-    IEnumerable<T> Items { get; }
-    IPaginationMetaData MetaData { get; }
-}

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/RequestParameters/IPaginationMetaData.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/RequestParameters/IPaginationMetaData.cs
@@ -1,11 +1,44 @@
 namespace LTU.SearchEngine.Backend.Core.RequestParameters;
 
+/// <summary>
+/// Defines the contract for pagination metadata, providing state information 
+/// for navigation and result set boundaries.
+/// </summary>
+/// <remarks>
+/// This metadata allows clients (e.g., front-end applications) to render 
+/// pagination controls, such as "Next/Previous" buttons and page number indicators.
+/// </remarks>
 public interface IPaginationMetaData
 {
-    int CurrentPage { get; set; }
-    int TotalPages { get; set; }
-    int PageSize { get; set; }
-    int TotalItemCount { get; set; }
-    bool HasPrevious { get; }
-    bool HasNext { get; }
+	/// <summary>
+	/// Gets or sets the current one-based page index.
+	/// </summary>
+	int CurrentPage { get; set; }
+
+	/// <summary>
+	/// Gets or sets the total number of pages available based on the <see cref="TotalItemCount"/> and <see cref="PageSize"/>.
+	/// </summary>
+	int TotalPages { get; set; }
+
+	/// <summary>
+	/// Gets or sets the maximum number of items allowed per page.
+	/// </summary>
+	int PageSize { get; set; }
+
+	/// <summary>
+	/// Gets or sets the total number of documents matching the search criteria across all pages.
+	/// </summary>
+	int TotalItemCount { get; set; }
+
+	/// <summary>
+	/// Gets a value indicating whether there is at least one page available before the <see cref="CurrentPage"/>.
+	/// </summary>
+	/// <value><c>true</c> if <see cref="CurrentPage"/> is greater than 1; otherwise, <c>false</c>.</value>
+	bool HasPrevious { get; }
+
+	/// <summary>
+	/// Gets a value indicating whether there is at least one page available after the <see cref="CurrentPage"/>.
+	/// </summary>
+	/// <value><c>true</c> if <see cref="CurrentPage"/> is less than <see cref="TotalPages"/>; otherwise, <c>false</c>.</value>
+	bool HasNext { get; }
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/RequestParameters/IPaginationMetaData.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/RequestParameters/IPaginationMetaData.cs
@@ -1,0 +1,11 @@
+namespace LTU.SearchEngine.Backend.Core.RequestParameters;
+
+public interface IPaginationMetaData
+{
+    int CurrentPage { get; set; }
+    int TotalPages { get; set; }
+    int PageSize { get; set; }
+    int TotalItemCount { get; set; }
+    bool HasPrevious { get; }
+    bool HasNext { get; }
+}

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/RequestParameters/PaginatedResult.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/RequestParameters/PaginatedResult.cs
@@ -1,0 +1,13 @@
+namespace LTU.SearchEngine.Backend.Core.RequestParameters;
+
+public class PaginatedResult<T> : IPaginatedResult<T>
+{
+    public IEnumerable<T> Items { get; }
+    public IPaginationMetaData MetaData { get; }
+
+    public PaginatedResult(IEnumerable<T> items, IPaginationMetaData metaData)
+    {
+        Items = items;
+        MetaData = metaData;
+    }
+}

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/RequestParameters/PaginatedResult.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/RequestParameters/PaginatedResult.cs
@@ -1,11 +1,29 @@
 namespace LTU.SearchEngine.Backend.Core.RequestParameters;
 
+
+/// <summary>
+/// A generic container that bundles a collection of data items with their associated pagination metadata.
+/// </summary>
+/// <typeparam name="T">The type of the elements contained in the result set.</typeparam>
+/// <remarks>
+/// This class is primarily used by repositories and services to return a subset of data (a "page") 
+/// along with the information required to navigate through the entire result set.
+/// </remarks>
 public class PaginatedResult<T>
 {
     public IEnumerable<T> Items { get; }
-    public PaginationMetaData MetaData { get; }
 
-    public PaginatedResult(IEnumerable<T> items, PaginationMetaData metaData)
+	/// <summary>
+	/// Gets the metadata describing the pagination state (e.g., total pages, current page).
+	/// </summary>
+	public PaginationMetaData MetaData { get; }
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="PaginatedResult{T}"/> class.
+	/// </summary>
+	/// <param name="items">The sequence of items belonging to the current page.</param>
+	/// <param name="metaData">The pagination metadata associated with the result set.</param>
+	public PaginatedResult(IEnumerable<T> items, PaginationMetaData metaData)
     {
         Items = items;
         MetaData = metaData;

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/RequestParameters/PaginatedResult.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/RequestParameters/PaginatedResult.cs
@@ -1,11 +1,11 @@
 namespace LTU.SearchEngine.Backend.Core.RequestParameters;
 
-public class PaginatedResult<T> : IPaginatedResult<T>
+public class PaginatedResult<T>
 {
     public IEnumerable<T> Items { get; }
-    public IPaginationMetaData MetaData { get; }
+    public PaginationMetaData MetaData { get; }
 
-    public PaginatedResult(IEnumerable<T> items, IPaginationMetaData metaData)
+    public PaginatedResult(IEnumerable<T> items, PaginationMetaData metaData)
     {
         Items = items;
         MetaData = metaData;

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/RequestParameters/PaginationMetaData.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/RequestParameters/PaginationMetaData.cs
@@ -1,0 +1,19 @@
+namespace LTU.SearchEngine.Backend.Core.RequestParameters;
+
+public class PaginationMetaData : IPaginationMetaData
+{
+    public int CurrentPage { get; set; }
+    public int TotalPages { get; set; }
+    public int PageSize { get; set; }
+    public int TotalItemCount { get; set; }
+    public bool HasPrevious => CurrentPage > 1;
+    public bool HasNext => CurrentPage < TotalPages;
+
+    public PaginationMetaData(int currentPage, int totalPages, int pageSize, int totalItemCount)
+    {
+        CurrentPage = currentPage;
+        TotalPages = totalPages;
+        PageSize = pageSize;
+        TotalItemCount = totalItemCount;
+    }
+}

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/RequestParameters/PaginationMetaData.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/RequestParameters/PaginationMetaData.cs
@@ -1,15 +1,39 @@
 namespace LTU.SearchEngine.Backend.Core.RequestParameters;
 
+
+/// <summary>
+/// Provides a concrete implementation of <see cref="IPaginationMetaData"/> used to 
+/// describe the state of a paginated data set.
+/// </summary>
 public class PaginationMetaData : IPaginationMetaData
 {
-    public int CurrentPage { get; set; }
-    public int TotalPages { get; set; }
-    public int PageSize { get; set; }
-    public int TotalItemCount { get; set; }
-    public bool HasPrevious => CurrentPage > 1;
-    public bool HasNext => CurrentPage < TotalPages;
+	/// <inheritdoc/>
+	public int CurrentPage { get; set; }
+	
+    /// <inheritdoc/>
+	public int TotalPages { get; set; }
 
-    public PaginationMetaData(int currentPage, int totalPages, int pageSize, int totalItemCount)
+	/// <inheritdoc/>
+	public int PageSize { get; set; }
+
+	/// <inheritdoc/>
+	public int TotalItemCount { get; set; }
+
+	/// <inheritdoc/>
+	public bool HasPrevious => CurrentPage > 1;
+
+	/// <inheritdoc/>
+	public bool HasNext => CurrentPage < TotalPages;
+
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="PaginationMetaData"/> class with explicit pagination values.
+	/// </summary>
+	/// <param name="currentPage">The current one-based page index.</param>
+	/// <param name="totalPages">The total number of available pages.</param>
+	/// <param name="pageSize">The number of items per page.</param>
+	/// <param name="totalItemCount">The total count of items across all pages.</param>
+	public PaginationMetaData(int currentPage, int totalPages, int pageSize, int totalItemCount)
     {
         CurrentPage = currentPage;
         TotalPages = totalPages;

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/RequestParameters/PaginationRequestParameters.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/RequestParameters/PaginationRequestParameters.cs
@@ -2,13 +2,28 @@ using LTU.SearchEngine.Backend.Core.Exceptions;
 
 namespace LTU.SearchEngine.Backend.Core.RequestParameters;
 
+
+/// <summary>
+/// Encapsulates request parameters for controlling pagination, including validation logic and constraints.
+/// </summary>
+/// <remarks>
+/// This class enforces engine-level restrictions to ensure performance and prevent excessive 
+/// resource consumption, such as limiting the maximum page size and restricting deep pagination depth.
+/// </remarks>
 public class PaginationRequestParameters
 {
     private const int _c_maxPageSize = 100; 
     private int _pageNumber = 1;
     private int _pageSize = 10;
 
-    public int PageNumber 
+	/// <summary>
+	/// Gets or sets the requested page number.
+	/// </summary>
+	/// <value>Defaults to 1. Minimum value is 1.</value>
+	/// <exception cref="PaginationOutOfRangeException">
+	/// Thrown if the value exceeds the deep pagination limit (currently 100) to protect system performance.
+	/// </exception>
+	public int PageNumber 
     { 
         get => _pageNumber;
         set
@@ -23,14 +38,24 @@ public class PaginationRequestParameters
             _pageNumber = value < 1 ? 1: value;
         }
     }
-    
-    public int PageSize 
+
+	/// <summary>
+	/// Gets or sets the number of items per page.
+	/// </summary>
+	/// <value>Defaults to 10. Automatically capped at the maximum allowed size (currently 100).</value>
+	public int PageSize 
     { 
         get => _pageSize;
         set => _pageSize = value > _c_maxPageSize ? _c_maxPageSize : value; 
     }
 
-    public void Deconstruct(out int pageNumber, out int pageSize)
+
+	/// <summary>
+	/// Allows the object to be deconstructed into its constituent page number and page size components.
+	/// </summary>
+	/// <param name="pageNumber">The validated current page number.</param>
+	/// <param name="pageSize">The validated current page size.</param>
+	public void Deconstruct(out int pageNumber, out int pageSize)
     {
         pageNumber = PageNumber;
         pageSize = PageSize;

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/RequestParameters/PaginationRequestParameters.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/RequestParameters/PaginationRequestParameters.cs
@@ -1,0 +1,38 @@
+using LTU.SearchEngine.Backend.Core.Exceptions;
+
+namespace LTU.SearchEngine.Backend.Core.RequestParameters;
+
+public class PaginationRequestParameters
+{
+    private const int _c_maxPageSize = 100; 
+    private int _pageNumber = 1;
+    private int _pageSize = 10;
+
+    public int PageNumber 
+    { 
+        get => _pageNumber;
+        set
+        {
+            if (value > 100)
+            {
+                throw new PaginationOutOfRangeException(
+                    "Deep pagination is restricted. Please refine your query!"
+                );
+            }
+            
+            _pageNumber = value < 1 ? 1: value;
+        }
+    }
+    
+    public int PageSize 
+    { 
+        get => _pageSize;
+        set => _pageSize = value > _c_maxPageSize ? _c_maxPageSize : value; 
+    }
+
+    public void Deconstruct(out int pageNumber, out int pageSize)
+    {
+        pageNumber = PageNumber;
+        pageSize = PageSize;
+    }
+}

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/RequestParameters/QueryParameters.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/RequestParameters/QueryParameters.cs
@@ -1,2 +1,0 @@
-namespace LTU.SearchEngine.Backend.Core.RequestParameters;
-

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/RequestParameters/QueryParameters.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/RequestParameters/QueryParameters.cs
@@ -1,0 +1,2 @@
+namespace LTU.SearchEngine.Backend.Core.RequestParameters;
+

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/RequestParameters/SearchQueryRequestParameters.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/RequestParameters/SearchQueryRequestParameters.cs
@@ -2,11 +2,27 @@ using LTU.SearchEngine.Backend.Core.Exceptions.SearchQueryExceptions;
 
 namespace LTU.SearchEngine.Backend.Core.RequestParameters;
 
+/// <summary>
+/// Encapsulates the user's search input and associated metadata required for query processing.
+/// </summary>
+/// <remarks>
+/// This class acts as the first line of defense for the search engine, validating that the 
+/// input is within safe operational limits (e.g., length and content) before it reaches the 
+/// <see cref="LTU.SearchEngine.Application.QueryParsing.IQueryParser"/>.
+/// </remarks>
 public class SearchQueryRequestParameters
 {
     private string _query = string.Empty;
 
-    public string Query 
+	/// <summary>
+	/// Gets or sets the raw search expression provided by the user.
+	/// </summary>
+	/// <value>The search string (e.g., "artificial intelligence AND robots"). Input is automatically trimmed.</value>
+	/// <exception cref="QuerySyntaxException">
+	/// Thrown if the value is null, empty, or consists only of white space.
+	/// Also thrown if the query length exceeds the 500-character safety limit.
+	/// </exception>
+	public string Query 
     { 
         get => _query; 
         set
@@ -19,7 +35,15 @@ public class SearchQueryRequestParameters
             
             _query = value.Trim();    
         } 
-    } 
+    }
 
-    public string Language { get; set; } = "sv"; 
+	/// <summary>
+	/// Gets or sets the ISO language code used to drive language-specific tokenization and normalization.
+	/// </summary>
+	/// <value>A two-letter ISO code. Defaults to "sv" (Swedish).</value>
+	/// <remarks>
+	/// This code ensures the engine uses the correct stop-word lists and stemming rules 
+	/// during the processing of the <see cref="Query"/>.
+	/// </remarks>
+	public string Language { get; set; } = "sv"; 
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/RequestParameters/SearchQueryRequestParameters.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Backend.Core/RequestParameters/SearchQueryRequestParameters.cs
@@ -1,0 +1,25 @@
+using LTU.SearchEngine.Backend.Core.Exceptions.SearchQueryExceptions;
+
+namespace LTU.SearchEngine.Backend.Core.RequestParameters;
+
+public class SearchQueryRequestParameters
+{
+    private string _query = string.Empty;
+
+    public string Query 
+    { 
+        get => _query; 
+        set
+        {
+            if (string.IsNullOrWhiteSpace(value)) 
+                throw new QuerySyntaxException("Search query cannot be empty.");
+
+             if (value.Length > 500) 
+                throw new QuerySyntaxException("Query length is limited to 500 characters!");
+            
+            _query = value.Trim();    
+        } 
+    } 
+
+    public string Language { get; set; } = "sv"; 
+}

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Extentions/QueryableExtensionPagination.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Extentions/QueryableExtensionPagination.cs
@@ -6,7 +6,7 @@ namespace LTU.SearchEngine.Infrastructure.Extensions;
 
 public static class QueryableExtensionPagination
 {
-    public static async Task<IPaginatedResult<T>> ToPaginatedResultAsync<T>(
+    public static async Task<PaginatedResult<T>> ToPaginatedResultAsync<T>(
         this IQueryable<T> source, 
         // int pageNumber, 
         // int pageSize

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Extentions/QueryableExtensionPagination.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Extentions/QueryableExtensionPagination.cs
@@ -4,12 +4,34 @@ using Microsoft.EntityFrameworkCore;
 
 namespace LTU.SearchEngine.Infrastructure.Extensions;
 
+/// <summary>
+/// Provides extension methods for <see cref="IQueryable{T}"/> to facilitate asynchronous pagination.
+/// </summary>
 public static class QueryableExtensionPagination
 {
-    public static async Task<PaginatedResult<T>> ToPaginatedResultAsync<T>(
+
+	/// <summary>
+	/// Executes a query asynchronously and wraps the results in a <see cref="PaginatedResult{T}"/>.
+	/// </summary>
+	/// <typeparam name="T">The type of the elements in the source query.</typeparam>
+	/// <param name="source">The <see cref="IQueryable{T}"/> to paginate.</param>
+	/// <param name="paginationParameters">The parameters defining the requested page and size.</param>
+	/// <returns>
+	/// A task that represents the asynchronous operation. The task result contains a 
+	/// <see cref="PaginatedResult{T}"/> including the subset of items and the calculated metadata.
+	/// </returns>
+	/// <remarks>
+	/// This method performs two database operations:
+	/// <list type="number">
+	///     <item><description>A count operation to determine the total number of matching records.</description></item>
+	///     <item><description>A filtered fetch using <c>Skip</c> and <c>Take</c> logic.</description></item>
+	/// </list>
+	/// </remarks>
+	/// <exception cref="PaginationOutOfRangeException">
+	/// Thrown if <paramref name="paginationParameters"/> contains a page number or page size less than 1.
+	/// </exception>
+	public static async Task<PaginatedResult<T>> ToPaginatedResultAsync<T>(
         this IQueryable<T> source, 
-        // int pageNumber, 
-        // int pageSize
         PaginationRequestParameters paginationParameters
         )
     {

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Extentions/QueryableExtensionPagination.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Extentions/QueryableExtensionPagination.cs
@@ -1,0 +1,37 @@
+using LTU.SearchEngine.Backend.Core.Exceptions;
+using LTU.SearchEngine.Backend.Core.RequestParameters;
+using Microsoft.EntityFrameworkCore;
+
+namespace LTU.SearchEngine.Infrastructure.Extensions;
+
+public static class QueryableExtensionPagination
+{
+    public static async Task<IPaginatedResult<T>> ToPaginatedResultAsync<T>(
+        this IQueryable<T> source, 
+        // int pageNumber, 
+        // int pageSize
+        PaginationRequestParameters paginationParameters
+        )
+    {
+        var (pageNumber, pageSize) = paginationParameters;
+
+        if (pageNumber < 1) throw new PaginationOutOfRangeException(nameof(pageNumber), "Page number must be higher than 0.");
+        if (pageSize < 1) throw new PaginationOutOfRangeException(nameof(pageSize), "Page size must be higher than 0.");
+
+        int count = await source.CountAsync();
+
+        var items = await source
+            .Skip(pageSize * (pageNumber - 1))
+            .Take(pageSize)
+            .ToListAsync();
+
+        var MetaData = new PaginationMetaData(
+            currentPage: pageNumber,
+            totalPages: (int)Math.Ceiling(count / (double)pageSize),
+            pageSize: pageSize,
+            totalItemCount: count
+        );    
+
+        return new PaginatedResult<T>(items, MetaData);
+    }
+}

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Repositories/SqlIndexRepository.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Repositories/SqlIndexRepository.cs
@@ -4,7 +4,9 @@ using LTU.SearchEngine.Backend.Core.Model;
 using LTU.SearchEngine.Backend.Core.Model.Entities;
 using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
 using LTU.SearchEngine.Backend.Core.Model.ValueObjects.QueryNodes;
+using LTU.SearchEngine.Backend.Core.RequestParameters;
 using LTU.SearchEngine.Infrastructure.Data;
+using LTU.SearchEngine.Infrastructure.Extensions;
 using Microsoft.EntityFrameworkCore;
 
 
@@ -64,14 +66,19 @@ public class SqlIndexRepository : IIndexRepository
 
 
     // Retrieves a list of documents based on their unique IDs
-    public async Task<List<Page>> GetDocumentsByIdAsync(List<int> pageIds)
+    // public async Task<List<Page>> GetDocumentsByIdAsync(List<int> pageIds)
+    public async Task<IPaginatedResult<Page>> GetDocumentsByIdAsync(
+        List<int> pageIds, 
+        PaginationRequestParameters paginationParameters
+        )
 	{
 		//Creates a new database context based on their unique IDs
 		await using var context = await _factory.CreateDbContextAsync();
 
 		return await context.Pages
 			.Where(p => pageIds.Contains(p.Id))
-			.ToListAsync();
+            .ToPaginatedResultAsync(paginationParameters);
+			// .ToListAsync();
 	}
 
 	public async Task<HashSet<int>> GetDocumentIdsForPhraseAsync(PhraseNode<HashSet<int>> phraseNode)

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Repositories/SqlIndexRepository.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Repositories/SqlIndexRepository.cs
@@ -13,23 +13,33 @@ using Microsoft.EntityFrameworkCore;
 namespace LTU.SearchEngine.Infrastructure.Repositories;
 
 /// <summary>
-/// Handles database operations for the search engine´s indexing against a SQL database.
-/// Uses IDbContextFactory to ensure thread safety during parallel web crawling.
+/// Handles database operations for the search engine's indexing against a SQL database using Entity Framework Core.
 /// </summary>
+/// <remarks>
+/// This implementation uses <see cref="IDbContextFactory{TContext}"/> to ensure thread safety during 
+/// parallel web crawling and utilizes a <see cref="SemaphoreProvider"/> to prevent race conditions 
+/// during term and page synchronization.
+/// </remarks>
 public class SqlIndexRepository : IIndexRepository
 {
     private readonly IDbContextFactory<SearchDbContext> _factory;
     private readonly SemaphoreProvider _semaphoreProvider;
 
-    public SqlIndexRepository(IDbContextFactory<SearchDbContext> factory, SemaphoreProvider semaphoreProvider)
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="SqlIndexRepository"/> class.
+	/// </summary>
+	/// <param name="factory">The factory used to create new <see cref="SearchDbContext"/> instances.</param>
+	/// <param name="semaphoreProvider">Provider for synchronization primitives to handle concurrent database access.</param>
+	public SqlIndexRepository(IDbContextFactory<SearchDbContext> factory, SemaphoreProvider semaphoreProvider)
     {
         _factory = factory;
         _semaphoreProvider = semaphoreProvider;
     }
 
-    // Saves a fully processed document from the pipeline to the database.
-    // Merge words from the title, headers and body content.
-    public async Task AddDocumentAsync(IndexDocument document)
+
+	/// <inheritdoc/>
+	public async Task AddDocumentAsync(IndexDocument document)
     {
         var allUniqueTerms = document.TitleTerms.Keys
             .Union(document.HeaderTerms.Keys)
@@ -65,10 +75,9 @@ public class SqlIndexRepository : IIndexRepository
     }
 
 
-    // Retrieves a list of documents based on their unique IDs
-    // public async Task<List<Page>> GetDocumentsByIdAsync(List<int> pageIds)
+	/// <inheritdoc/>
     public async Task<PaginatedResult<Page>> GetDocumentsByIdAsync(
-        List<int> pageIds, 
+	List<int> pageIds, 
         PaginationRequestParameters paginationParameters
         )
 	{
@@ -78,9 +87,10 @@ public class SqlIndexRepository : IIndexRepository
 		return await context.Pages
 			.Where(p => pageIds.Contains(p.Id))
             .ToPaginatedResultAsync(paginationParameters);
-			// .ToListAsync();
 	}
 
+
+	/// <inheritdoc/>
 	public async Task<HashSet<int>> GetDocumentIdsForPhraseAsync(PhraseNode<HashSet<int>> phraseNode)
 	{
         await using var context = await _factory.CreateDbContextAsync();
@@ -114,7 +124,9 @@ public class SqlIndexRepository : IIndexRepository
 		return result;
 	}
 
-    public async Task<int?> GetExistingDocumentByHashAsync(string hash)
+
+	/// <inheritdoc/>
+	public async Task<int?> GetExistingDocumentByHashAsync(string hash)
     {
         await using var context = await _factory.CreateDbContextAsync();
         
@@ -124,7 +136,9 @@ public class SqlIndexRepository : IIndexRepository
             .FirstOrDefaultAsync();
     }
 
-    public async Task UpdateLastCrawledAsync(int id, DateTime newCrawl)
+
+	/// <inheritdoc/>
+	public async Task UpdateLastCrawledAsync(int id, DateTime newCrawl)
     {
         await using var context = await _factory.CreateDbContextAsync();
         await context.Pages
@@ -135,10 +149,8 @@ public class SqlIndexRepository : IIndexRepository
     }
 
 
-    /// <summary>
-    /// Finds the IDs of all pages containing a specific word.
-    /// </summary>
-    public async Task<HashSet<int>> GetDocumentIdsForTermAsync(string term)
+	/// <inheritdoc/>
+	public async Task<HashSet<int>> GetDocumentIdsForTermAsync(string term)
     {
         await using var context = await _factory.CreateDbContextAsync();
 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Repositories/SqlIndexRepository.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Infrastructure/Repositories/SqlIndexRepository.cs
@@ -67,7 +67,7 @@ public class SqlIndexRepository : IIndexRepository
 
     // Retrieves a list of documents based on their unique IDs
     // public async Task<List<Page>> GetDocumentsByIdAsync(List<int> pageIds)
-    public async Task<IPaginatedResult<Page>> GetDocumentsByIdAsync(
+    public async Task<PaginatedResult<Page>> GetDocumentsByIdAsync(
         List<int> pageIds, 
         PaginationRequestParameters paginationParameters
         )

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Api.Tests/SearchControllerTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Api.Tests/SearchControllerTests.cs
@@ -38,9 +38,9 @@ public class SearchControllerTests
         };
 
         var expectedDto = new SearchResponseDTO(
-            searchResults: fakeItems,
-            metaData: new PaginationMetaData(1,1,1,1),
-            message: "Success"
+            SearchResults: fakeItems,
+            MetaData: new PaginationMetaData(1,1,1,1),
+            Message: "Success"
         );
 
         var searchParam = SearchQueryRequestParametersBuilder.BuildParameters(validQuery);
@@ -57,9 +57,9 @@ public class SearchControllerTests
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var responseDto = Assert.IsType<SearchResponseDTO>(okResult.Value);
 
-        Assert.NotEmpty(responseDto.searchResults);
-        Assert.Equal(1, responseDto.metaData.TotalItemCount);
-        Assert.Equal("Success", responseDto.message);
+        Assert.NotEmpty(responseDto.SearchResults);
+        Assert.Equal(1, responseDto.MetaData.TotalItemCount);
+        Assert.Equal("Success", responseDto.Message);
 
         // Verify that the call reached the service layer 
         _mockQueryService.Verify(s => s.GetSearchResultsAsync(searchParam, pageParam), Times.Once);
@@ -106,9 +106,9 @@ public class SearchControllerTests
         var pageParam = PaginationRequestParametersBuilder.BuildPaginationParameters();
 
         var emptyDto = new SearchResponseDTO(
-            searchResults: new List<DocumentDTO>(),
+            SearchResults: new List<DocumentDTO>(),
             new PaginationMetaData(0,0,0,0),
-            message: "No results found"
+            Message: "No results found"
         );
 
         _mockQueryService
@@ -122,9 +122,9 @@ public class SearchControllerTests
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var responseDto = Assert.IsType<SearchResponseDTO>(okResult.Value);
 
-        Assert.Empty(responseDto.searchResults);
-        Assert.Equal(0, responseDto.metaData.TotalItemCount);
-        Assert.Equal("No results found", responseDto.message);
+        Assert.Empty(responseDto.SearchResults);
+        Assert.Equal(0, responseDto.MetaData.TotalItemCount);
+        Assert.Equal("No results found", responseDto.Message);
     }
 
     [Theory]
@@ -140,9 +140,9 @@ public class SearchControllerTests
                 : SearchQueryRequestParametersBuilder.BuildParameters(query, input);
 
         var emptyDto = new SearchResponseDTO(
-            searchResults: new List<DocumentDTO>(),
+            SearchResults: new List<DocumentDTO>(),
             It.IsAny<PaginationMetaData>(),
-            message: "No results found"
+            Message: "No results found"
         );
 
         var pageParam = PaginationRequestParametersBuilder.BuildPaginationParameters();

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Api.Tests/SearchControllerTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Api.Tests/SearchControllerTests.cs
@@ -1,7 +1,10 @@
 ﻿using LTU.SearchEngine.Api;
 using LTU.SearchEngine.Application;
 using LTU.SearchEngine.Application.QueryParsing;
+using LTU.SearchEngine.Backend.Core.Exceptions.SearchQueryExceptions;
 using LTU.SearchEngine.Backend.Core.Model.DTOs;
+using LTU.SearchEngine.Backend.Core.RequestParameters;
+using LTU.SearchEngine.Test.HelperClasses;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
 
@@ -36,29 +39,30 @@ public class SearchControllerTests
 
         var expectedDto = new SearchResponseDTO(
             searchResults: fakeItems,
-            currentPage: 1,
-            pageSize: 1,
-            totalResults: 1,
+            metaData: new PaginationMetaData(1,1,1,1),
             message: "Success"
         );
 
+        var searchParam = SearchQueryRequestParametersBuilder.BuildParameters(validQuery);
+        var pageParam = PaginationRequestParametersBuilder.BuildPaginationParameters();
+
         _mockQueryService
-            .Setup(s => s.GetSearchResultsAsync(validQuery))
+            .Setup(s => s.GetSearchResultsAsync(searchParam, pageParam))
             .Returns(Task.FromResult(expectedDto)); 
 
         // Act
-        var result = await _controller.GetSearchResponses(validQuery);
+        var result = await _controller.GetSearchResponses(searchParam, pageParam);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var responseDto = Assert.IsType<SearchResponseDTO>(okResult.Value);
 
         Assert.NotEmpty(responseDto.searchResults);
-        Assert.Equal(1, responseDto.totalResults);
+        Assert.Equal(1, responseDto.metaData.TotalItemCount);
         Assert.Equal("Success", responseDto.message);
 
         // Verify that the call reached the service layer 
-        _mockQueryService.Verify(s => s.GetSearchResultsAsync(validQuery), Times.Once);
+        _mockQueryService.Verify(s => s.GetSearchResultsAsync(searchParam, pageParam), Times.Once);
     }
 
 
@@ -72,15 +76,23 @@ public class SearchControllerTests
     public async Task GetSearchResponses_ShouldTrimQuery_WhenQueryIsValidButHasLeadingOrTrailingWhiteSpaces(
         string input, string expectedTrim)
     {
+        var searchParam = SearchQueryRequestParametersBuilder.BuildParameters(query: input);
+        var searchParamExpected = SearchQueryRequestParametersBuilder.BuildParameters(query: expectedTrim);
+        var pageParam = PaginationRequestParametersBuilder.BuildPaginationParameters();
+        
         // Arrange
         _mockQueryService
-            .Setup(s => s.GetSearchResultsAsync(It.IsAny<string>()));
+            .Setup(s => s.GetSearchResultsAsync(searchParam, pageParam));
       
         // Act
-        var result = await _controller.GetSearchResponses(input);
+        var result = await _controller.GetSearchResponses(searchParam, pageParam);
 
         // Assert
-        _mockQueryService.Verify(s => s.GetSearchResultsAsync(expectedTrim), Times.Once);
+        _mockQueryService.Verify(s => s.GetSearchResultsAsync(
+            It.Is<SearchQueryRequestParameters>(sqrp => sqrp.Query == expectedTrim), 
+            It.IsAny<PaginationRequestParameters>()), 
+            Times.Once
+        );
     }
 
 
@@ -90,27 +102,28 @@ public class SearchControllerTests
         // Arrange
         string query = "zero-results";
 
+        var searchParam = SearchQueryRequestParametersBuilder.BuildParameters(query);
+        var pageParam = PaginationRequestParametersBuilder.BuildPaginationParameters();
+
         var emptyDto = new SearchResponseDTO(
             searchResults: new List<DocumentDTO>(),
-            currentPage: 1,
-            pageSize: 0,
-            totalResults: 0,
+            new PaginationMetaData(0,0,0,0),
             message: "No results found"
         );
 
         _mockQueryService
-            .Setup(s => s.GetSearchResultsAsync(query))
+            .Setup(s => s.GetSearchResultsAsync(searchParam, pageParam))
             .Returns(Task.FromResult(emptyDto)); 
 
         // Act
-        var result = await _controller.GetSearchResponses(query);
+        var result = await _controller.GetSearchResponses(searchParam, pageParam);
 
         // Assert
         var okResult = Assert.IsType<OkObjectResult>(result.Result);
         var responseDto = Assert.IsType<SearchResponseDTO>(okResult.Value);
 
         Assert.Empty(responseDto.searchResults);
-        Assert.Equal(0, responseDto.totalResults);
+        Assert.Equal(0, responseDto.metaData.TotalItemCount);
         Assert.Equal("No results found", responseDto.message);
     }
 
@@ -122,48 +135,30 @@ public class SearchControllerTests
     {
         // Arrange
         string query = "zero-results";
+        var searchParam = (input == "NO_INPUT") 
+                ? SearchQueryRequestParametersBuilder.BuildParameters(query) 
+                : SearchQueryRequestParametersBuilder.BuildParameters(query, input);
 
         var emptyDto = new SearchResponseDTO(
             searchResults: new List<DocumentDTO>(),
-            currentPage: 1,
-            pageSize: 0,
-            totalResults: 0,
+            It.IsAny<PaginationMetaData>(),
             message: "No results found"
         );
 
+        var pageParam = PaginationRequestParametersBuilder.BuildPaginationParameters();
+
         _mockQueryService
-            .Setup(s => s.GetSearchResultsAsync(query, languageCode: expected))
+            .Setup(s => s.GetSearchResultsAsync(searchParam, pageParam))
             .Returns(Task.FromResult(emptyDto)); 
 
-        Func<Task<ActionResult<SearchResponseDTO>>> act = input switch
-        {
-            "NO_INPUT"  => () => _controller.GetSearchResponses(query: query),
-            _           => () => _controller.GetSearchResponses(query: query, language: input)
-        };
-
         // Act
-        await act();
+        await _controller.GetSearchResponses(searchParam, pageParam);
         
         // Assert
         _mockQueryService.Verify(qs => qs.GetSearchResultsAsync(
-            query: It.IsAny<string>(),
-            languageCode: expected
-        ));
-    }
-
-    [Theory]
-    [InlineData("")]
-    [InlineData("    ")]
-    [InlineData("NULL_TEST")]
-    public async Task GetSearchResponses_ShouldReturnBadRequest_WhenQueryIsInvalid(string input)
-    {
-        string? invalidQuery = input.Equals("NULL_TEST") ? null : input;
-
-        // Act
-        var result = await _controller.GetSearchResponses(invalidQuery!);
-
-        // Assert
-        Assert.IsType<BadRequestObjectResult>(result.Result);
+            It.Is<SearchQueryRequestParameters>(sqrp => sqrp.Language == expected),
+            It.IsAny<PaginationRequestParameters>()
+        ), Times.Once);
     }
 
     [Fact]
@@ -171,55 +166,22 @@ public class SearchControllerTests
     {
         // Arrange
         string query = "error";
+        var searchParam = SearchQueryRequestParametersBuilder.BuildSearchParameters();
+        var pageParam = PaginationRequestParametersBuilder.BuildPaginationParameters();
 
         _mockQueryService
-            .Setup(s => s.GetSearchResultsAsync(query))
+            .Setup(s => s.GetSearchResultsAsync(searchParam, pageParam))
             .ThrowsAsync(new System.Exception("Database connection failed"));
 
         // Act & Assert
-        await Assert.ThrowsAsync<System.Exception>(() => _controller.GetSearchResponses(query));
+        await Assert.ThrowsAsync<System.Exception>(() => _controller.GetSearchResponses(searchParam, pageParam));
     }
 
     [Fact]
-    public async Task GetSearchResponses_QueryTooLong_ReturnsBadRequest()
+    public async Task GetSearchResponses_QueryTooLong_ThrowsException()
     {
-        // Arrange: Create a string longer than 500 characters
-        var longQuery = new string('a', 501);
-
-        // Act
-        var result = await _controller.GetSearchResponses(longQuery);
-
-        // Assert
-        var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
-        Assert.Equal("Query length is limited to 500 characters!", badRequest.Value);
-    }
-   
-   
-    [Fact]
-    public async Task GetSearchResponses_DeepPagination_ReturnsBadRequest()
-    {
-        // Arrange
-        var query = "query";
-
-        // Act
-        var result = await _controller.GetSearchResponses(query, pageNumber: 101);
-
-        // Assert
-        var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
-        Assert.Equal("Deep pagination is restricted. Please refine your query!", badRequest.Value);
-    }
-
-    [Fact]
-    public async Task GetSearchResponses_NegativePageNumber_ReturnsBadRequest()
-    {
-        // Arrange
-        var query = "query";
-
-        // Act
-        var result = await _controller.GetSearchResponses(query, pageNumber: -1);
-
-        // Assert
-        var badRequest = Assert.IsType<BadRequestObjectResult>(result.Result);
-        Assert.Equal("Page number must be 1 or greater.", badRequest.Value);
-    }
+       // Arrange & Act & Assert
+        Assert.Throws<QuerySyntaxException>(() => 
+            SearchQueryRequestParametersBuilder.BuildParameters(new string('a', 501)));
+    }  
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Application.Tests/QueryParserTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Application.Tests/QueryParserTests.cs
@@ -3,6 +3,7 @@ using LTU.SearchEngine.Application.QueryParsing.Helpers;
 using LTU.SearchEngine.Backend.Core.Model.DTOs;
 using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
 using LTU.SearchEngine.Backend.Core.Model.ValueObjects.QueryNodes;
+using LTU.SearchEngine.Backend.Core.RequestParameters;
 using LTU.SearchEngine.Backend.Core.SearchQueryBuilder;
 using LTU.SearchEngine.Test.HelperClasses;
 using Moq;
@@ -45,12 +46,13 @@ public class QueryParserTests
 	{
 		// Arrange
 		string query = "cat AND dog";
-		
+		var searchParam = SearchQueryRequestParametersBuilder.BuildParameters(query);
+        
 		var queryStringTokenizingResult = 
 			QueryStringTokenizingResultBuilder.BuildQueryStringTokenizingResult();
 
 		_tokenizerMock
-			.Setup(t => t.Tokenize(query))
+			.Setup(t => t.Tokenize(searchParam))
 			.Returns(queryStringTokenizingResult);
 
 		_treeBuilderMock
@@ -58,10 +60,10 @@ public class QueryParserTests
 			.Returns(Mock.Of<QueryNode<HashSet<int>>>());
 
 		// Act
-		_parser.Parse(query);
+		_parser.Parse(searchParam);
 
 		// Assert
-		_tokenizerMock.Verify(t => t.Tokenize(query), Times.Once);
+		_tokenizerMock.Verify(t => t.Tokenize(searchParam), Times.Once);
 	}
 
 	[Fact]
@@ -69,12 +71,13 @@ public class QueryParserTests
 	{
 		// Arrange
 		string query = "cat";
-	
+		var searchParam = SearchQueryRequestParametersBuilder.BuildParameters(query);
+
 		var queryStringTokenizingResult = 
 			QueryStringTokenizingResultBuilder.BuildQueryStringTokenizingResult();
 
 		_tokenizerMock
-			.Setup(t => t.Tokenize(query))
+			.Setup(t => t.Tokenize(searchParam))
 			.Returns(queryStringTokenizingResult);
 
 		_treeBuilderMock
@@ -82,7 +85,7 @@ public class QueryParserTests
 			.Returns(Mock.Of<QueryNode<HashSet<int>>>());
 
 		// Act
-		_parser.Parse(query);
+		_parser.Parse(searchParam);
 
 		// Assert
 		_treeBuilderMock.Verify(t => t.BuildTree(queryStringTokenizingResult.Tokens), Times.Once);
@@ -93,14 +96,15 @@ public class QueryParserTests
 	{
 		// Arrange
 		string query = "cat";
-		
+		var searchParam = SearchQueryRequestParametersBuilder.BuildParameters(query);
+
 		var queryStringTokenizingResult = 
 			QueryStringTokenizingResultBuilder.BuildQueryStringTokenizingResult();
 
 		var expectedResult = QueryParsingResultBuilder.BuildQueryParsingResult();
 	
 		_tokenizerMock
-			.Setup(t => t.Tokenize(query))
+			.Setup(t => t.Tokenize(searchParam))
 			.Returns(queryStringTokenizingResult);
 
 		_treeBuilderMock
@@ -108,7 +112,7 @@ public class QueryParserTests
 			.Returns(expectedResult.RootNode);
 
 		// Act
-		var result = _parser.Parse(query);
+		var result = _parser.Parse(searchParam);
 
 		// Assert
 		Assert.Equivalent(expectedResult, result);
@@ -123,33 +127,29 @@ public class QueryParserTests
 	{
 		// Arrange
 		string query = "cat";
-		var queryStringTokenizingResult = 
-				QueryStringTokenizingResultBuilder.BuildQueryStringTokenizingResult();
-
+		
+		var tokenizerResult = QueryStringTokenizingResultBuilder.BuildQueryStringTokenizingResult();
 		var expectedResult = QueryParsingResultBuilder.BuildQueryParsingResult();
 	
 		_tokenizerMock
-			.Setup(t => t.Tokenize(query, languageCode: expected))
-			.Returns(queryStringTokenizingResult);
+        .Setup(t => t.Tokenize(It.IsAny<SearchQueryRequestParameters>()))
+        .Returns(tokenizerResult);
 
 		_treeBuilderMock
-			.Setup(t => t.BuildTree(queryStringTokenizingResult.Tokens))
+			.Setup(t => t.BuildTree(It.IsAny<IEnumerable<ExtractedQueryToken>>()))
 			.Returns(expectedResult.RootNode);
 
-		Func<QueryParsingResult<HashSet<int>, IgnoredTermsDTO>> act = input switch
-        {
-            "NO_INPUT"  => () => _parser.Parse(query),
-            _           => () => _parser.Parse(query, languageCode: input)
-        };
-
+		var searchParam = input == "NO_INPUT" 
+			? SearchQueryRequestParametersBuilder.BuildParameters(query)
+			: SearchQueryRequestParametersBuilder.BuildParameters(query, language: input);
+	
 		// Act
-		act();
+		_parser.Parse(searchParam);
 
 		// Assert
 		_tokenizerMock.Verify(t => t.Tokenize(
-			input: It.IsAny<string>(),
-			languageCode: expected
-		));
+			It.Is<SearchQueryRequestParameters>(sqrp => sqrp.Language == expected)
+		), Times.Once);
 	}
 
 	[Fact]
@@ -164,37 +164,43 @@ public class QueryParserTests
 			ignored
 		);
 
-		_tokenizerMock.Setup(t => t.Tokenize(query, It.IsAny<string>()))
+		var searchParam = SearchQueryRequestParametersBuilder.BuildParameters(query, It.IsAny<string>());
+		
+		_tokenizerMock.Setup(t => t.Tokenize(searchParam))
 			.Returns(tokenizerResult);
 
 		_treeBuilderMock.Setup(t => t.BuildTree(It.IsAny<IEnumerable<ExtractedQueryToken>>()))
 			.Returns(Mock.Of<QueryNode<HashSet<int>>>());
 
 		// Act
-		var result = _parser.Parse(query);
+		var result = _parser.Parse(searchParam);
 
 		// Assert
 		Assert.Equal(ignored, result.IgnoredTokens);
 	}
 
-	[Fact]
-	public void Parse_WhenNoTokens_ShouldStillReturnResultWithRootNode()
-	{
-		// Arrange
-		var tokenizerResult = new QueryStringTokenizingResult<ExtractedQueryToken, IgnoredTermsDTO>(
-			Enumerable.Empty<ExtractedQueryToken>(),
-			Enumerable.Empty<IgnoredTermsDTO>()
-		);
+	// [Fact]
+	// public void Parse_WhenNoTokens_ShouldStillReturnResultWithRootNode()
+	// {
+	// 	// Arrange
+	// 	var tokenizerResult = new QueryStringTokenizingResult<ExtractedQueryToken, IgnoredTermsDTO>(
+	// 		Enumerable.Empty<ExtractedQueryToken>(),
+	// 		Enumerable.Empty<IgnoredTermsDTO>()
+	// 	);
 
-		_tokenizerMock.Setup(t => t.Tokenize(It.IsAny<string>(), It.IsAny<string>())).Returns(tokenizerResult);
-		_treeBuilderMock.Setup(t => t.BuildTree(It.IsAny<IEnumerable<ExtractedQueryToken>>()))
-						.Returns(Mock.Of<QueryNode<HashSet<int>>>());
+	// 	// var searchParam = SearchQueryRequestParametersBuilder.BuildParameters(" ", "sv");
+	// 	var searchParam = new SearchQueryRequestParameters { Query = " ", Language = "sv"};
+		
+	// 	_tokenizerMock.Setup(t => t.Tokenize(searchParam)).Returns(tokenizerResult);
+	// 	_treeBuilderMock
+	// 		.Setup(t => t.BuildTree(It.IsAny<IEnumerable<ExtractedQueryToken>>()))
+	// 		.Returns(Mock.Of<QueryNode<HashSet<int>>>());
 
-		// Act
-		var result = _parser.Parse(" ");
+	// 	// Act
+	// 	var result = _parser.Parse(searchParam);
 
-		// Assert
-		Assert.NotNull(result.RootNode);
-		Assert.Empty(result.IgnoredTokens);
-	}
+	// 	// Assert
+	// 	Assert.NotNull(result.RootNode);
+	// 	Assert.Empty(result.IgnoredTokens);
+	// }
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Application.Tests/QueryServiceTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Application.Tests/QueryServiceTests.cs
@@ -20,7 +20,6 @@ public class QueryServiceTests
     private SearchQueryRequestParameters _searchParam;
     private PaginationRequestParameters _pageParam;
     private readonly IQueryService _sut;
-    private IPaginatedResult<Page> _paginatedResult;
 
 
     
@@ -72,7 +71,7 @@ public class QueryServiceTests
 
         _searchParam = SearchQueryRequestParametersBuilder.BuildParameters(rawQuery, languageCode);
         _pageParam = PaginationRequestParametersBuilder.BuildPaginationParameters();
-        _paginatedResult = PaginatedResultBuilder<Page>.BuildPaginatedResult(fakeDocumentList);
+        var paginatedResult = PaginatedResultBuilder<Page>.BuildPaginatedResult(fakeDocumentList);
 
 
         _mockQueryParser
@@ -87,7 +86,7 @@ public class QueryServiceTests
             .Setup(ir => ir.GetDocumentsByIdAsync(
                 It.Is<List<int>>(l => l.SequenceEqual(fakeResultIds.ToList())), 
                 It.IsAny<PaginationRequestParameters>()))
-            .ReturnsAsync(_paginatedResult);
+            .ReturnsAsync(paginatedResult);
     }
 
    

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Application.Tests/QueryServiceTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Application.Tests/QueryServiceTests.cs
@@ -4,6 +4,7 @@ using LTU.SearchEngine.Backend.Core.Enums;
 using LTU.SearchEngine.Backend.Core.Model.DTOs;
 using LTU.SearchEngine.Backend.Core.Model.Entities;
 using LTU.SearchEngine.Backend.Core.Model.ValueObjects.QueryNodes;
+using LTU.SearchEngine.Backend.Core.RequestParameters;
 using LTU.SearchEngine.Backend.Core.SearchQueryBuilder;
 using LTU.SearchEngine.Infrastructure.Repositories;
 using LTU.SearchEngine.Test.HelperClasses;
@@ -16,7 +17,12 @@ public class QueryServiceTests
     private readonly Mock<IIndexRepository> _mockIndexRepository; 
     private readonly Mock<IQueryParser> _mockQueryParser; 
     private readonly Mock<IQueryVisitor<HashSet<int>>> _mockQueryEvaluatorVisitor; 
+    private SearchQueryRequestParameters _searchParam;
+    private PaginationRequestParameters _pageParam;
     private readonly IQueryService _sut;
+    private IPaginatedResult<Page> _paginatedResult;
+
+
     
     public QueryServiceTests()
     {
@@ -63,18 +69,25 @@ public class QueryServiceTests
     {
         var fakeQueryParsingResult = 
             QueryParsingResultBuilder.BuildQueryParsingResult(rootNode: fakeOperatorNode);
-        
+
+        _searchParam = SearchQueryRequestParametersBuilder.BuildParameters(rawQuery, languageCode);
+        _pageParam = PaginationRequestParametersBuilder.BuildPaginationParameters();
+        _paginatedResult = PaginatedResultBuilder<Page>.BuildPaginatedResult(fakeDocumentList);
+
+
         _mockQueryParser
-            .Setup(p => p.Parse(rawQuery, languageCode))
+            .Setup(p => p.Parse(It.Is<SearchQueryRequestParameters>(s => s.Query == rawQuery)))
             .Returns(fakeQueryParsingResult);
 
         _mockQueryEvaluatorVisitor
             .Setup(qe => qe.ExecuteAsync(fakeOperatorNode))
             .ReturnsAsync(fakeResultIds);
 
-        _mockIndexRepository.
-            Setup(ir => ir.GetDocumentsByIdAsync(fakeResultIds.ToList()))
-            .ReturnsAsync(fakeDocumentList);
+        _mockIndexRepository
+            .Setup(ir => ir.GetDocumentsByIdAsync(
+                It.Is<List<int>>(l => l.SequenceEqual(fakeResultIds.ToList())), 
+                It.IsAny<PaginationRequestParameters>()))
+            .ReturnsAsync(_paginatedResult);
     }
 
    
@@ -96,16 +109,16 @@ public class QueryServiceTests
         SetupMocks(rawQuery, "sv", fakeOperatorNode, fakeResultIds, fakeDocumentList);
 
         // Act
-        var result = await _sut.GetSearchResultsAsync(rawQuery);
+        var result = await _sut.GetSearchResultsAsync(_searchParam, _pageParam);
 
         // Assert
         Assert.NotNull(result);
         Assert.IsType<SearchResponseDTO>(result);
         Assert.Equal(fakePage.Title, result.searchResults.First().Title);
 
-        _mockQueryParser.Verify(p => p.Parse(rawQuery), Times.Once);
+        _mockQueryParser.Verify(p => p.Parse(_searchParam), Times.Once);
         _mockQueryEvaluatorVisitor.Verify(qe => qe.ExecuteAsync(fakeOperatorNode), Times.Once);
-        _mockIndexRepository.Verify(ir => ir.GetDocumentsByIdAsync(fakeResultIds.ToList()), Times.Once);
+        _mockIndexRepository.Verify(ir => ir.GetDocumentsByIdAsync(fakeResultIds.ToList(), _pageParam), Times.Once);
     }
 
    
@@ -127,7 +140,7 @@ public class QueryServiceTests
         SetupMocks(rawQuery, "sv", fakeOperatorNode, fakeResultIds, fakeDocumentList);
 
         // Act
-        var result = await _sut.GetSearchResultsAsync(rawQuery);
+        var result = await _sut.GetSearchResultsAsync(_searchParam, _pageParam);
 
         // Assert
         Assert.NotNull(result.message);
@@ -152,16 +165,18 @@ public class QueryServiceTests
 
         SetupMocks(rawQuery, expected, fakeOperatorNode, fakeResultIds, fakeDocumentList);
 
-        Func<Task<SearchResponseDTO>> act = input switch
-        {
-            "NO_INPUT"  => () => _sut.GetSearchResultsAsync(rawQuery),
-            _           => () => _sut.GetSearchResultsAsync(rawQuery, languageCode: input)
-        };
+
+        var searchParam = input.Equals("NO_INPUT") 
+            ? SearchQueryRequestParametersBuilder.BuildParameters(rawQuery)
+            : SearchQueryRequestParametersBuilder.BuildParameters(rawQuery, input);
+ 
 
         // Act 
-        var result = await act();
-            
-        // Assert
-        _mockQueryParser.Verify(qp => qp.Parse(It.IsAny<string>(), expected));    
+        var result = _sut.GetSearchResultsAsync(searchParam, _pageParam);
+
+        _mockQueryParser.Verify(qp => 
+            qp.Parse(It.Is<SearchQueryRequestParameters>(sqrp => sqrp.Language == expected)),
+            Times.Once
+        );
     }
 }

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Application.Tests/QueryServiceTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Application.Tests/QueryServiceTests.cs
@@ -113,7 +113,7 @@ public class QueryServiceTests
         // Assert
         Assert.NotNull(result);
         Assert.IsType<SearchResponseDTO>(result);
-        Assert.Equal(fakePage.Title, result.searchResults.First().Title);
+        Assert.Equal(fakePage.Title, result.SearchResults.First().Title);
 
         _mockQueryParser.Verify(p => p.Parse(_searchParam), Times.Once);
         _mockQueryEvaluatorVisitor.Verify(qe => qe.ExecuteAsync(fakeOperatorNode), Times.Once);
@@ -142,8 +142,8 @@ public class QueryServiceTests
         var result = await _sut.GetSearchResultsAsync(_searchParam, _pageParam);
 
         // Assert
-        Assert.NotNull(result.message);
-        Assert.Matches(@"Search completed in \d+\.\d{2} ms", result.message);
+        Assert.NotNull(result.Message);
+        Assert.Matches(@"Search completed in \d+\.\d{2} ms", result.Message);
     }
 
 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Core.Tests/PaginatedResultTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Core.Tests/PaginatedResultTests.cs
@@ -1,0 +1,74 @@
+﻿using LTU.SearchEngine.Backend.Core.RequestParameters;
+
+namespace LTU.SearchEngine.Test.Core.Tests;
+
+public class PaginatedResultTests
+{
+	[Fact]
+	public void Constructor_AssignsItemsAndMetaData_Correctly()
+	{
+		// Arrange
+		var items = new List<string> { "Result 1", "Result 2", "Result 3" };
+		var metaData = new PaginationMetaData(1, 1, 1, 1);
+
+		// Act
+		var sut = new PaginatedResult<string>(items, metaData);
+
+		// Assert
+		Assert.Equal(items, sut.Items);
+		Assert.Equal(metaData, sut.MetaData);
+		Assert.Equal(3, sut.Items.Count());
+	}
+
+	[Fact]
+	public void GenericType_WorksWithReferenceTypes()
+	{
+		// Arrange
+		var items = new List<TestDataObject> { new() { Id = 1 }, new() { Id = 2 } };
+		var metaData = new PaginationMetaData(1, 1, 1, 1);
+
+		// Act
+		var sut = new PaginatedResult<TestDataObject>(items, metaData);
+
+		// Assert
+		Assert.IsType<PaginatedResult<TestDataObject>>(sut);
+		Assert.Equal(2, sut.Items.Count());
+		Assert.Contains(sut.Items, x => x.Id == 1);
+	}
+
+	[Fact]
+	public void GenericType_WorksWithValueTypes()
+	{
+		// Arrange
+		var items = new List<int> { 10, 20, 30 };
+		var metaData = new PaginationMetaData(1,1,1,1);
+
+		// Act
+		var sut = new PaginatedResult<int>(items, metaData);
+
+		// Assert
+		Assert.IsType<PaginatedResult<int>>(sut);
+		Assert.Equal(3, sut.Items.Count());
+	}
+
+	[Fact]
+	public void Items_WhenEmpty_InitializesCorrectly()
+	{
+		// Arrange
+		var items = Enumerable.Empty<string>();
+		var metaData = new PaginationMetaData(1,1,1,1);
+
+		// Act
+		var sut = new PaginatedResult<string>(items, metaData);
+
+		// Assert
+		Assert.Empty(sut.Items);
+		Assert.NotNull(sut.MetaData);
+	}
+
+	// Simple helper class for testing reference types
+	private class TestDataObject
+	{
+		public int Id { get; set; }
+	}
+}

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Core.Tests/PaginationMetaDataTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Core.Tests/PaginationMetaDataTests.cs
@@ -1,0 +1,74 @@
+﻿using LTU.SearchEngine.Backend.Core.RequestParameters;
+
+namespace LTU.SearchEngine.Test.Core.Tests;
+
+public class PaginationMetaDataTests
+{
+	[Fact]
+	public void Constructor_SetsAllPropertiesCorrectly()
+	{
+		// Arrange
+		int expectedPage = 2;
+		int expectedTotalPages = 10;
+		int expectedSize = 20;
+		int expectedTotalItems = 200;
+
+		// Act
+		var sut = new PaginationMetaData(expectedPage, expectedTotalPages, expectedSize, expectedTotalItems);
+
+		// Assert
+		Assert.Equal(expectedPage, sut.CurrentPage);
+		Assert.Equal(expectedTotalPages, sut.TotalPages);
+		Assert.Equal(expectedSize, sut.PageSize);
+		Assert.Equal(expectedTotalItems, sut.TotalItemCount);
+	}
+
+	[Theory]
+	[InlineData(1, 5, false)] // First page: No previous
+	[InlineData(2, 5, true)]  // Middle page: Has previous
+	[InlineData(5, 5, true)]  // Last page: Has previous
+	public void HasPrevious_ReflectsLogicCorrectly(int current, int total, bool expected)
+	{
+		// Arrange
+		var sut = new PaginationMetaData(current, total, 10, 50);
+
+		// Assert
+		Assert.Equal(expected, sut.HasPrevious);
+	}
+
+	[Theory]
+	[InlineData(1, 5, true)]  // First page: Has next
+	[InlineData(3, 5, true)]  // Middle page: Has next
+	[InlineData(5, 5, false)] // Last page: No next
+	[InlineData(6, 5, false)] // Out of bounds: No next
+	public void HasNext_ReflectsLogicCorrectly(int current, int total, bool expected)
+	{
+		// Arrange
+		var sut = new PaginationMetaData(current, total, 10, 50);
+
+		// Assert
+		Assert.Equal(expected, sut.HasNext);
+	}
+
+	[Fact]
+	public void Pagination_WithSinglePage_HasNoNavigation()
+	{
+		// Arrange
+		var sut = new PaginationMetaData(1, 1, 10, 5);
+
+		// Assert
+		Assert.False(sut.HasPrevious);
+		Assert.False(sut.HasNext);
+	}
+
+	[Fact]
+	public void Pagination_WithZeroItems_HasNoNavigation()
+	{
+		// Arrange
+		var sut = new PaginationMetaData(1, 0, 10, 0);
+
+		// Assert
+		Assert.False(sut.HasPrevious);
+		Assert.False(sut.HasNext);
+	}
+}

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Core.Tests/PaginationRequestParametersTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Core.Tests/PaginationRequestParametersTests.cs
@@ -1,0 +1,101 @@
+﻿using LTU.SearchEngine.Backend.Core.Exceptions;
+using LTU.SearchEngine.Backend.Core.RequestParameters;
+
+namespace LTU.SearchEngine.Test.Core.Tests;
+
+public class PaginationRequestParametersTests
+{
+	[Fact]
+	public void PageNumber_DefaultsToOne()
+	{
+		// Arrange & Act
+		var sut = new PaginationRequestParameters();
+
+		// Assert
+		Assert.Equal(1, sut.PageNumber);
+	}
+
+	[Theory]
+	[InlineData(0)]
+	[InlineData(-1)]
+	[InlineData(-50)]
+	public void PageNumber_SetToLessThanOne_CorrectsToOne(int invalidPage)
+	{
+		// Arrange
+		var sut = new PaginationRequestParameters();
+
+		// Act
+		sut.PageNumber = invalidPage;
+
+		// Assert
+		Assert.Equal(1, sut.PageNumber);
+	}
+
+	[Fact]
+	public void PageNumber_SetAboveOneHundred_ThrowsPaginationOutOfRangeException()
+	{
+		// Arrange
+		var sut = new PaginationRequestParameters();
+
+		// Act & Assert
+		var exception = Assert.Throws<PaginationOutOfRangeException>(() => sut.PageNumber = 101);
+		Assert.Contains("Deep pagination is restricted", exception.Message);
+	}
+
+	[Fact]
+	public void PageSize_DefaultsToTen()
+	{
+		// Arrange & Act
+		var sut = new PaginationRequestParameters();
+
+		// Assert
+		Assert.Equal(10, sut.PageSize);
+	}
+
+	[Theory]
+	[InlineData(101)]
+	[InlineData(1000)]
+	public void PageSize_SetAboveMaxLimit_CapsAtOneHundred(int oversizedPageSize)
+	{
+		// Arrange
+		var sut = new PaginationRequestParameters();
+
+		// Act
+		sut.PageSize = oversizedPageSize;
+
+		// Assert
+		Assert.Equal(100, sut.PageSize);
+	}
+
+	[Fact]
+	public void Deconstruct_ReturnsCorrectValues()
+	{
+		// Arrange
+		var sut = new PaginationRequestParameters
+		{
+			PageNumber = 5,
+			PageSize = 25
+		};
+
+		// Act
+		var (pageNumber, pageSize) = sut;
+
+		// Assert
+		Assert.Equal(5, pageNumber);
+		Assert.Equal(25, pageSize);
+	}
+
+	[Fact]
+	public void PageNumber_SetToValidValue_UpdatesCorrectly()
+	{
+		// Arrange
+		var sut = new PaginationRequestParameters();
+		int validPage = 42;
+
+		// Act
+		sut.PageNumber = validPage;
+
+		// Assert
+		Assert.Equal(validPage, sut.PageNumber);
+	}
+}

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Core.Tests/SearchQueryRequestParametersTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/Core.Tests/SearchQueryRequestParametersTests.cs
@@ -1,0 +1,72 @@
+﻿using LTU.SearchEngine.Backend.Core.Exceptions.SearchQueryExceptions;
+using LTU.SearchEngine.Backend.Core.RequestParameters;
+
+namespace LTU.SearchEngine.Test.Core.Tests;
+
+public class SearchQueryRequestParametersTests
+{
+	[Fact]
+	public void Query_SetValidString_ShouldBeStoredAndTrimmed()
+	{
+		// Arrange
+		var sut = new SearchQueryRequestParameters();
+		var input = "  dotnet testing  ";
+		var expected = "dotnet testing";
+
+		// Act
+		sut.Query = input;
+
+		// Assert
+		Assert.Equal(expected, sut.Query);
+	}
+
+	[Theory]
+	[InlineData("")]
+	[InlineData(" ")]
+	[InlineData(null)]
+	public void Query_SetNullOrWhiteSpace_ShouldThrowQuerySyntaxException(string invalidInput)
+	{
+		// Arrange
+		var sut = new SearchQueryRequestParameters();
+
+		// Act & Assert
+		var exception = Assert.Throws<QuerySyntaxException>(() => sut.Query = invalidInput);
+		Assert.Equal("Search query cannot be empty.", exception.Message);
+	}
+
+	[Fact]
+	public void Query_SetStringOver500Characters_ShouldThrowQuerySyntaxException()
+	{
+		// Arrange
+		var sut = new SearchQueryRequestParameters();
+		var longQuery = new string('a', 501);
+
+		// Act & Assert
+		var exception = Assert.Throws<QuerySyntaxException>(() => sut.Query = longQuery);
+		Assert.Contains("limited to 500 characters", exception.Message);
+	}
+
+	[Fact]
+	public void Language_DefaultsToSwedish()
+	{
+		// Arrange & Act
+		var sut = new SearchQueryRequestParameters();
+
+		// Assert
+		Assert.Equal("sv", sut.Language);
+	}
+
+	[Fact]
+	public void Language_CanBeUpdated()
+	{
+		// Arrange
+		var sut = new SearchQueryRequestParameters();
+		var newLang = "en";
+
+		// Act
+		sut.Language = newLang;
+
+		// Assert
+		Assert.Equal(newLang, sut.Language);
+	}
+}

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/HelperClasses/PaginatedResultBuilder.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/HelperClasses/PaginatedResultBuilder.cs
@@ -5,12 +5,12 @@ namespace LTU.SearchEngine.Test.HelperClasses;
 
 public static class PaginatedResultBuilder<T>
 {
-    public static PaginatedResult<T> BuildPaginatedResult(List<T> items, IPaginationMetaData metaData)
+    public static PaginatedResult<T> BuildPaginatedResult(List<T> items, PaginationMetaData metaData)
     {
         return new PaginatedResult<T>(items: items, metaData: metaData);     
     }   
     
-    public static PaginatedResult<T> BuildPaginatedResult(IPaginationMetaData metaData)
+    public static PaginatedResult<T> BuildPaginatedResult(PaginationMetaData metaData)
     {
         return new PaginatedResult<T>(items: new List<T>(), metaData: metaData);     
     }   

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/HelperClasses/PaginatedResultBuilder.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/HelperClasses/PaginatedResultBuilder.cs
@@ -1,0 +1,22 @@
+
+using LTU.SearchEngine.Backend.Core.RequestParameters;
+
+namespace LTU.SearchEngine.Test.HelperClasses;
+
+public static class PaginatedResultBuilder<T>
+{
+    public static PaginatedResult<T> BuildPaginatedResult(List<T> items, IPaginationMetaData metaData)
+    {
+        return new PaginatedResult<T>(items: items, metaData: metaData);     
+    }   
+    
+    public static PaginatedResult<T> BuildPaginatedResult(IPaginationMetaData metaData)
+    {
+        return new PaginatedResult<T>(items: new List<T>(), metaData: metaData);     
+    }   
+    
+    public static PaginatedResult<T> BuildPaginatedResult(List<T> items)
+    {
+        return new PaginatedResult<T>(items: items, metaData: new PaginationMetaData(1, 1, 1, 1));     
+    }    
+}

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/HelperClasses/PaginationRequestParametersBuilder.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/HelperClasses/PaginationRequestParametersBuilder.cs
@@ -1,0 +1,16 @@
+using LTU.SearchEngine.Backend.Core.RequestParameters;
+
+namespace LTU.SearchEngine.Test.HelperClasses;
+
+public static class PaginationRequestParametersBuilder
+{
+    public static PaginationRequestParameters BuildPaginationParameters(int pageNumber, int pageSize)
+    {
+        return new PaginationRequestParameters{ PageNumber = pageNumber, PageSize = pageSize };     
+    }   
+
+    public static PaginationRequestParameters BuildPaginationParameters()
+    {
+        return new PaginationRequestParameters{ PageNumber = 1, PageSize = 10 };     
+    }   
+}

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/HelperClasses/SearchQueryRequestParametersBuilder.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/HelperClasses/SearchQueryRequestParametersBuilder.cs
@@ -1,0 +1,23 @@
+using LTU.SearchEngine.Backend.Core.RequestParameters;
+
+namespace LTU.SearchEngine.Test.HelperClasses;
+
+public static class SearchQueryRequestParametersBuilder
+{
+    public static SearchQueryRequestParameters BuildParameters(string query, string? language = null)
+    {
+        var parameters = new SearchQueryRequestParameters { Query = query };
+        
+        if (language != null)
+        {
+            parameters.Language = language;
+        }
+        
+        return parameters;
+    }
+
+    public static SearchQueryRequestParameters BuildSearchParameters()
+    {
+        return BuildParameters("fakeQuery");
+    }
+}

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/IntegrationTesting/SearchQueryIntegrationTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/IntegrationTesting/SearchQueryIntegrationTests.cs
@@ -160,25 +160,25 @@ public class SearchQueryIntegrationTests : IClassFixture<WebApplicationFactory<P
         var url = SearchUrlGenerator.QueryUrlBuilder(query: "cats", language: "en");
         var catsResult = await apiClient.GetFromJsonAsync<SearchResponseDTO>(url);
         
-        Assert.NotNull(catsResult!.searchResults);
-        Assert.Contains(catsResult.searchResults, r => r.Url.Contains("/a"));
-        Assert.Contains(catsResult.searchResults, r => r.Url.Contains("/c"));
-        Assert.DoesNotContain(catsResult.searchResults, r => r.Url.Contains("/b"));
+        Assert.NotNull(catsResult!.SearchResults);
+        Assert.Contains(catsResult.SearchResults, r => r.Url.Contains("/a"));
+        Assert.Contains(catsResult.SearchResults, r => r.Url.Contains("/c"));
+        Assert.DoesNotContain(catsResult.SearchResults, r => r.Url.Contains("/b"));
 
         // Act & Assert: Step 2 - Multiple Terms ("cats dogs") implicit OR
         url = SearchUrlGenerator.QueryUrlBuilder(query: "cats dogs", language: "en");
         var multipleResult = await apiClient.GetFromJsonAsync<SearchResponseDTO>(url);
         
-        Assert.Equal(3, multipleResult!.searchResults.Count());
+        Assert.Equal(3, multipleResult!.SearchResults.Count());
 
         // Act & Assert: Step 3 - Boolean AND ("cats AND dogs") 
         url = SearchUrlGenerator.QueryUrlBuilder(query: "cats AND dogs", language: "en");
         var andResult = await apiClient.GetFromJsonAsync<SearchResponseDTO>(url);
 
         // Expected: Only Document C
-        Assert.Single(andResult!.searchResults);
-        Assert.Equal("Doc C", andResult.searchResults.First().Title);
-        Assert.Contains("/c", andResult.searchResults.First().Url);
+        Assert.Single(andResult!.SearchResults);
+        Assert.Equal("Doc C", andResult.SearchResults.First().Title);
+        Assert.Contains("/c", andResult.SearchResults.First().Url);
     }
   
   
@@ -223,18 +223,18 @@ public class SearchQueryIntegrationTests : IClassFixture<WebApplicationFactory<P
         var helloResult = await apiClient.GetFromJsonAsync<SearchResponseDTO>(url);
         
         
-        Assert.Contains(helloResult!.searchResults, r => r.Url.Contains("/b"));
-        Assert.DoesNotContain(helloResult.searchResults, r => r.Url.Contains("/c"));
-        Assert.DoesNotContain(helloResult.searchResults, r => r.Url.Contains("/a"));
+        Assert.Contains(helloResult!.SearchResults, r => r.Url.Contains("/b"));
+        Assert.DoesNotContain(helloResult.SearchResults, r => r.Url.Contains("/c"));
+        Assert.DoesNotContain(helloResult.SearchResults, r => r.Url.Contains("/a"));
 
         // Act & Assert: Step 2 - ("test")
         url = SearchUrlGenerator.QueryUrlBuilder(query: "test", language: "en");
         var testResult = await apiClient.GetFromJsonAsync<SearchResponseDTO>(url);
         
-        Assert.Equal(2, testResult!.searchResults.Count());
-        Assert.Contains(testResult.searchResults, r => r.Url.Contains("/a"));
-        Assert.Contains(testResult.searchResults, r => r.Url.Contains("/c"));
-        Assert.DoesNotContain(testResult.searchResults, r => r.Url.Contains("/b"));
+        Assert.Equal(2, testResult!.SearchResults.Count());
+        Assert.Contains(testResult.SearchResults, r => r.Url.Contains("/a"));
+        Assert.Contains(testResult.SearchResults, r => r.Url.Contains("/c"));
+        Assert.DoesNotContain(testResult.SearchResults, r => r.Url.Contains("/b"));
     }
    
 
@@ -289,7 +289,7 @@ public class SearchQueryIntegrationTests : IClassFixture<WebApplicationFactory<P
         var helloResult = await apiClient.GetFromJsonAsync<SearchResponseDTO>(url);
         
         // Assert
-        Assert.Contains(helloResult!.searchResults, r => r.Url.Contains("/a"));
+        Assert.Contains(helloResult!.SearchResults, r => r.Url.Contains("/a"));
     }
     
 
@@ -363,9 +363,9 @@ public class SearchQueryIntegrationTests : IClassFixture<WebApplicationFactory<P
         var url = SearchUrlGenerator.QueryUrlBuilder(query: input, language: "en");
         var helloResult = await apiClient.GetFromJsonAsync<SearchResponseDTO>(url);
         
-        Assert.Contains(helloResult!.searchResults, r => r.Url.Contains("/a"));
-        Assert.DoesNotContain(helloResult.searchResults, r => r.Url.Contains("/b"));
-        Assert.DoesNotContain(helloResult.searchResults, r => r.Url.Contains("/c"));
+        Assert.Contains(helloResult!.SearchResults, r => r.Url.Contains("/a"));
+        Assert.DoesNotContain(helloResult.SearchResults, r => r.Url.Contains("/b"));
+        Assert.DoesNotContain(helloResult.SearchResults, r => r.Url.Contains("/c"));
     }
 
     private async Task<HttpClient> SetupSearchBooleanOperatorAreCaseSensitiveDatabase(WebApplicationFactory<Program> testFactory)
@@ -425,8 +425,8 @@ public class SearchQueryIntegrationTests : IClassFixture<WebApplicationFactory<P
         var result = await apiClient .GetFromJsonAsync<SearchResponseDTO>(url);
         
         // Assert
-        Assert.Contains(result!.searchResults, r => r.Url.Contains("/a"));
-        Assert.Contains(result.ignoredTokens!, r => r.Token.Contains(expectedIgnored));
+        Assert.Contains(result!.SearchResults, r => r.Url.Contains("/a"));
+        Assert.Contains(result.IgnoredTokens!, r => r.Token.Contains(expectedIgnored));
         
         // Act - Step 2 - Capital letters 
         query = $"term1 {correctOperator} term2";
@@ -434,8 +434,8 @@ public class SearchQueryIntegrationTests : IClassFixture<WebApplicationFactory<P
         result = await apiClient.GetFromJsonAsync<SearchResponseDTO>(url);
         
         // Assert
-        Assert.Contains(result!.searchResults, r => r.Url.Contains("/a"));
-        Assert.DoesNotContain(result.ignoredTokens!, r => r.Token.Contains(expectedIgnored));    
+        Assert.Contains(result!.SearchResults, r => r.Url.Contains("/a"));
+        Assert.DoesNotContain(result.IgnoredTokens!, r => r.Token.Contains(expectedIgnored));    
     }
 
 
@@ -463,8 +463,8 @@ public class SearchQueryIntegrationTests : IClassFixture<WebApplicationFactory<P
         var result = await apiClient .GetFromJsonAsync<SearchResponseDTO>(url);
         
         // Assert
-        Assert.Contains(result!.searchResults, r => r.Url.Contains("/a"));
-        Assert.Contains(result.ignoredTokens!, r => r.Token.Contains(expectedIgnored));
+        Assert.Contains(result!.SearchResults, r => r.Url.Contains("/a"));
+        Assert.Contains(result.IgnoredTokens!, r => r.Token.Contains(expectedIgnored));
         
         // Act - Step 2 - Capital letters 
         query = $"term1 {correctOperator} term2";
@@ -472,8 +472,8 @@ public class SearchQueryIntegrationTests : IClassFixture<WebApplicationFactory<P
         result = await apiClient.GetFromJsonAsync<SearchResponseDTO>(url);
         
         // Assert
-        Assert.DoesNotContain(result!.searchResults, r => r.Url.Contains("/a"));
-        Assert.DoesNotContain(result.ignoredTokens!, r => r.Token.Contains(expectedIgnored));
+        Assert.DoesNotContain(result!.SearchResults, r => r.Url.Contains("/a"));
+        Assert.DoesNotContain(result.IgnoredTokens!, r => r.Token.Contains(expectedIgnored));
     }
     
 
@@ -555,7 +555,7 @@ public class SearchQueryIntegrationTests : IClassFixture<WebApplicationFactory<P
         var result = await apiClient.GetFromJsonAsync<SearchResponseDTO>(url);
         
         // Assert
-        Assert.Equal(expected, result!.searchResults.Count());
+        Assert.Equal(expected, result!.SearchResults.Count());
     }
     
     
@@ -629,7 +629,7 @@ public class SearchQueryIntegrationTests : IClassFixture<WebApplicationFactory<P
         var result = await apiClient.GetFromJsonAsync<SearchResponseDTO>(url);
         
         // Assert
-        Assert.Equal(expected, result!.searchResults.Count());
+        Assert.Equal(expected, result!.SearchResults.Count());
     }
     
     
@@ -697,7 +697,7 @@ public class SearchQueryIntegrationTests : IClassFixture<WebApplicationFactory<P
         var result = await apiClient.GetFromJsonAsync<SearchResponseDTO>(url);
         
         // Assert
-        Assert.Equal(expected, result!.searchResults.Count());
+        Assert.Equal(expected, result!.SearchResults.Count());
     }
 
     [Fact]
@@ -764,7 +764,7 @@ public class SearchQueryIntegrationTests : IClassFixture<WebApplicationFactory<P
         var result = await apiClient.GetFromJsonAsync<SearchResponseDTO>(url);
         
         // Assert
-        Assert.Equal(2, result!.searchResults.Count());
+        Assert.Equal(2, result!.SearchResults.Count());
     }
 
 
@@ -815,22 +815,22 @@ public class SearchQueryIntegrationTests : IClassFixture<WebApplicationFactory<P
         var result = await apiClient.GetFromJsonAsync<SearchResponseDTO>(url);
 
         // Assert - 1
-        Assert.Equal(2, result!.searchResults.Count());
-        Assert.Contains(result.searchResults, r => r.Title.Equals("Doc A"));
-        Assert.Contains(result.searchResults, r => r.Title.Equals("Doc B"));
-        Assert.DoesNotContain(result.searchResults, r => r.Title.Equals("Doc C"));
-        Assert.DoesNotContain(result.searchResults, r => r.Title.Equals("Doc D"));
+        Assert.Equal(2, result!.SearchResults.Count());
+        Assert.Contains(result.SearchResults, r => r.Title.Equals("Doc A"));
+        Assert.Contains(result.SearchResults, r => r.Title.Equals("Doc B"));
+        Assert.DoesNotContain(result.SearchResults, r => r.Title.Equals("Doc C"));
+        Assert.DoesNotContain(result.SearchResults, r => r.Title.Equals("Doc D"));
 
         // Act - 2
         url = SearchUrlGenerator.QueryUrlBuilder("Cat AND (dog OR fish)", language: "en");
         result = await apiClient.GetFromJsonAsync<SearchResponseDTO>(url);
 
         // Assert - 2
-        Assert.Single(result!.searchResults);
-        Assert.Contains(result.searchResults, r => r.Title.Equals("Doc A"));
-        Assert.DoesNotContain(result.searchResults, r => r.Title.Equals("Doc B"));
-        Assert.DoesNotContain(result.searchResults, r => r.Title.Equals("Doc C"));
-        Assert.DoesNotContain(result.searchResults, r => r.Title.Equals("Doc D"));
+        Assert.Single(result!.SearchResults);
+        Assert.Contains(result.SearchResults, r => r.Title.Equals("Doc A"));
+        Assert.DoesNotContain(result.SearchResults, r => r.Title.Equals("Doc B"));
+        Assert.DoesNotContain(result.SearchResults, r => r.Title.Equals("Doc C"));
+        Assert.DoesNotContain(result.SearchResults, r => r.Title.Equals("Doc D"));
     }
     
     public void Dispose()

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/QueryTokenizerTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/QueryTokenizerTests.cs
@@ -1,6 +1,5 @@
 ﻿using LTU.SearchEngine.Application.QueryParsing.Helpers;
 using LTU.SearchEngine.Backend.Core;
-using LTU.SearchEngine.Backend.Core.Entities;
 using LTU.SearchEngine.Backend.Core.Enums;
 using LTU.SearchEngine.Backend.Core.Exceptions;
 using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
@@ -29,8 +28,7 @@ public class QueryTokenizerTests
 
 	public SearchQueryRequestParameters CreateSearchParam(string? input, string? language)
 	{
-		// if (input != null && language != null)
-		return SearchQueryRequestParametersBuilder.BuildParameters(input, language);
+		return SearchQueryRequestParametersBuilder.BuildParameters(input!, language);
 	}
 
 	[Fact]

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/QueryTokenizerTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/QueryTokenizerTests.cs
@@ -128,15 +128,6 @@ public class QueryTokenizerTests
 
 
 	[Fact]
-	public void Tokenize_EmptyInput_ReturnsEmptyList()
-	{
-		// Act & Assert 
-		Assert.Empty(_sut.Tokenize(CreateSearchParam("", "en")).Tokens);
-		Assert.Empty(_sut.Tokenize(CreateSearchParam("   ", "en")).Tokens);
-	}
-
-
-	[Fact]
 	public void Tokenize_UnclosedQuotes_TreatsAllWordsAsTerms_AddsImplicitOr()
 	{
 		// Arrange
@@ -593,7 +584,7 @@ public class QueryTokenizerTests
 	public void Tokenize_IsLanguagePreFix_FindsActiveLanguage(string input)
 	{
 		// Arrange 
-		var searchParam = CreateSearchParam(input, "en");
+		var searchParam = CreateSearchParam(input, null);
 
 		// Act 
 		var result = _sut.Tokenize(searchParam);
@@ -613,7 +604,7 @@ public class QueryTokenizerTests
 	public void Tokenize_IsLanguagePreFix_FindsNoLanguage_UsesDefault(string input, int instances)
 	{
 		// Arrange 
-		var searchParam = CreateSearchParam(input, "en");
+		var searchParam = CreateSearchParam(input, null);
 
 		// Act 
 		var result = _sut.Tokenize(searchParam);

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/QueryTokenizerTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryParsing.Tests/QueryTokenizerTests.cs
@@ -1,8 +1,11 @@
 ﻿using LTU.SearchEngine.Application.QueryParsing.Helpers;
 using LTU.SearchEngine.Backend.Core;
+using LTU.SearchEngine.Backend.Core.Entities;
 using LTU.SearchEngine.Backend.Core.Enums;
 using LTU.SearchEngine.Backend.Core.Exceptions;
 using LTU.SearchEngine.Backend.Core.Model.ValueObjects;
+using LTU.SearchEngine.Backend.Core.RequestParameters;
+using LTU.SearchEngine.Test.HelperClasses;
 using Moq;
 
 namespace LTU.SearchEngine.Test.QueryParsing.Tests;
@@ -23,6 +26,12 @@ public class QueryTokenizerTests
             .Setup(n => n.Normalize(It.IsAny<string>(), It.IsAny<string>()))
             .Returns((string s, string lang) => new List<string> { s });
     }
+
+	public SearchQueryRequestParameters CreateSearchParam(string? input, string? language)
+	{
+		// if (input != null && language != null)
+		return SearchQueryRequestParametersBuilder.BuildParameters(input, language);
+	}
 
 	[Fact]
 	public void Constructor_NullIQuerySyntaxHelper_ShouldThrowArgumentNullException()
@@ -52,8 +61,10 @@ public class QueryTokenizerTests
 			.Setup(sh => sh.ValidateGrouping(It.IsAny<List<ExtractedQueryToken>>()))
 			.Throws(new InvalidQueryStringException("Mismatched parentheses", input));
 
+		var searchParam = CreateSearchParam(input, "en");
+		
 		// Act & Assert 
-		Assert.Throws<InvalidQueryStringException>(() => _sut.Tokenize(input, "en"));
+		Assert.Throws<InvalidQueryStringException>(() => _sut.Tokenize(searchParam));
 	}
 
 	[Fact]
@@ -67,9 +78,10 @@ public class QueryTokenizerTests
 		var banana = new ExtractedQueryToken(QueryTokenType.Term, "banana", RequirementLevel.Optional, "en");
 
 		var expected = new List<ExtractedQueryToken> { apple, orange, banana };
+		var searchParam = CreateSearchParam(input, "en");
 
 		// Act 
-		var result = _sut.Tokenize(input, "en");
+		var result = _sut.Tokenize(searchParam);
 
 		// Assert 
 		Assert.Equivalent(expected, result.Tokens);
@@ -85,8 +97,10 @@ public class QueryTokenizerTests
 		var helloDolly = new ExtractedQueryToken(QueryTokenType.Phrase, "hello dolly", RequirementLevel.Optional, "en");
 		var dog = new ExtractedQueryToken(QueryTokenType.Term, "dog", RequirementLevel.Optional, "en");
 
+		var searchParam = CreateSearchParam(input, "en");
+
 		// Act 
-		var result = _sut.Tokenize(input, "en");
+		var result = _sut.Tokenize(searchParam);
 		var resultList = result.Tokens.ToList();
 
 		// Assert
@@ -103,9 +117,10 @@ public class QueryTokenizerTests
 		var input = "  word1    word2  ";
 		var word1 = new ExtractedQueryToken(QueryTokenType.Term, "word1", RequirementLevel.Optional, "en");
 		var word2 = new ExtractedQueryToken(QueryTokenType.Term, "word2", RequirementLevel.Optional, "en");
+		var searchParam = CreateSearchParam(input, "en");
 
 		// Act
-		var result = _sut.Tokenize(input, "en");
+		var result = _sut.Tokenize(searchParam);
 
 		// Assert
 		Assert.Equivalent(new[] { word1, word2}, result.Tokens);
@@ -116,8 +131,8 @@ public class QueryTokenizerTests
 	public void Tokenize_EmptyInput_ReturnsEmptyList()
 	{
 		// Act & Assert 
-		Assert.Empty(_sut.Tokenize("", "en").Tokens);
-		Assert.Empty(_sut.Tokenize("   ", "en").Tokens);
+		Assert.Empty(_sut.Tokenize(CreateSearchParam("", "en")).Tokens);
+		Assert.Empty(_sut.Tokenize(CreateSearchParam("   ", "en")).Tokens);
 	}
 
 
@@ -131,8 +146,11 @@ public class QueryTokenizerTests
 		var unclosed = new ExtractedQueryToken(QueryTokenType.Term, "\"unclosed", RequirementLevel.Optional, "en");
 		var phrase = new ExtractedQueryToken(QueryTokenType.Term, "phrase", RequirementLevel.Optional, "en");
 		var or = new ExtractedQueryToken(QueryTokenType.LogicalOperator, "OR", RequirementLevel.Optional);
+		
+		var searchParam = CreateSearchParam(input, "en");
+
 		// Act
-		var result = _sut.Tokenize(input, "en");
+		var result = _sut.Tokenize(searchParam);
 		var resultList = result.Tokens.ToList();
 
 		// Assert
@@ -149,9 +167,10 @@ public class QueryTokenizerTests
     {
         // Arrange
         var input = "apple banana";
-        
+        var searchParam = CreateSearchParam(input, "en");
+
 		// Act 
-		var result = _sut.Tokenize(input, "en");
+		var result = _sut.Tokenize(searchParam);
 
 
 		// Assert 
@@ -173,9 +192,10 @@ public class QueryTokenizerTests
     {
 		// Arrange
 		var input = "apple banana orange";
-        
+        var searchParam = CreateSearchParam(input, "en");
+
 		// Act 
-		var result = _sut.Tokenize(input, "en");
+		var result = _sut.Tokenize(searchParam);
 
 		// Assert 
 		var resultList = result.Tokens.ToList();
@@ -195,8 +215,11 @@ public class QueryTokenizerTests
     [InlineData("+orange", "orange")]
     public void Tokenize_PlusPrefixOnTerm_SetsRequirementLevelToRequired(string input, string expectedTerm)
     {
+		// Arrange 
+		var searchParam = CreateSearchParam(input, "en");
+
         // Act
-        var result = _sut.Tokenize(input, "en");
+        var result = _sut.Tokenize(searchParam);
         var token = result.Tokens.First();
 
         // Assert
@@ -211,9 +234,10 @@ public class QueryTokenizerTests
     {
         // Arrange
         var input = "+\"mandatory phrase\"";
+		var searchParam = CreateSearchParam(input, "en");
 
         // Act
-        var result = _sut.Tokenize(input, "en");
+        var result = _sut.Tokenize(searchParam);
         var token = result.Tokens.First();
 
         // Assert
@@ -228,8 +252,11 @@ public class QueryTokenizerTests
 	[InlineData("+\"apple pie\" +\"banana split\"")]
     public void Tokenize_MultipleRequiredTerms_InsertsImplicitAND(string input)
     {
+		// Arrange
+		var searchParam = CreateSearchParam(input, "en");
+		
         // Act
-        var result = _sut.Tokenize(input, "en");
+        var result = _sut.Tokenize(searchParam);
         var resultList = result.Tokens.ToList();
 
         // Assert (required, AND, required)
@@ -245,8 +272,11 @@ public class QueryTokenizerTests
 	[InlineData("\\+\"apple banana\"", "+apple banana")]
 	public void Tokenize_EscapedPlusAtStart_ShouldBeOptional(string input, string expected)
     {
+		// Arrange 
+		var searchParam = CreateSearchParam(input, "en");
+
         // Act
-        var result = _sut.Tokenize(input, "en");
+        var result = _sut.Tokenize(searchParam);
         var token = result.Tokens.First();
 
         // Assert
@@ -262,8 +292,11 @@ public class QueryTokenizerTests
 	[InlineData("\"apple banana\\+\"", "apple banana+")]
 	public void Tokenize_EscapedPlusInPhrase_ShouldNotInsertRequired(string input, string expected)
     {
+		// Arrange
+		var searchParam = CreateSearchParam(input, "en");
+
         // Act
-        var result = _sut.Tokenize(input, "en");
+        var result = _sut.Tokenize(searchParam);
         var token = result.Tokens.First();
 
         // Assert
@@ -277,9 +310,10 @@ public class QueryTokenizerTests
     {
 		// Arrange
 		string input = "+(term1 AND term2)";
+		var searchParam = CreateSearchParam(input, "en");
 		
         // Act
-        var result = _sut.Tokenize(input, "en");
+        var result = _sut.Tokenize(searchParam);
         var token = result.Tokens.First();
 
         // Assert
@@ -294,9 +328,10 @@ public class QueryTokenizerTests
 		// Arrange
 		// Logic: +( term1 AND +( term1 OR term2 ) )
 		string input = "+(term1 AND +(term1 OR term2))";
+		var searchParam = CreateSearchParam(input, "en");
 		
 		// Act
-		var result = _sut.Tokenize(input, "en");
+		var result = _sut.Tokenize(searchParam);
 		var tokens = result.Tokens.ToList();
 
 		// Assert
@@ -315,11 +350,16 @@ public class QueryTokenizerTests
 	[Fact]
 	public void Tokenize_DeeplyNestedRequired_AllOpeningBracketsAreRequired()
 	{
+		// Arrange
 		string input = "+(+(+(term)))"; // Triple nested required
-		var result = _sut.Tokenize(input, "en");
+		var searchParam = CreateSearchParam(input, "en");
+
+		// Act 
+		var result = _sut.Tokenize(searchParam);
 
 		var openBrackets = result.Tokens.Where(t => t.Token == "(").ToList();
 
+		// Assert
 		Assert.Equal(3, openBrackets.Count);
 		Assert.All(openBrackets, t => Assert.Equal(RequirementLevel.Required, t.RequirementLevel));
 	}
@@ -330,9 +370,10 @@ public class QueryTokenizerTests
     {
 		// Arrange
 		var input = "start AND phrase";
+		var searchParam = CreateSearchParam(input, "en");
 
 		// Act 
-        var result = _sut.Tokenize(input, "en");
+        var result = _sut.Tokenize(searchParam);
 
 		// Assert 
 		var resultList = result.Tokens.ToList();
@@ -349,9 +390,10 @@ public class QueryTokenizerTests
     {
 		// Arrange 
         var input = "cat \"hello dolly\" dog";
+		var searchParam = CreateSearchParam(input, "en");
 
 		// Act 
-        var result = _sut.Tokenize(input, "en");
+        var result = _sut.Tokenize(searchParam);
 
 		// Assert 
 		var resultList = result.Tokens.ToList();
@@ -369,9 +411,10 @@ public class QueryTokenizerTests
     {
 		// Arrange
 		var input = "start && phrase";
+		var searchParam = CreateSearchParam(input, "en");
 
 		// Act 
-        var result = _sut.Tokenize(input, "en");
+        var result = _sut.Tokenize(searchParam);
 
 		// Assert 
 		var resultList = result.Tokens.ToList();
@@ -386,7 +429,6 @@ public class QueryTokenizerTests
     [Theory]
 	[InlineData("!")]
 	[InlineData("-")]
-	// [InlineData("+")]
 	[InlineData("&&")]
 	[InlineData("||")]
 	[InlineData("AND")]
@@ -396,13 +438,14 @@ public class QueryTokenizerTests
 	{
 		// Arrange
 		var input = $"start {operatorInput} phrase";
+		var searchParam = CreateSearchParam(input, "en");
 
 		var start = new ExtractedQueryToken(QueryTokenType.Term, "start", RequirementLevel.Optional, "en");
 		var expectedOperator = new ExtractedQueryToken(QueryTokenType.LogicalOperator, operatorInput, RequirementLevel.Optional);
 		var phrase = new ExtractedQueryToken(QueryTokenType.Term, "phrase", RequirementLevel.Optional, "en");
 
 		// Act
-		var result = _sut.Tokenize(input, "en");
+		var result = _sut.Tokenize(searchParam);
 		var resultList = result.Tokens.ToList();
 
 		// Assert
@@ -420,6 +463,7 @@ public class QueryTokenizerTests
 	{
 		// Arrange
 		var input = $"first {operatorInput}second";
+		var searchParam = CreateSearchParam(input, "en");
 
 		var first = new ExtractedQueryToken(QueryTokenType.Term, "first", RequirementLevel.Optional, "en");
 		var expectedOperator = new ExtractedQueryToken(
@@ -428,7 +472,7 @@ public class QueryTokenizerTests
 		var second = new ExtractedQueryToken(QueryTokenType.Term, "second", RequirementLevel.Optional, "en");
 
 		// Act
-		var result = _sut.Tokenize(input, "en");
+		var result = _sut.Tokenize(searchParam);
 
 		// Assert
 		var resultList = result.Tokens.ToList();
@@ -448,6 +492,7 @@ public class QueryTokenizerTests
 	{
 		// Arrange
 		var input = $"{operator1}\"start phrase\"{operator2}";
+		var searchParam = CreateSearchParam(input, "en");
 
 		var expectedOperator1 = new ExtractedQueryToken(
 			QueryTokenType.GroupingOperator, operator1, RequirementLevel.Optional
@@ -460,7 +505,7 @@ public class QueryTokenizerTests
 		);
 
 		// Act
-		var result = _sut.Tokenize(input, "en");
+		var result = _sut.Tokenize(searchParam);
 
 		// Assert
 		var resultList = result.Tokens.ToList();
@@ -482,8 +527,9 @@ public class QueryTokenizerTests
             .Setup(n => n.Normalize(It.IsAny<string>(), "en"))
             .Returns((string s, string lang) => new List<string> { s });
 
+		var searchParam = CreateSearchParam("the Running man", "en");
 		// Act 
-        _sut.Tokenize("the Running man", "en");
+        _sut.Tokenize(searchParam);
 
 		// Assert
         _mockNormalizer.Verify(
@@ -492,7 +538,6 @@ public class QueryTokenizerTests
     }
 
     [Theory]
-    // [InlineData("+")]
     [InlineData("AND")]
     [InlineData("OR")]
     [InlineData("NOT")]
@@ -503,14 +548,16 @@ public class QueryTokenizerTests
     public void Tokenize_Should_Not_Normalize_LogicalOperators(string input)
     {
         // Arrange
-        var result = _sut.Tokenize(input, "en");
-		var resultList = result.Tokens.ToList();
+		var searchParam = CreateSearchParam(input, "en");
 
 		// Act 
+        var result = _sut.Tokenize(searchParam);
+		var resultList = result.Tokens.ToList();
+
+		// Assert 
         Assert.Single(resultList);
         Assert.Equal(QueryTokenType.LogicalOperator, resultList[0].TokenType);
 		
-		// Assert 
         _mockNormalizer.Verify(
             n => n.Normalize(It.IsAny<string>(), "en"),
             Times.Never);
@@ -524,8 +571,11 @@ public class QueryTokenizerTests
 	[InlineData("en: term1 term2 term3")]
 	public void Tokenize_IsLanguagePreFix_FindsGlobalLanguage(string input)
 	{
+		// Arrange
+		var searchParam = CreateSearchParam(input, "en");
+
 		// Act 
-		var result = _sut.Tokenize(input, "sv");
+		var result = _sut.Tokenize(searchParam);
 		var resultList = result.Tokens.ToList();
 
 		// Assert 
@@ -542,8 +592,11 @@ public class QueryTokenizerTests
 	[InlineData("term1 term2 en:term3")]
 	public void Tokenize_IsLanguagePreFix_FindsActiveLanguage(string input)
 	{
+		// Arrange 
+		var searchParam = CreateSearchParam(input, "en");
+
 		// Act 
-		var result = _sut.Tokenize(input, "sv");
+		var result = _sut.Tokenize(searchParam);
 		var resultList = result.Tokens.ToList();
 
 		// Assert 
@@ -559,8 +612,11 @@ public class QueryTokenizerTests
 	[InlineData("term1 AND term3", 2)] 
 	public void Tokenize_IsLanguagePreFix_FindsNoLanguage_UsesDefault(string input, int instances)
 	{
+		// Arrange 
+		var searchParam = CreateSearchParam(input, "en");
+
 		// Act 
-		var result = _sut.Tokenize(input, "sv");
+		var result = _sut.Tokenize(searchParam);
 		var resultList = result.Tokens.ToList();
 
 		// Assert 
@@ -578,9 +634,10 @@ public class QueryTokenizerTests
 			.Returns(new List<string>{""}); // Everything is a stop-word
 
 		var input = "\"the and a\"";
+		var searchParam = CreateSearchParam(input, "en");
 
 		// Act
-		var result = _sut.Tokenize(input, "en");
+		var result = _sut.Tokenize(searchParam);
 
 		// Assert
 		var resultList = result.Tokens.ToList();
@@ -597,9 +654,10 @@ public class QueryTokenizerTests
 		// en:apple -> English
 		// sv:banan -> Swedish
 		// orange   -> English (falls back to global)
+		var searchParam = CreateSearchParam(input, "en");
 
 		// Act
-		var result = _sut.Tokenize(input, "en");
+		var result = _sut.Tokenize(searchParam);
 		var resultList = result.Tokens.ToList();
 
 		// Assert
@@ -618,9 +676,10 @@ public class QueryTokenizerTests
 		// Arrange
 		_mockNormalizer.Setup(n => n.Normalize("the", "en")).Returns(new List<string>{""});
 		var input = "the";
+		var searchParam = CreateSearchParam(input, "en");
 
 		// Act
-		var result = _sut.Tokenize(input, "en");
+		var result = _sut.Tokenize(searchParam);
 
 		// Assert
 		Assert.Single(result.Tokens); 
@@ -638,8 +697,11 @@ public class QueryTokenizerTests
 	[InlineData("\\-F\\+G\\#H", "-F+G#H")]
 	public void Tokenize_EscapedSymbols_ArePassedToNormalizerAsLiteralText(string input, string expected)
 	{
+		// Arrange 
+		var searchParam = CreateSearchParam(input, "en");
+		
 		// Act
-		var result = _sut.Tokenize(input, "en");
+		var result = _sut.Tokenize(searchParam);
 
 		// Assert
 		Assert.Equal(expected, result.Tokens.First().Token); 

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryableExtensionPaginationTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/QueryableExtensionPaginationTests.cs
@@ -1,0 +1,89 @@
+﻿using LTU.SearchEngine.Backend.Core.RequestParameters;
+using LTU.SearchEngine.Infrastructure.Extensions;
+using Microsoft.EntityFrameworkCore;
+
+namespace LTU.SearchEngine.Test;
+
+public class QueryableExtensionPaginationTests
+{
+	private DbContextOptions<TestDbContext> GetInMemoryOptions()
+	{
+		return new DbContextOptionsBuilder<TestDbContext>()
+			.UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+			.Options;
+	}
+
+	[Fact]
+	public async Task ToPaginatedResultAsync_ReturnsCorrectPageAndMetaData()
+	{
+		// Arrange
+		int expectedPageNumber = 10;
+
+
+		using var context = new TestDbContext(GetInMemoryOptions());
+		var data = Enumerable.Range(1, 25).Select(i => new TestEntity { Id = i });
+		await context.Entities.AddRangeAsync(data);
+		await context.SaveChangesAsync();
+
+		var paramsObj = new PaginationRequestParameters
+		{
+			PageNumber = 2,
+			PageSize = 10
+		};
+
+		// Act
+		var result = await context.Entities.AsQueryable().ToPaginatedResultAsync(paramsObj);
+
+		// Assert
+		Assert.Equal(expectedPageNumber, result.Items.Count()); // Page 2 should have 10 items
+		Assert.Equal(11, result.Items.First().Id); // First item on page 2 (index 10) should have ID 11
+		Assert.Equal(25, result.MetaData.TotalItemCount);
+		Assert.Equal(3, result.MetaData.TotalPages); // 25 items / 10 per page = 3 pages
+		Assert.True(result.MetaData.HasNext);
+		Assert.True(result.MetaData.HasPrevious);
+	}
+
+	[Fact]
+	public async Task ToPaginatedResultAsync_LastPage_HasCorrectItemCount()
+	{
+		// Arrange
+		using var context = new TestDbContext(GetInMemoryOptions());
+		var data = Enumerable.Range(1, 25).Select(i => new TestEntity { Id = i });
+		await context.Entities.AddRangeAsync(data);
+		await context.SaveChangesAsync();
+
+		var paramsObj = new PaginationRequestParameters { PageNumber = 3, PageSize = 10 };
+
+		// Act
+		var result = await context.Entities.AsQueryable().ToPaginatedResultAsync(paramsObj);
+
+		// Assert - last page should have 5 items left
+		Assert.Equal(5, result.Items.Count()); 
+		Assert.False(result.MetaData.HasNext);
+	}
+
+	[Fact]
+	public async Task ToPaginatedResultAsync_EmptySource_ReturnsEmptyResult()
+	{
+		// Arrange
+		using var context = new TestDbContext(GetInMemoryOptions());
+		var paramsObj = new PaginationRequestParameters { PageNumber = 1, PageSize = 10 };
+
+		// Act
+		var result = await context.Entities.AsQueryable().ToPaginatedResultAsync(paramsObj);
+
+		// Assert
+		Assert.Empty(result.Items);
+		Assert.Equal(0, result.MetaData.TotalItemCount);
+		Assert.Equal(0, result.MetaData.TotalPages);
+	}
+
+	// Helper classes to simulate database environment
+	public class TestEntity { public int Id { get; set; } }
+
+	public class TestDbContext : DbContext
+	{
+		public TestDbContext(DbContextOptions<TestDbContext> options) : base(options) { }
+		public DbSet<TestEntity> Entities { get; set; } = null!;
+	}
+}

--- a/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/SqlIndexRepositoryTests.cs
+++ b/LTU.SearchEngine.Backend/LTU.SearchEngine.Test/SqlIndexRepositoryTests.cs
@@ -152,15 +152,16 @@ public class SqlIndexRepositoryTests : IDisposable
         await setupContext.SaveChangesAsync();
 
         var idsToFetch = new List<int> { page1.Id, page3.Id }; // We only want 1 and 3
+        var pageParam = PaginationRequestParametersBuilder.BuildPaginationParameters();
 
         // Act
-        var resultPages = await _sut.GetDocumentsByIdAsync(idsToFetch);
+        var paginatedResult = await _sut.GetDocumentsByIdAsync(idsToFetch, pageParam);
 
         // Assert
-        Assert.Equal(2, resultPages.Count);
-        Assert.Contains(resultPages, p => p.Url == "https://test1.com");
-        Assert.Contains(resultPages, p => p.Url == "https://test3.com");
-        Assert.DoesNotContain(resultPages, p => p.Url == "https://test2.com"); // We didn't ask for this one!
+        Assert.Equal(2, paginatedResult.Items.Count());
+        Assert.Contains(paginatedResult.Items, p => p.Url == "https://test1.com");
+        Assert.Contains(paginatedResult.Items, p => p.Url == "https://test3.com");
+        Assert.DoesNotContain(paginatedResult.Items, p => p.Url == "https://test2.com"); // We didn't ask for this one!
     }
 
 


### PR DESCRIPTION
Introduce SearchQueryRequestParameters and PaginationRequestParameters with validation, and add pagination primitives ( PaginatedResult, IPaginationMetaData, PaginationMetaData).

Wire up pagination: add Queryable.ToPaginatedResultAsync extension, update IIndexRepository and SqlIndexRepository to return paginated results, and propagate pagination metadata into SearchResponseDTO.

Refactor query pipeline signatures (tokenizer, parser, query service, controller, and interfaces) to accept request parameter objects instead of raw strings/ints.
Add PaginationOutOfRangeException and map it in ProblemDetailsExceptionHandler; 

Update tests to pass SearchQueryRequestParameters and PaginationRequestParameters instead of raw query strings/ints.

Added test helper builders (SearchQueryRequestParametersBuilder, PaginationRequestParametersBuilder, PaginatedResultBuilder) and adjusted imports.

Also updated tokenizer/parser/service/controller tests and SqlIndexRepositoryTests to work with paginated results.

Updated IIndexRepository, SqlIndexRepository, QueryableExtensionPagination, PaginatedResult implementation, test helpers, and unit tests to match the new types; removed one empty-input tokenizer test and adjusted some tokenizer language parameter usages.

And lastly, added unit test file for the new introduced classes.